### PR TITLE
fix: Don't load localSchemaFile as part of project code

### DIFF
--- a/src/language-server/config/config.ts
+++ b/src/language-server/config/config.ts
@@ -208,8 +208,12 @@ export class ApolloConfig {
 
 export class ClientConfig extends ApolloConfig {
   public client!: ClientConfigFormat;
+  public isClient!: true;
+  public isService!: false;
 }
 
 export class ServiceConfig extends ApolloConfig {
   public service!: ServiceConfigFormat;
+  public isClient!: false;
+  public isService!: true;
 }

--- a/src/language-server/errors/__tests__/NoMissingClientDirectives.test.ts
+++ b/src/language-server/errors/__tests__/NoMissingClientDirectives.test.ts
@@ -180,7 +180,7 @@ describe("client state", () => {
     const project = new GraphQLClientProject({
       config,
       loadingHandler: new MockLoadingHandler(),
-      rootURI,
+      configFolderURI: rootURI,
     });
 
     const errors = Object.create(null);

--- a/src/language-server/project/base.ts
+++ b/src/language-server/project/base.ts
@@ -1,4 +1,4 @@
-import { extname } from "path";
+import path, { extname } from "path";
 import { lstatSync, readFileSync } from "fs";
 import URI from "vscode-uri";
 
@@ -23,7 +23,15 @@ import { GraphQLDocument, extractGraphQLDocuments } from "../document";
 
 import type { LoadingHandler } from "../loadingHandler";
 import { FileSet } from "../fileSet";
-import { ApolloConfig, keyEnvVar } from "../config";
+import {
+  ApolloConfig,
+  ClientConfig,
+  isClientConfig,
+  isLocalServiceConfig,
+  isServiceConfig,
+  keyEnvVar,
+  ServiceConfig,
+} from "../config";
 import {
   schemaProviderFromConfig,
   GraphQLSchemaProvider,
@@ -50,10 +58,10 @@ const fileAssociations: { [extension: string]: string } = {
   ".exs": "elixir",
 };
 
-export interface GraphQLProjectConfig {
+interface GraphQLProjectConfig {
   clientIdentity?: ClientIdentity;
-  config: ApolloConfig;
-  fileSet: FileSet;
+  config: ClientConfig | ServiceConfig;
+  configFolderURI: URI;
   loadingHandler: LoadingHandler;
 }
 
@@ -72,19 +80,34 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
   public config: ApolloConfig;
   public schema?: GraphQLSchema;
   private fileSet: FileSet;
+  private rootURI: URI;
   protected loadingHandler: LoadingHandler;
 
   protected lastLoadDate?: number;
 
   constructor({
     config,
-    fileSet,
+    configFolderURI,
     loadingHandler,
     clientIdentity,
   }: GraphQLProjectConfig) {
     this.config = config;
-    this.fileSet = fileSet;
     this.loadingHandler = loadingHandler;
+    // the URI of the folder _containing_ the apollo.config.js is the true project's root.
+    // if a config doesn't have a uri associated, we can assume the `rootURI` is the project's root.
+    this.rootURI = config.configDirURI || configFolderURI;
+
+    const { includes, excludes } = config.isClient
+      ? config.client
+      : config.service;
+    const fileSet = new FileSet({
+      rootURI: this.rootURI,
+      includes: [...includes, ".env", "apollo.config.js"],
+      excludes: [...excludes],
+      configURI: config.configURI,
+    });
+
+    this.fileSet = fileSet;
     this.schemaProvider = schemaProviderFromConfig(config, clientIdentity);
     const { engine } = config;
     if (engine.apiKey) {
@@ -160,11 +183,15 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
     return this.fileSet.includesFile(uri);
   }
 
+  allIncludedFiles() {
+    return this.fileSet.allFiles();
+  }
+
   async scanAllIncludedFiles() {
     await this.loadingHandler.handle(
       `Loading queries for ${this.displayName}`,
       (async () => {
-        for (const filePath of this.fileSet.allFiles()) {
+        for (const filePath of this.allIncludedFiles()) {
           const uri = URI.file(filePath).toString();
 
           // If we already have query documents for this file, that means it was either

--- a/src/language-server/project/client.ts
+++ b/src/language-server/project/client.ts
@@ -81,7 +81,6 @@ export interface GraphQLClientProjectConfig {
   loadingHandler: LoadingHandler;
 }
 export class GraphQLClientProject extends GraphQLProject {
-  public rootURI: URI;
   public serviceID?: string;
   public config!: ClientConfig;
 
@@ -112,7 +111,6 @@ export class GraphQLClientProject extends GraphQLProject {
     });
 
     super({ config, fileSet, loadingHandler, clientIdentity });
-    this.rootURI = rootURI;
     this.serviceID = config.graph;
 
     /**

--- a/src/language-server/project/client.ts
+++ b/src/language-server/project/client.ts
@@ -101,16 +101,7 @@ export class GraphQLClientProject extends GraphQLProject {
     configFolderURI,
     clientIdentity,
   }: GraphQLClientProjectConfig) {
-    const fileSet = new FileSet({
-      // the URI of the folder _containing_ the apollo.config.js is the true project's root.
-      // if a config doesn't have a uri associated, we can assume the `rootURI` is the project's root.
-      rootURI: config.configDirURI || configFolderURI,
-      includes: [...config.client.includes, ".env", "apollo.config.js"],
-      excludes: config.client.excludes,
-      configURI: config.configURI,
-    });
-
-    super({ config, fileSet, loadingHandler, clientIdentity });
+    super({ config, configFolderURI, loadingHandler, clientIdentity });
     this.serviceID = config.graph;
 
     /**
@@ -126,7 +117,7 @@ export class GraphQLClientProject extends GraphQLProject {
         (config.configURI && path === config.configURI.fsPath)
       );
 
-    if (fileSet.allFiles().filter(filterConfigAndEnvFiles).length === 0) {
+    if (this.allIncludedFiles().filter(filterConfigAndEnvFiles).length === 0) {
       console.warn(
         "⚠️  It looks like there are 0 files associated with this Apollo Project. " +
           "This may be because you don't have any files yet, or your includes/excludes " +

--- a/src/language-server/project/client.ts
+++ b/src/language-server/project/client.ts
@@ -77,7 +77,7 @@ export function isClientProject(
 export interface GraphQLClientProjectConfig {
   clientIdentity?: ClientIdentity;
   config: ClientConfig;
-  rootURI: URI;
+  configFolderURI: URI;
   loadingHandler: LoadingHandler;
 }
 export class GraphQLClientProject extends GraphQLProject {
@@ -98,13 +98,13 @@ export class GraphQLClientProject extends GraphQLProject {
   constructor({
     config,
     loadingHandler,
-    rootURI,
+    configFolderURI,
     clientIdentity,
   }: GraphQLClientProjectConfig) {
     const fileSet = new FileSet({
       // the URI of the folder _containing_ the apollo.config.js is the true project's root.
       // if a config doesn't have a uri associated, we can assume the `rootURI` is the project's root.
-      rootURI: config.configDirURI || rootURI,
+      rootURI: config.configDirURI || configFolderURI,
       includes: [...config.client.includes, ".env", "apollo.config.js"],
       excludes: config.client.excludes,
       configURI: config.configURI,

--- a/src/language-server/project/service.ts
+++ b/src/language-server/project/service.ts
@@ -14,18 +14,18 @@ export function isServiceProject(
 export interface GraphQLServiceProjectConfig {
   clientIdentity?: ClientIdentity;
   config: ServiceConfig;
-  rootURI: URI;
+  configFolderURI: URI;
   loadingHandler: LoadingHandler;
 }
 export class GraphQLServiceProject extends GraphQLProject {
   constructor({
     clientIdentity,
     config,
-    rootURI,
+    configFolderURI,
     loadingHandler,
   }: GraphQLServiceProjectConfig) {
     const fileSet = new FileSet({
-      rootURI: config.configDirURI || rootURI,
+      rootURI: config.configDirURI || configFolderURI,
       includes: [...config.service.includes, ".env", "apollo.config.js"],
       excludes: config.service.excludes,
       configURI: config.configURI,

--- a/src/language-server/project/service.ts
+++ b/src/language-server/project/service.ts
@@ -24,14 +24,7 @@ export class GraphQLServiceProject extends GraphQLProject {
     configFolderURI,
     loadingHandler,
   }: GraphQLServiceProjectConfig) {
-    const fileSet = new FileSet({
-      rootURI: config.configDirURI || configFolderURI,
-      includes: [...config.service.includes, ".env", "apollo.config.js"],
-      excludes: config.service.excludes,
-      configURI: config.configURI,
-    });
-
-    super({ config, fileSet, loadingHandler, clientIdentity });
+    super({ config, configFolderURI, loadingHandler, clientIdentity });
     this.config = config;
   }
 

--- a/src/language-server/workspace.ts
+++ b/src/language-server/workspace.ts
@@ -66,13 +66,13 @@ export class GraphQLWorkspace {
       ? new GraphQLClientProject({
           config,
           loadingHandler: this.LanguageServerLoadingHandler,
-          rootURI: URI.parse(folder.uri),
+          configFolderURI: URI.parse(folder.uri),
           clientIdentity,
         })
       : new GraphQLServiceProject({
           config: config as ServiceConfig,
           loadingHandler: this.LanguageServerLoadingHandler,
-          rootURI: URI.parse(folder.uri),
+          configFolderURI: URI.parse(folder.uri),
           clientIdentity,
         });
 


### PR DESCRIPTION
This should fix what I believe is the most common case for hitting https://github.com/apollographql/apollo-tooling/issues/801 (VSCode Plugin: Loading Schema Twice).

When using a local schema file to power the VSCode extension, if the schema file is in the `includes` (which it probably is by default), we will read it as part of the project code and try to extend the existing schema. Since this file has already been included as the base, the extension will fail and show an error.

This change adds the local schema file(s) to the `excludes` list for the file set, which I think this makes sense overall. Excluding this from the project does mean that it wont get included for providers when editing this file, however in practice I dont think this worked anyways, and I dont see a strong use case for supporting editing a local schema file anyways assuming it did work.

First three commits are refactors to make the intent of the final commit more clear.