### PR TITLE
Switch to graphql-code-generator

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,8 @@
 module.exports = {
   parser: "@typescript-eslint/parser",
   plugins: ["prettier", "@typescript-eslint"],
+  // Skip generated file.
+  ignorePatterns: ["src/language-server/graphqlTypes.ts"],
   rules: {
     "prettier/prettier": "error",
   },

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/erbium
+v16

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,0 +1,10 @@
+# Would be better to get the schema from the Studio registry once it can be a public variant.
+schema: https://graphql.api.apollographql.com/api/graphql
+generates:
+  ./src/language-server/graphqlTypes.ts:
+    documents:
+      - src/language-server/providers/schema/engine.ts
+      - src/language-server/engine/operations/schemaTagsAndFieldStats.ts
+    plugins:
+      - typescript
+      - typescript-operations

--- a/codegen.yml
+++ b/codegen.yml
@@ -8,3 +8,5 @@ generates:
     plugins:
       - typescript
       - typescript-operations
+    config:
+      avoidOptionals: true

--- a/codegen.yml
+++ b/codegen.yml
@@ -3,8 +3,8 @@ schema: https://graphql.api.apollographql.com/api/graphql
 generates:
   ./src/language-server/graphqlTypes.ts:
     documents:
-      - src/language-server/providers/schema/engine.ts
-      - src/language-server/engine/operations/schemaTagsAndFieldStats.ts
+      - src/**/*.ts
+      - "!src/**/__tests__**/*.ts"
     plugins:
       - typescript
       - typescript-operations

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,8 @@
         "vscode-uri": "1.0.6"
       },
       "devDependencies": {
+        "@graphql-codegen/cli": "^2.2.0",
+        "@graphql-codegen/typescript-operations": "^2.1.3",
         "@types/cosmiconfig": "5.0.3",
         "@types/glob": "7.1.1",
         "@types/jest": "^26.0.24",
@@ -124,6 +126,12 @@
         "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
       }
     },
+    "node_modules/@ardatan/fetch-event-source": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@ardatan/fetch-event-source/-/fetch-event-source-2.0.2.tgz",
+      "integrity": "sha512-mcpz/wJ7s50PJIVz4OQ1Yim3w/AAchtYtIg0QMWiMR2cZZoI9t23hRyqeumtD5EmyJu0fxtjmQ5WY8GI86V4rQ==",
+      "dev": true
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
@@ -137,9 +145,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.9.tgz",
-      "integrity": "sha512-p3QjZmMGHDGdpcwEYYWu7i7oJShJvtgMjJeb0W95PPhSm++3lm8YXYOh45Y6iCN9PkZLTZ7CIX5nFrp7pw7TXw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -185,14 +193,27 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.9.tgz",
-      "integrity": "sha512-4yoHbhDYzFa0GLfCzLp5GxH7vPPMAHdZjyE7M/OajM9037zhx0rf+iNsJwp4PT0MSFpwjG7BsHEbPkBQpZ6cYA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.9",
+        "@babel/types": "^7.15.4",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -207,13 +228,38 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
-      "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
+      "integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.14.5",
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+      "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.15.0",
         "@babel/helper-validator-option": "^7.14.5",
         "browserslist": "^4.16.6",
         "semver": "^6.3.0"
@@ -225,94 +271,237 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.4.tgz",
+      "integrity": "sha512-7ZmzFi+DwJx6A7mHRwbuucEYpyBwmh2Ca0RvI6z2+WLZYCqV0JOaLb+u0zbtmDicebgKBZgqbYfLaKNqSgv5Pw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-annotate-as-pure": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name/node_modules/@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-get-function-arity/node_modules/@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables/node_modules/@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.14.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
-      "integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+      "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.8.tgz",
-      "integrity": "sha512-RyE+NFOjXn5A9YU1dkpeBaduagTlZ0+fccnIcAGbv1KGUlReBj7utF7oEth8IdIBQPcux0DDgW5MFBH2xu9KcA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz",
+      "integrity": "sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.14.5",
-        "@babel/helper-simple-access": "^7.14.8",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.8",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.8",
-        "@babel/types": "^7.14.8"
+        "@babel/helper-module-imports": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-simple-access": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms/node_modules/@babel/parser": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
+      "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms/node_modules/@babel/traverse": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms/node_modules/@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+      "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -328,39 +517,135 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
-      "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+      "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.14.5",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers/node_modules/@babel/parser": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
+      "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers/node_modules/@babel/traverse": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers/node_modules/@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+      "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.8"
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-simple-access/node_modules/@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.15.4.tgz",
+      "integrity": "sha512-BMRLsdh+D1/aap19TycS4eD1qELGrCBJwzaY9IE8LrpJtJb+H7rQkPIdsfgnMtLBA6DJls7X9z93Z4U8h7xw0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration/node_modules/@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -484,15 +769,50 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.9.tgz",
-      "integrity": "sha512-RdUTOseXJ8POjjOeEBEvNMIZU/nm4yu2rufRkcibzkkg7DmQvXU8v3M4Xk9G7uuI86CDGkKcuDWgioqZm+mScQ==",
+      "version": "7.15.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
+      "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-class-properties": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.14.5.tgz",
+      "integrity": "sha512-q/PLpv5Ko4dVc1LYMpCY7RVAAO4uk55qPwrIuJ5QJ8c6cVuAmhu7I/49JOppXL6gXf7ZHzpRVEUZdYoPLM04Gg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.15.6.tgz",
+      "integrity": "sha512-qtOHo7A1Vt+O23qEAX+GdBpqaIuD3i9VRrWgCJeq7WO6H2d14EK3q11urj5Te2MAeK97nMiIdRpwd/ST4JFbNg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.15.0",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-transform-parameters": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
@@ -531,6 +851,21 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-flow": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.14.5.tgz",
+      "integrity": "sha512-9WK5ZwKCdWHxVuU13XNT6X73FGmutAXeor5lGFq6qhOFtMFUF4jkbijuyUdZZlpYq6E2hZeZf/u3959X9wsv0Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -550,6 +885,21 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
+      "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -657,33 +1007,387 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/template": {
+    "node_modules/@babel/plugin-transform-arrow-functions": {
       "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.14.5.tgz",
+      "integrity": "sha512-KOnO0l4+tD5IfOdi4x8C1XmEIRWUjNRV8wc6K2vz/3e8yAOoZZvsRXRRIF/yo/MAOFb4QjtAw9xSxMXbSMRy8A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.14.5.tgz",
+      "integrity": "sha512-dtqWqdWZ5NqBX3KzsVCWfQI3A53Ft5pWFCT2eCVUftWZgjc5DpDponbIF1+c+7cSGk2wN0YK7HGL/ezfRbpKBQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoping": {
+      "version": "7.15.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.15.3.tgz",
+      "integrity": "sha512-nBAzfZwZb4DkaGtOes1Up1nOAp9TDRRFw4XBzBBSG9QK7KVFmYzgj9o9sbPv7TX5ofL4Auq4wZnxCoPnI/lz2Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-classes": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.15.4.tgz",
+      "integrity": "sha512-Yjvhex8GzBmmPQUvpXRPWQ9WnxXgAFuZSrqOK/eJlOGIXwvv8H3UEdUigl1gb/bnjTrln+e8bkZUYCBt/xYlBg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-computed-properties": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.14.5.tgz",
+      "integrity": "sha512-pWM+E4283UxaVzLb8UBXv4EIxMovU4zxT1OPnpHJcmnvyY9QbPPTKZfEj31EUvG3/EQRbYAGaYEUZ4yWOBC2xg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-destructuring": {
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.7.tgz",
+      "integrity": "sha512-0mDE99nK+kVh3xlc5vKwB6wnP9ecuSj+zQCa/n0voENtP/zymdT4HH6QEb65wjjcbqr1Jb/7z9Qp7TF5FtwYGw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-flow-strip-types": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.14.5.tgz",
+      "integrity": "sha512-KhcolBKfXbvjwI3TV7r7TkYm8oNXHNBqGOy6JDVwtecFaRoKYsUUqJdS10q0YDKW1c6aZQgO+Ys3LfGkox8pXA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-flow": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-for-of": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.15.4.tgz",
+      "integrity": "sha512-DRTY9fA751AFBDh2oxydvVm4SYevs5ILTWLs6xKXps4Re/KG5nfUkr+TdHCrRWB8C69TlzVgA9b3RmGWmgN9LA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-function-name": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.14.5.tgz",
+      "integrity": "sha512-vbO6kv0fIzZ1GpmGQuvbwwm+O4Cbm2NrPzwlup9+/3fdkuzo1YqOZcXw26+YUJB84Ja7j9yURWposEHLYwxUfQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-function-name": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-literals": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.14.5.tgz",
+      "integrity": "sha512-ql33+epql2F49bi8aHXxvLURHkxJbSmMKl9J5yHqg4PLtdE6Uc48CH1GS6TQvZ86eoB/ApZXwm7jlA+B3kra7A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-member-expression-literals": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.14.5.tgz",
+      "integrity": "sha512-WkNXxH1VXVTKarWFqmso83xl+2V3Eo28YY5utIkbsmXoItO8Q3aZxN4BTS2k0hz9dGUloHK26mJMyQEYfkn/+Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.15.4.tgz",
+      "integrity": "sha512-qg4DPhwG8hKp4BbVDvX1s8cohM8a6Bvptu4l6Iingq5rW+yRUAhe/YRup/YcW2zCOlrysEWVhftIcKzrEZv3sA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-simple-access": "^7.15.4",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-super": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.14.5.tgz",
+      "integrity": "sha512-MKfOBWzK0pZIrav9z/hkRqIk/2bTv9qvxHzPQc12RcVkMOzpIKnFCNYJip00ssKWYkd8Sf5g0Wr7pqJ+cmtuFg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-parameters": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.15.4.tgz",
+      "integrity": "sha512-9WB/GUTO6lvJU3XQsSr6J/WKvBC2hcs4Pew8YxZagi6GkTdniyqp8On5kqdK8MN0LMeu0mGbhPN+O049NV/9FQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-property-literals": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.14.5.tgz",
+      "integrity": "sha512-r1uilDthkgXW8Z1vJz2dKYLV1tuw2xsbrp3MrZmD99Wh9vsfKoob+JTgri5VUb/JqyKRXotlOtwgu4stIYCmnw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-display-name": {
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.15.1.tgz",
+      "integrity": "sha512-yQZ/i/pUCJAHI/LbtZr413S3VT26qNrEm0M5RRxQJA947/YNYwbZbBaXGDrq6CG5QsZycI1VIP6d7pQaBfP+8Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz",
+      "integrity": "sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-jsx": "^7.14.5",
+        "@babel/types": "^7.14.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-shorthand-properties": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.14.5.tgz",
+      "integrity": "sha512-xLucks6T1VmGsTB+GWK5Pl9Jl5+nRXD1uoFdA5TSO6xtiNjtXTjKkmPdFXVLGlK5A2/or/wQMKfmQ2Y0XJfn5g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-spread": {
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.14.6.tgz",
+      "integrity": "sha512-Zr0x0YroFJku7n7+/HH3A2eIrGMjbmAIbJSVv0IZ+t3U2WUQUA64S/oeied2e+MaGSjmt4alzBCsK9E8gh+fag==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.14.5.tgz",
+      "integrity": "sha512-22btZeURqiepOfuy/VkFr+zStqlujWaarpMErvay7goJS6BWwdd6BY9zQyDLDa4x2S3VugxFb162IZ4m/S/+Gg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/parser": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
+      "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.9.tgz",
-      "integrity": "sha512-bldh6dtB49L8q9bUyB7bC20UKgU+EFDwKJylwl234Kv+ySZeMD31Xeht6URyueQ6LrRRpF2tmkfcZooZR9/e8g==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.9",
+        "@babel/generator": "^7.15.0",
         "@babel/helper-function-name": "^7.14.5",
         "@babel/helper-hoist-variables": "^7.14.5",
         "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.14.9",
-        "@babel/types": "^7.14.9",
+        "@babel/parser": "^7.15.0",
+        "@babel/types": "^7.15.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -692,9 +1396,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
-      "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.14.9",
@@ -800,6 +1504,892 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@graphql-codegen/cli": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-2.2.0.tgz",
+      "integrity": "sha512-f4EsScASza57aPM1z6eKAaYmwz83B/LsmiyBb8phy1NfbWea2IBUCfEgtvOHN85xbiMpdQfNtckE2mC84yH80w==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/core": "2.1.0",
+        "@graphql-codegen/plugin-helpers": "^2.1.0",
+        "@graphql-tools/apollo-engine-loader": "^7.0.5",
+        "@graphql-tools/code-file-loader": "^7.0.6",
+        "@graphql-tools/git-loader": "^7.0.5",
+        "@graphql-tools/github-loader": "^7.0.5",
+        "@graphql-tools/graphql-file-loader": "^7.0.5",
+        "@graphql-tools/json-file-loader": "^7.1.2",
+        "@graphql-tools/load": "^7.3.0",
+        "@graphql-tools/prisma-loader": "^7.0.6",
+        "@graphql-tools/url-loader": "^7.0.11",
+        "@graphql-tools/utils": "^8.1.1",
+        "ansi-escapes": "^4.3.1",
+        "chalk": "^4.1.0",
+        "change-case-all": "1.0.14",
+        "chokidar": "^3.5.2",
+        "common-tags": "^1.8.0",
+        "cosmiconfig": "^7.0.0",
+        "debounce": "^1.2.0",
+        "dependency-graph": "^0.11.0",
+        "detect-indent": "^6.0.0",
+        "glob": "^7.1.6",
+        "globby": "^11.0.4",
+        "graphql-config": "^4.0.1",
+        "inquirer": "^7.3.3",
+        "is-glob": "^4.0.1",
+        "json-to-pretty-yaml": "^1.2.2",
+        "latest-version": "5.1.0",
+        "listr": "^0.14.3",
+        "listr-update-renderer": "^0.5.0",
+        "log-symbols": "^4.0.0",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^1.0.4",
+        "string-env-interpolation": "^1.0.1",
+        "ts-log": "^2.2.3",
+        "tslib": "~2.3.0",
+        "valid-url": "^1.0.9",
+        "wrap-ansi": "^7.0.0",
+        "yaml": "^1.10.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "gql-gen": "bin.js",
+        "graphql-code-generator": "bin.js",
+        "graphql-codegen": "bin.js"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/yargs": {
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
+      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@graphql-codegen/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-pNzpBZWP+B7doPtANN61CMoBq382KMuGierbZXyilrO6RAqgN/DgU4UEIaQFat1BfiVA5GFDAQryysOv4glU8g==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^2.1.0",
+        "@graphql-tools/schema": "^8.1.2",
+        "@graphql-tools/utils": "^8.1.1",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/core/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.1.1.tgz",
+      "integrity": "sha512-7jjN9fekMQkpd7cRTbaBxgqt/hkR3CXeOUSsEyHFDDHKtvCrnev3iyc75IeWXpO9tOwDE8mVPTzEZnu4QukrNA==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^8.1.1",
+        "change-case-all": "1.0.14",
+        "common-tags": "1.8.0",
+        "import-from": "4.0.0",
+        "lodash": "~4.17.0",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/typescript": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.2.1.tgz",
+      "integrity": "sha512-U3sJwgw+x9pascy9BTdD+MiLLyvDfldQYahaJBBmaA3OuTihn+GMiOC5+zaoizf5PN5M6pjs2H4aejXbvUWw/A==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^2.1.1",
+        "@graphql-codegen/visitor-plugin-common": "2.2.0",
+        "auto-bind": "~4.0.0",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-operations": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-2.1.3.tgz",
+      "integrity": "sha512-CGRc2mu7NVW+U6J+a66YdLn7UAZFrVO1axBSzgQOCR9OaSJ9Kr2K3Iq/R8PX31YHWu6hDI93Nf8zc2TIiRLDwQ==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^2.1.1",
+        "@graphql-codegen/typescript": "^2.2.0",
+        "@graphql-codegen/visitor-plugin-common": "2.2.0",
+        "auto-bind": "~4.0.0",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.2.0.tgz",
+      "integrity": "sha512-DxLWp+Y7PRb2BnNK4U/bhNPYzU90SVpt/9MM/bVB/cl93bFxxqtKJhuu7UhsP9QdlT1uJ++gN5EOYbPxJrDshw==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^2.1.1",
+        "@graphql-tools/optimize": "^1.0.1",
+        "@graphql-tools/relay-operation-optimizer": "^6.3.7",
+        "@graphql-tools/utils": "8.2.1",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.14",
+        "dependency-graph": "^0.11.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-tools/utils": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.2.1.tgz",
+      "integrity": "sha512-xjyetFpDy2/MY8P4+NiE7i1czCrAI36Twjm+jcoBfPctMnJegZkZnLfepmjwYQ92Sv9hnhr+x52OUQAddj29CQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/apollo-engine-loader": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-7.1.0.tgz",
+      "integrity": "sha512-JKK34xQiB1l2sBfi8G5c1HZZkleQbwOlLAkySycKTrU+VMzu5lEjhzYwowIbLLjTthjUHQkRFANHkxvB42t5SQ==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^8.2.0",
+        "cross-fetch": "^3.1.4",
+        "sync-fetch": "0.3.0",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/apollo-engine-loader/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/batch-execute": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.1.0.tgz",
+      "integrity": "sha512-PPf8SZto4elBtkaV65RldkjvxCuwYV7tLYKH+w6QnsxogfjrtiwijmewtqIlfnpPRnuhmMzmOlhoDyf0I8EwHw==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^8.2.0",
+        "dataloader": "2.0.0",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.10"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/batch-execute/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/code-file-loader": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.1.0.tgz",
+      "integrity": "sha512-1EVuKGzTDcZoPQAjJYy0Fw2vwLN1ZnWYDlCZLaqml87tCUzJcqcHlQw26SRhDEvVnJC/oCV+mH+2QE55UxqWuA==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/graphql-tag-pluck": "^7.1.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "globby": "^11.0.3",
+        "tslib": "~2.3.0",
+        "unixify": "^1.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/code-file-loader/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/delegate": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.2.1.tgz",
+      "integrity": "sha512-fvQjSrCJCfchSQlLNHPcj1TwojyV1CPtXmwtSEVKvyp9axokuP37WGyliOWUYCepfwpklklLFUeTEiWlCoxv2Q==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/batch-execute": "^8.1.0",
+        "@graphql-tools/schema": "^8.2.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "dataloader": "2.0.0",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.10"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/delegate/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/git-loader": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-7.1.0.tgz",
+      "integrity": "sha512-n6JBKc7Po8aE9/pueH0wO2EXicueuCT3VCo9YcFcCkdEl1tUZwIoIUgNUqgki2eS8u2Z76F2EWZwWBWO2ipXEw==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/graphql-tag-pluck": "^7.1.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "is-glob": "4.0.1",
+        "micromatch": "^4.0.4",
+        "tslib": "~2.3.0",
+        "unixify": "^1.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/git-loader/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/github-loader": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-7.1.0.tgz",
+      "integrity": "sha512-RL8bREscN+CO/gP58BE+aA+PXUIwMY7okmrWtrupjRyo1IYv0bfaZXKHRF+qb2gqlJxksM5Q9HevO/MIj6T1eQ==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/graphql-tag-pluck": "^7.1.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "cross-fetch": "3.1.4",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/github-loader/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/graphql-file-loader": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.1.0.tgz",
+      "integrity": "sha512-VWGetkBuyWrUxSpMnbpzZs2yHWBFeo9nTYjc8+o+xyJKpG/CRfvQrhBRNRFfV/5C0j5/Z1FMfUgsroEAG5H3HQ==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/import": "^6.4.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "globby": "^11.0.3",
+        "tslib": "~2.3.0",
+        "unixify": "^1.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/graphql-file-loader/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/graphql-tag-pluck": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.1.0.tgz",
+      "integrity": "sha512-Y0iRqHKoB0i1RCpskuFKmvnehBcKSu9awEq7ml4/RWSMHRkVlJs8PAFuChyOO6jASC2ttkyfssB6qLJugvc+DQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "7.15.3",
+        "@babel/traverse": "7.15.0",
+        "@babel/types": "7.15.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/import": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.4.0.tgz",
+      "integrity": "sha512-jfE01oPcmc4vzAcYLs6xT7XC4jJWrM1HNtIwc7HyyHTxrC3nf36XrF3txEZ2l20GT53+OWnMgYx1HhauLGdJmA==",
+      "dev": true,
+      "dependencies": {
+        "resolve-from": "5.0.0",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/import/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/json-file-loader": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.2.0.tgz",
+      "integrity": "sha512-YMGjYtjYoalmGHUynypSqxm99fSBOXWqoDeDVYTHAZy970yo61yTi72owEtg7dwB4fQndL2wCoh6ZDS5ruiDDg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^8.2.0",
+        "globby": "^11.0.3",
+        "tslib": "~2.3.0",
+        "unixify": "^1.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/json-file-loader/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/load": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.3.0.tgz",
+      "integrity": "sha512-ZVipT7yzOpf/DJ2sLI3xGwnULVFp/icu7RFEgDo2ZX0WHiS7EjWZ0cegxEm87+WN4fMwpiysRLzWx67VIHwKGA==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/schema": "8.2.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "p-limit": "3.1.0",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/load/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphql-tools/load/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/merge": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.1.2.tgz",
+      "integrity": "sha512-kFLd4kKNJXYXnKIhM8q9zgGAtbLmsy3WmGdDxYq3YHBJUogucAxnivQYyRIseUq37KGmSAIWu3pBQ23TKGsGOw==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^8.2.2",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/merge/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/optimize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.1.0.tgz",
+      "integrity": "sha512-OW3tX3DHZ/5bRPPGI5UNgaQpaV7HihvV9zX6MYCLwERWRZTbc2DsNIq+H8L5Y5q2E2G8/H7vuz7q8LH8RgyP6A==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/optimize/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/prisma-loader": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.1.0.tgz",
+      "integrity": "sha512-fehVzximGYuVkbl4mIbXjPz3XlL+7N4BlnXI5QEAif2DJ8fkTpPN7E9PoV80lxWkLDNokFFDHH6qq7hr99JyOg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/url-loader": "^7.1.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "@types/js-yaml": "^4.0.0",
+        "@types/json-stable-stringify": "^1.0.32",
+        "@types/jsonwebtoken": "^8.5.0",
+        "chalk": "^4.1.0",
+        "debug": "^4.3.1",
+        "dotenv": "^10.0.0",
+        "graphql-request": "^3.3.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "isomorphic-fetch": "^3.0.0",
+        "js-yaml": "^4.0.0",
+        "json-stable-stringify": "^1.0.1",
+        "jsonwebtoken": "^8.5.1",
+        "lodash": "^4.17.20",
+        "replaceall": "^0.1.6",
+        "scuid": "^1.1.0",
+        "tslib": "~2.3.0",
+        "yaml-ast-parser": "^0.0.43"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/relay-operation-optimizer": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.4.0.tgz",
+      "integrity": "sha512-auNvHC8gHu9BHBPnLA5c8Iv5VAXQG866KZJz7ljhKpXPdlPevK4zjHlVJwqnF8H6clJ9NgZpizN4kNNCe/3R9g==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^8.2.0",
+        "relay-compiler": "11.0.2",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/relay-operation-optimizer/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/@graphql-tools/relay-operation-optimizer/node_modules/relay-compiler": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-11.0.2.tgz",
+      "integrity": "sha512-nDVAURT1YncxSiDOKa39OiERkAr0DUcPmlHlg+C8zD+EiDo2Sgczf2R6cDsN4UcDvucYtkLlDLFErPwgLs8WzA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.0.0",
+        "@babel/generator": "^7.5.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "babel-preset-fbjs": "^3.3.0",
+        "chalk": "^4.0.0",
+        "fb-watchman": "^2.0.0",
+        "fbjs": "^3.0.0",
+        "glob": "^7.1.1",
+        "immutable": "~3.7.6",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "relay-runtime": "11.0.2",
+        "signedsource": "^1.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "relay-compiler": "bin/relay-compiler"
+      },
+      "peerDependencies": {
+        "graphql": "^15.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/relay-operation-optimizer/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/relay-operation-optimizer/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@graphql-tools/relay-operation-optimizer/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/relay-operation-optimizer/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@graphql-tools/relay-operation-optimizer/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@graphql-tools/schema": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.2.0.tgz",
+      "integrity": "sha512-ufmI5mJQa8NJczzfkh0pUttKvspqDcT5LLakA3jUmOrrE4d4NVj6onZlazdTzF5sAepSNqanFnwhrxZpCAJMKg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/merge": "^8.1.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.10"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/schema/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/url-loader": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.1.0.tgz",
+      "integrity": "sha512-h0NAcjPBei/Zf69OeFZWUbPXKA2aK5YXyfAZkAc+LP8pnBDBZW+mPr2lOZZJPJ8LMZPPjf5hwVHqXGImduHgmA==",
+      "dev": true,
+      "dependencies": {
+        "@ardatan/fetch-event-source": "2.0.2",
+        "@graphql-tools/delegate": "^8.2.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "@graphql-tools/wrap": "^8.1.0",
+        "@n1ru4l/graphql-live-query": "0.7.1",
+        "@types/websocket": "1.0.4",
+        "@types/ws": "^7.4.7",
+        "abort-controller": "3.0.0",
+        "cross-fetch": "3.1.4",
+        "extract-files": "11.0.0",
+        "form-data": "4.0.0",
+        "graphql-ws": "^5.4.1",
+        "is-promise": "4.0.0",
+        "isomorphic-ws": "4.0.1",
+        "lodash": "4.17.21",
+        "meros": "1.1.4",
+        "subscriptions-transport-ws": "^0.10.0",
+        "sync-fetch": "0.3.0",
+        "tslib": "~2.3.0",
+        "valid-url": "1.0.9",
+        "value-or-promise": "1.0.10",
+        "ws": "8.2.1"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/url-loader/node_modules/@n1ru4l/graphql-live-query": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@n1ru4l/graphql-live-query/-/graphql-live-query-0.7.1.tgz",
+      "integrity": "sha512-5kJPe2FkPNsCGu9tocKIzUSNO986qAqdnbk8hIFqWlpVPBAmEAOYb1mr6PA18FYAlu7ojWm9Hm13k29aj2GGlQ==",
+      "dev": true,
+      "peerDependencies": {
+        "graphql": "^15.4.0"
+      }
+    },
+    "node_modules/@graphql-tools/url-loader/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@graphql-tools/url-loader/node_modules/meros": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/meros/-/meros-1.1.4.tgz",
+      "integrity": "sha512-E9ZXfK9iQfG9s73ars9qvvvbSIkJZF5yOo9j4tcwM5tN8mUKfj/EKN5PzOr3ZH0y5wL7dLAHw3RVEfpQV9Q7VQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@types/node": ">=12"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@graphql-tools/url-loader/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/url-loader/node_modules/ws": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.1.tgz",
+      "integrity": "sha512-XkgWpJU3sHU7gX8f13NqTn6KQ85bd1WU7noBHTT8fSohx7OS1TPY8k+cyRPCzFkia7C4mM229yeHr1qK9sM4JQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@graphql-tools/utils": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.2.2.tgz",
+      "integrity": "sha512-29FFY5U4lpXuBiW9dRvuWnBVwGhWbGLa2leZcAMU/Pz47Cr/QLZGVgpLBV9rt+Gbs7wyIJM7t7EuksPs0RDm3g==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/utils/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/wrap": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.1.0.tgz",
+      "integrity": "sha512-WLT/bFewOIY8KJMzgOJSM/02fXJSFktFvI+JRu39wDH+hwFy1y7pFC0Bs1TP8B/hAEJ+t9+7JspX0LQWAUFjDg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/delegate": "^8.2.0",
+        "@graphql-tools/schema": "^8.2.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.10"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/wrap/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -818,6 +2408,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+      "dev": true
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "dev": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1479,6 +3075,35 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@samverschueren/stream-to-observable": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
+      "integrity": "sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==",
+      "dev": true,
+      "dependencies": {
+        "any-observable": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        },
+        "zen-observable": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -1495,6 +3120,18 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "dependencies": {
+        "defer-to-connect": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -1648,11 +3285,32 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.3.tgz",
+      "integrity": "sha512-5t9BhoORasuF5uCPr+d5/hdB++zRFUTMIZOzbNkr+jZh3yQht4HYbRDyj9fY8n2TZT30iW9huzav73x4NikqWg==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.8",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
       "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
       "dev": true
+    },
+    "node_modules/@types/json-stable-stringify": {
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.33.tgz",
+      "integrity": "sha512-qEWiQff6q2tA5gcJGWwzplQcXdJtm+0oy6IHGHzlOf3eFAkGE/FIPXZK9ofWgNSHVp8AFFI33PJJshS0ei3Gvw==",
+      "dev": true
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.5.tgz",
+      "integrity": "sha512-OGqtHQ7N5/Ap/TUwO6IgHDuLiAoTmHhGpNvgkCm/F4N6pKzx/RBSfr2OXZSwC6vkfnsEdb6+7DNZVtiXiwdwFw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/lodash": {
       "version": "4.14.171",
@@ -1700,6 +3358,12 @@
         "form-data": "^3.0.0"
       }
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
     "node_modules/@types/prettier": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
@@ -1711,6 +3375,24 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "node_modules/@types/websocket": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.4.tgz",
+      "integrity": "sha512-qn1LkcFEKK8RPp459jkjzsfpbsx36BBt3oC3pITYtkoBw/aVX+EZFa5j3ThCRTNpLFvIMr5dSTD4RaMdilIOpA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
@@ -1927,6 +3609,18 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
@@ -2053,6 +3747,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/anymatch": {
@@ -2225,6 +3928,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -2239,6 +3948,18 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "node_modules/auto-bind": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/await-to-js": {
       "version": "2.1.1",
@@ -2280,6 +4001,15 @@
         "@babel/core": "^7.8.0"
       }
     },
+    "node_modules/babel-plugin-dynamic-import-node": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+      "dev": true,
+      "dependencies": {
+        "object.assign": "^4.1.0"
+      }
+    },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
@@ -2311,6 +4041,12 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/babel-plugin-syntax-trailing-function-commas": {
+      "version": "7.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+      "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==",
+      "dev": true
+    },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
@@ -2334,6 +4070,44 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/babel-preset-fbjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.4.0.tgz",
+      "integrity": "sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==",
+      "dev": true,
+      "dependencies": {
+        "@babel/plugin-proposal-class-properties": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+        "@babel/plugin-syntax-class-properties": "^7.0.0",
+        "@babel/plugin-syntax-flow": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-classes": "^7.0.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.0.0",
+        "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+        "@babel/plugin-transform-for-of": "^7.0.0",
+        "@babel/plugin-transform-function-name": "^7.0.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-member-expression-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+        "@babel/plugin-transform-object-super": "^7.0.0",
+        "@babel/plugin-transform-parameters": "^7.0.0",
+        "@babel/plugin-transform-property-literals": "^7.0.0",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-template-literals": "^7.0.0",
+        "babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/babel-preset-jest": {
       "version": "27.0.6",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.0.6.tgz",
@@ -2350,10 +4124,45 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+      "dev": true
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -2438,6 +4247,30 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -2447,10 +4280,58 @@
         "node": "*"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+      "dev": true
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "dev": true,
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -2494,6 +4375,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dev": true,
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/camel-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
     "node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -2513,6 +4410,23 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
+    "node_modules/capital-case": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/capital-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2529,6 +4443,50 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dev": true,
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/change-case-all": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
+      "integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
+      "dev": true,
+      "dependencies": {
+        "change-case": "^4.1.2",
+        "is-lower-case": "^2.0.2",
+        "is-upper-case": "^2.0.2",
+        "lower-case": "^2.0.2",
+        "lower-case-first": "^2.0.2",
+        "sponge-case": "^1.0.1",
+        "swap-case": "^2.0.2",
+        "title-case": "^3.0.3",
+        "upper-case": "^2.0.2",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/change-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
     "node_modules/char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -2537,6 +4495,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
     },
     "node_modules/cheerio": {
       "version": "1.0.0-rc.10",
@@ -2581,6 +4545,27 @@
       "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
       "dev": true
     },
+    "node_modules/chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
@@ -2593,6 +4578,96 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "dependencies": {
+        "slice-ansi": "0.0.4",
+        "string-width": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -2604,6 +4679,15 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2612,6 +4696,15 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -2665,10 +4758,36 @@
         "node": ">= 6"
       }
     },
+    "node_modules/common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      }
+    },
+    "node_modules/constant-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
     },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
@@ -2713,13 +4832,29 @@
         "node": ">=4"
       }
     },
+    "node_modules/cosmiconfig-toml-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-toml-loader/-/cosmiconfig-toml-loader-1.0.0.tgz",
+      "integrity": "sha512-H/2gurFWVi7xXvCyvsWRLCMekl4tITJcX0QEsDMpzxtuxDyM59xLatYNg4s/k9AA/HdtCYfj2su8mgA0GSDLDA==",
+      "dev": true,
+      "dependencies": {
+        "@iarna/toml": "^2.2.5"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "dependencies": {
+        "node-fetch": "2.6.1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -2801,6 +4936,24 @@
         "node": ">=10"
       }
     },
+    "node_modules/dataloader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==",
+      "dev": true
+    },
+    "node_modules/date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true
+    },
     "node_modules/debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -2818,17 +4971,47 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
+    "node_modules/decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.3",
@@ -2844,6 +5027,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "dev": true
     },
     "node_modules/define-properties": {
       "version": "1.1.3",
@@ -2870,6 +5059,24 @@
       "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
       "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
       "dev": true
+    },
+    "node_modules/dependency-graph": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -2997,6 +5204,22 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dot-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
     "node_modules/dotenv": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
@@ -3005,11 +5228,35 @@
         "node": ">=10"
       }
     },
+    "node_modules/duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.3.792",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.792.tgz",
       "integrity": "sha512-RM2O2xrNarM7Cs+XF/OE2qX/aBROyOZqqgP+8FXMXSuWuUqCfUUzg7NytQrzZU3aSqk1Qq6zqnVkJsbfMkIatg==",
       "dev": true
+    },
+    "node_modules/elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -3028,6 +5275,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
@@ -3550,6 +5806,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "dev": true
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3620,6 +5891,44 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/extract-files": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
+      "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jaydenseric"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3677,6 +5986,27 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fbjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.0.tgz",
+      "integrity": "sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==",
+      "dev": true,
+      "dependencies": {
+        "cross-fetch": "^3.0.4",
+        "fbjs-css-vars": "^1.0.0",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      }
+    },
+    "node_modules/fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+      "dev": true
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -3684,6 +6014,30 @@
       "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -3921,6 +6275,40 @@
         "node": ">= 4"
       }
     },
+    "node_modules/got": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/got/node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
@@ -3936,6 +6324,192 @@
       },
       "engines": {
         "node": ">= 6.x"
+      }
+    },
+    "node_modules/graphql-config": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-4.0.1.tgz",
+      "integrity": "sha512-JdXxFzBwjujJMGLHUZom9SrmP/M4gF57iTDa3fJVm3Q85+Xw2kj9jZIygaaSLpDKhaPnMQZqfJ5Hmc6afKxS9w==",
+      "dev": true,
+      "dependencies": {
+        "@endemolshinegroup/cosmiconfig-typescript-loader": "3.0.2",
+        "@graphql-tools/graphql-file-loader": "^7.0.1",
+        "@graphql-tools/json-file-loader": "^7.0.1",
+        "@graphql-tools/load": "^7.1.0",
+        "@graphql-tools/merge": "^6.2.16",
+        "@graphql-tools/url-loader": "^7.0.3",
+        "@graphql-tools/utils": "^8.0.1",
+        "cosmiconfig": "7.0.0",
+        "cosmiconfig-toml-loader": "1.0.0",
+        "minimatch": "3.0.4",
+        "string-env-interpolation": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/graphql-config/node_modules/@endemolshinegroup/cosmiconfig-typescript-loader": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz",
+      "integrity": "sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==",
+      "dev": true,
+      "dependencies": {
+        "lodash.get": "^4",
+        "make-error": "^1",
+        "ts-node": "^9",
+        "tslib": "^2"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "cosmiconfig": ">=6"
+      }
+    },
+    "node_modules/graphql-config/node_modules/@graphql-tools/merge": {
+      "version": "6.2.17",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-6.2.17.tgz",
+      "integrity": "sha512-G5YrOew39fZf16VIrc49q3c8dBqQDD0ax5LYPiNja00xsXDi0T9zsEWVt06ApjtSdSF6HDddlu5S12QjeN8Tow==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/schema": "^8.0.2",
+        "@graphql-tools/utils": "8.0.2",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/graphql-config/node_modules/@graphql-tools/utils": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.0.2.tgz",
+      "integrity": "sha512-gzkavMOgbhnwkHJYg32Adv6f+LxjbQmmbdD5Hty0+CWxvaiuJq+nU6tzb/7VSU4cwhbNLx/lGu2jbCPEW1McZQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/graphql-config/node_modules/cosmiconfig": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+      "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/graphql-config/node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphql-config/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphql-config/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/graphql-config/node_modules/ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "dependencies": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
+      }
+    },
+    "node_modules/graphql-config/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/graphql-request": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.5.0.tgz",
+      "integrity": "sha512-Io89QpfU4rqiMbqM/KwMBzKaDLOppi8FU8sEccCE4JqCgz95W9Q8bvxQ4NfPALLSMvg9nafgg8AkYRmgKSlukA==",
+      "dev": true,
+      "dependencies": {
+        "cross-fetch": "^3.0.6",
+        "extract-files": "^9.0.0",
+        "form-data": "^3.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x"
+      }
+    },
+    "node_modules/graphql-request/node_modules/extract-files": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+      "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
+      "dev": true,
+      "engines": {
+        "node": "^10.17.0 || ^12.0.0 || >= 13.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jaydenseric"
       }
     },
     "node_modules/graphql-tag": {
@@ -3957,6 +6531,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
       "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
+    "node_modules/graphql-ws": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.5.0.tgz",
+      "integrity": "sha512-WQepPMGQQoqS2VsrI2I3RMLCVz3CW4/6ZqGV6ABDOwH4R62DzjxwMlwZbj6vhSI/7IM3/C911yITwgs77iO/hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
+    },
     "node_modules/growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -3975,6 +6561,27 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/has-bigints": {
@@ -4014,6 +6621,22 @@
         "he": "bin/he"
       }
     },
+    "node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dev": true,
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/header-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -4050,6 +6673,12 @@
         "domutils": "^2.5.2",
         "entities": "^2.0.0"
       }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "dev": true
     },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
@@ -4099,6 +6728,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -4106,6 +6755,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immutable": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+      "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/import-fresh": {
@@ -4126,6 +6784,18 @@
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/import-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/import-local": {
@@ -4153,6 +6823,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4167,6 +6846,36 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
+    "node_modules/inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -4180,6 +6889,28 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "dev": true,
+      "dependencies": {
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4191,6 +6922,18 @@
       "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -4300,6 +7043,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-2.0.2.tgz",
+      "integrity": "sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/is-lower-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
@@ -4331,10 +7089,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-observable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+      "dev": true,
+      "dependencies": {
+        "symbol-observable": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true
     },
     "node_modules/is-regex": {
@@ -4350,6 +7126,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dev": true,
+      "dependencies": {
+        "is-unc-path": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-stream": {
@@ -4395,11 +7183,78 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "node_modules/is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dev": true,
+      "dependencies": {
+        "unc-path-regex": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-2.0.2.tgz",
+      "integrity": "sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/is-upper-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "dev": true,
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -6047,10 +8902,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -6058,11 +8925,33 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "dependencies": {
+        "jsonify": "~0.0.0"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "node_modules/json-to-pretty-yaml": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz",
+      "integrity": "sha1-9M0L0KXo/h3yWq9boRiwmf2ZLVs=",
+      "dev": true,
+      "dependencies": {
+        "remedial": "^1.0.7",
+        "remove-trailing-spaces": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.0",
@@ -6079,6 +8968,76 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "dev": true,
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=4",
+        "npm": ">=1.4.28"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dev": true,
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dev": true,
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -6086,6 +9045,18 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/latest-version": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+      "dev": true,
+      "dependencies": {
+        "package-json": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/leven": {
@@ -6110,6 +9081,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
     "node_modules/linkify-it": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
@@ -6117,6 +9094,305 @@
       "dev": true,
       "dependencies": {
         "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/listr": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+      "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+      "dev": true,
+      "dependencies": {
+        "@samverschueren/stream-to-observable": "^0.3.0",
+        "is-observable": "^1.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.5.0",
+        "listr-verbose-renderer": "^0.5.0",
+        "p-map": "^2.0.0",
+        "rxjs": "^6.3.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr-update-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+      "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^2.3.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "listr": "^0.14.2"
+      }
+    },
+    "node_modules/listr-update-renderer/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/listr-update-renderer/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/listr-update-renderer/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/listr-update-renderer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/listr-update-renderer/node_modules/figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/listr-update-renderer/node_modules/log-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/listr-update-renderer/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/listr-update-renderer/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/listr-verbose-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+      "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.1",
+        "cli-cursor": "^2.1.0",
+        "date-fns": "^1.27.2",
+        "figures": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/listr-verbose-renderer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/listr/node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "dev": true
+    },
+    "node_modules/listr/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/locate-path": {
@@ -6153,10 +9429,52 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+      "dev": true
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+      "dev": true
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+      "dev": true
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
+      "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+      "dev": true
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -6173,6 +9491,198 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.xorby/-/lodash.xorby-4.7.0.tgz",
       "integrity": "sha1-nBmm+fBjputT3QPBtocXmYAUY9c="
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^3.0.0",
+        "cli-cursor": "^2.0.0",
+        "wrap-ansi": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-update/node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-update/node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-update/node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-update/node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+      "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/lower-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-2.0.2.tgz",
+      "integrity": "sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/lower-case-first/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/lower-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -6212,6 +9722,15 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.x"
+      }
+    },
+    "node_modules/map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/markdown-it": {
@@ -6322,6 +9841,15 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -6501,6 +10029,22 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dev": true,
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/no-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
     "node_modules/node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
@@ -6539,6 +10083,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-url": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -6563,11 +10116,35 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/nullthrows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "dev": true
+    },
+    "node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.11.0",
@@ -6686,6 +10263,15 @@
         "os-tmpdir": "^1.0.0"
       }
     },
+    "node_modules/p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/p-each-series": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
@@ -6725,6 +10311,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -6733,6 +10328,37 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/package-json": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+      "dev": true,
+      "dependencies": {
+        "got": "^9.6.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.0.0",
+        "semver": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dev": true,
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/param-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -6753,6 +10379,20 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "dev": true,
+      "dependencies": {
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/parse-json": {
@@ -6800,6 +10440,38 @@
         "parse5": "^6.0.1"
       }
     },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/pascal-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dev": true,
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/path-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6831,6 +10503,27 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "dev": true,
+      "dependencies": {
+        "path-root-regex": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -6890,6 +10583,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/prettier": {
@@ -6965,6 +10667,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "dependencies": {
+        "asap": "~2.0.3"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.1.tgz",
@@ -6983,6 +10694,16 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -7028,6 +10749,30 @@
         }
       ]
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -7046,6 +10791,24 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -7056,6 +10819,71 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+      "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+      "dev": true,
+      "dependencies": {
+        "rc": "^1.2.8"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "dev": true,
+      "dependencies": {
+        "rc": "^1.2.8"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/relay-runtime": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-11.0.2.tgz",
+      "integrity": "sha512-xxZkIRnL8kNE1cxmwDXX8P+wSeWLR+0ACFyAiAhvfWWAyjXb+bhjJ2FSsRGlNYfkqaTNEuDqpnodQV1/fF7Idw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "fbjs": "^3.0.0",
+        "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/remedial": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
+      "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "node_modules/remove-trailing-spaces": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/remove-trailing-spaces/-/remove-trailing-spaces-1.0.8.tgz",
+      "integrity": "sha512-O3vsMYfWighyFbTd8hk8VaSj9UAGENxAtX+//ugIst2RMk5e03h6RoIS+0ylsFxY1gvmPuAY/PO4It+gPEeySA==",
+      "dev": true
+    },
+    "node_modules/replaceall": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/replaceall/-/replaceall-0.1.6.tgz",
+      "integrity": "sha1-gdgax663LX9cSUKt8ml6MiBojY4=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.x"
       }
     },
     "node_modules/require-directory": {
@@ -7075,6 +10903,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.20.0",
@@ -7109,6 +10943,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "dependencies": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -7134,6 +10990,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7155,6 +11020,18 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -7180,6 +11057,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/scuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/scuid/-/scuid-1.1.0.tgz",
+      "integrity": "sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==",
+      "dev": true
+    },
     "node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -7188,6 +11071,35 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/sentence-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
@@ -7241,6 +11153,12 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "node_modules/signedsource": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz",
+      "integrity": "sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo=",
+      "dev": true
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7273,6 +11191,22 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dev": true,
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/snake-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7290,6 +11224,21 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/sponge-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
+      "integrity": "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/sponge-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -7306,6 +11255,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/string-env-interpolation": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz",
+      "integrity": "sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==",
+      "dev": true
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -7400,6 +11355,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/subscriptions-transport-ws": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.10.0.tgz",
+      "integrity": "sha512-k28LhLn3abJ1mowFW+LP4QGggE0e3hrk55zXbMHyAeZkCUYtC0owepiwqMD3zX8DglQVaxnhE760pESrNSEzpg==",
+      "dev": true,
+      "dependencies": {
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.10.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7425,11 +11396,48 @@
         "node": ">=8"
       }
     },
+    "node_modules/swap-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-2.0.2.tgz",
+      "integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/swap-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "node_modules/sync-fetch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/sync-fetch/-/sync-fetch-0.3.0.tgz",
+      "integrity": "sha512-dJp4qg+x4JwSEW1HibAuMi0IIrBI3wuQr2GimmqB7OXR50wmwzfdusG+p39R9w3R6aFtZ2mzvxvWKQ3Bd/vx3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.7.0",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/table": {
       "version": "6.7.1",
@@ -7512,6 +11520,27 @@
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "node_modules/title-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
+      "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/title-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -7537,6 +11566,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/to-regex-range": {
@@ -7641,6 +11679,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/ts-log": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.3.tgz",
+      "integrity": "sha512-XvB+OdKSJ708Dmf9ore4Uf/q62AYDTzFcAdxc8KNML1mmAWywRFVt/dn1KYJH8Agt5UJNujfM3znU5PxgAzA2w==",
+      "dev": true
     },
     "node_modules/ts-node": {
       "version": "8.10.2",
@@ -7760,6 +11804,25 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/ua-parser-js": {
+      "version": "0.7.28",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -7780,6 +11843,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/underscore": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
@@ -7795,6 +11867,60 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/unixify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+      "integrity": "sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unixify/node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/upper-case-first/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/upper-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -7809,6 +11935,18 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
       "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
       "dev": true
+    },
+    "node_modules/url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
+      "dependencies": {
+        "prepend-http": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/util.promisify": {
       "version": "1.1.1",
@@ -7861,6 +11999,21 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
+      "dev": true
+    },
+    "node_modules/value-or-promise": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.10.tgz",
+      "integrity": "sha512-1OwTzvcfXkAfabk60UVr5NdjtjJ0Fg0T5+B1bhxtrOEwSH2fe8y4DnLgoksfCyd8yZCOQQHB0qLMQnwgCjbXLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/vsce": {
@@ -8181,6 +12334,12 @@
         "iconv-lite": "0.4.24"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
+    },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -8230,6 +12389,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -8327,6 +12492,21 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true
+    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -8379,6 +12559,18 @@
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zen-observable": {
@@ -8438,6 +12630,12 @@
         "@apollographql/graphql-language-service-types": "^2.0.0"
       }
     },
+    "@ardatan/fetch-event-source": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@ardatan/fetch-event-source/-/fetch-event-source-2.0.2.tgz",
+      "integrity": "sha512-mcpz/wJ7s50PJIVz4OQ1Yim3w/AAchtYtIg0QMWiMR2cZZoI9t23hRyqeumtD5EmyJu0fxtjmQ5WY8GI86V4rQ==",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
@@ -8448,9 +12646,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.9.tgz",
-      "integrity": "sha512-p3QjZmMGHDGdpcwEYYWu7i7oJShJvtgMjJeb0W95PPhSm++3lm8YXYOh45Y6iCN9PkZLTZ7CIX5nFrp7pw7TXw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
       "dev": true
     },
     "@babel/core": {
@@ -8485,16 +12683,26 @@
       }
     },
     "@babel/generator": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.9.tgz",
-      "integrity": "sha512-4yoHbhDYzFa0GLfCzLp5GxH7vPPMAHdZjyE7M/OajM9037zhx0rf+iNsJwp4PT0MSFpwjG7BsHEbPkBQpZ6cYA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.9",
+        "@babel/types": "^7.15.4",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
+        "@babel/types": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -8503,88 +12711,230 @@
         }
       }
     },
-    "@babel/helper-compilation-targets": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
-      "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
+      "integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.14.5",
+        "@babel/types": "^7.15.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+      "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.15.0",
         "@babel/helper-validator-option": "^7.14.5",
         "browserslist": "^4.16.6",
         "semver": "^6.3.0"
       }
     },
-    "@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.4.tgz",
+      "integrity": "sha512-7ZmzFi+DwJx6A7mHRwbuucEYpyBwmh2Ca0RvI6z2+WLZYCqV0JOaLb+u0zbtmDicebgKBZgqbYfLaKNqSgv5Pw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-annotate-as-pure": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.14.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
-      "integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+      "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.8.tgz",
-      "integrity": "sha512-RyE+NFOjXn5A9YU1dkpeBaduagTlZ0+fccnIcAGbv1KGUlReBj7utF7oEth8IdIBQPcux0DDgW5MFBH2xu9KcA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz",
+      "integrity": "sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.14.5",
-        "@babel/helper-simple-access": "^7.14.8",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.8",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.8",
-        "@babel/types": "^7.14.8"
+        "@babel/helper-module-imports": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-simple-access": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
+          "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+          "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.4",
+            "@babel/helper-function-name": "^7.15.4",
+            "@babel/helper-hoist-variables": "^7.15.4",
+            "@babel/helper-split-export-declaration": "^7.15.4",
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+      "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-plugin-utils": {
@@ -8594,33 +12944,113 @@
       "dev": true
     },
     "@babel/helper-replace-supers": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
-      "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+      "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.14.5",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
+          "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+          "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.4",
+            "@babel/helper-function-name": "^7.15.4",
+            "@babel/helper-hoist-variables": "^7.15.4",
+            "@babel/helper-split-export-declaration": "^7.15.4",
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+      "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.8"
+        "@babel/types": "^7.15.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.15.4.tgz",
+      "integrity": "sha512-BMRLsdh+D1/aap19TycS4eD1qELGrCBJwzaY9IE8LrpJtJb+H7rQkPIdsfgnMtLBA6DJls7X9z93Z4U8h7xw0A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.15.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-validator-identifier": {
@@ -8716,10 +13146,33 @@
       }
     },
     "@babel/parser": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.9.tgz",
-      "integrity": "sha512-RdUTOseXJ8POjjOeEBEvNMIZU/nm4yu2rufRkcibzkkg7DmQvXU8v3M4Xk9G7uuI86CDGkKcuDWgioqZm+mScQ==",
+      "version": "7.15.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
+      "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
       "dev": true
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.14.5.tgz",
+      "integrity": "sha512-q/PLpv5Ko4dVc1LYMpCY7RVAAO4uk55qPwrIuJ5QJ8c6cVuAmhu7I/49JOppXL6gXf7ZHzpRVEUZdYoPLM04Gg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.15.6.tgz",
+      "integrity": "sha512-qtOHo7A1Vt+O23qEAX+GdBpqaIuD3i9VRrWgCJeq7WO6H2d14EK3q11urj5Te2MAeK97nMiIdRpwd/ST4JFbNg==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.15.0",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-transform-parameters": "^7.15.4"
+      }
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -8748,6 +13201,15 @@
         "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
+    "@babel/plugin-syntax-flow": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.14.5.tgz",
+      "integrity": "sha512-9WK5ZwKCdWHxVuU13XNT6X73FGmutAXeor5lGFq6qhOFtMFUF4jkbijuyUdZZlpYq6E2hZeZf/u3959X9wsv0Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
     "@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -8764,6 +13226,15 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
+      "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
@@ -8838,38 +13309,262 @@
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
-    "@babel/template": {
+    "@babel/plugin-transform-arrow-functions": {
       "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.14.5.tgz",
+      "integrity": "sha512-KOnO0l4+tD5IfOdi4x8C1XmEIRWUjNRV8wc6K2vz/3e8yAOoZZvsRXRRIF/yo/MAOFb4QjtAw9xSxMXbSMRy8A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.14.5.tgz",
+      "integrity": "sha512-dtqWqdWZ5NqBX3KzsVCWfQI3A53Ft5pWFCT2eCVUftWZgjc5DpDponbIF1+c+7cSGk2wN0YK7HGL/ezfRbpKBQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.15.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.15.3.tgz",
+      "integrity": "sha512-nBAzfZwZb4DkaGtOes1Up1nOAp9TDRRFw4XBzBBSG9QK7KVFmYzgj9o9sbPv7TX5ofL4Auq4wZnxCoPnI/lz2Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.15.4.tgz",
+      "integrity": "sha512-Yjvhex8GzBmmPQUvpXRPWQ9WnxXgAFuZSrqOK/eJlOGIXwvv8H3UEdUigl1gb/bnjTrln+e8bkZUYCBt/xYlBg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.14.5.tgz",
+      "integrity": "sha512-pWM+E4283UxaVzLb8UBXv4EIxMovU4zxT1OPnpHJcmnvyY9QbPPTKZfEj31EUvG3/EQRbYAGaYEUZ4yWOBC2xg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.7.tgz",
+      "integrity": "sha512-0mDE99nK+kVh3xlc5vKwB6wnP9ecuSj+zQCa/n0voENtP/zymdT4HH6QEb65wjjcbqr1Jb/7z9Qp7TF5FtwYGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-flow-strip-types": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.14.5.tgz",
+      "integrity": "sha512-KhcolBKfXbvjwI3TV7r7TkYm8oNXHNBqGOy6JDVwtecFaRoKYsUUqJdS10q0YDKW1c6aZQgO+Ys3LfGkox8pXA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-flow": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.15.4.tgz",
+      "integrity": "sha512-DRTY9fA751AFBDh2oxydvVm4SYevs5ILTWLs6xKXps4Re/KG5nfUkr+TdHCrRWB8C69TlzVgA9b3RmGWmgN9LA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.14.5.tgz",
+      "integrity": "sha512-vbO6kv0fIzZ1GpmGQuvbwwm+O4Cbm2NrPzwlup9+/3fdkuzo1YqOZcXw26+YUJB84Ja7j9yURWposEHLYwxUfQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.14.5.tgz",
+      "integrity": "sha512-ql33+epql2F49bi8aHXxvLURHkxJbSmMKl9J5yHqg4PLtdE6Uc48CH1GS6TQvZ86eoB/ApZXwm7jlA+B3kra7A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.14.5.tgz",
+      "integrity": "sha512-WkNXxH1VXVTKarWFqmso83xl+2V3Eo28YY5utIkbsmXoItO8Q3aZxN4BTS2k0hz9dGUloHK26mJMyQEYfkn/+Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.15.4.tgz",
+      "integrity": "sha512-qg4DPhwG8hKp4BbVDvX1s8cohM8a6Bvptu4l6Iingq5rW+yRUAhe/YRup/YcW2zCOlrysEWVhftIcKzrEZv3sA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-simple-access": "^7.15.4",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.14.5.tgz",
+      "integrity": "sha512-MKfOBWzK0pZIrav9z/hkRqIk/2bTv9qvxHzPQc12RcVkMOzpIKnFCNYJip00ssKWYkd8Sf5g0Wr7pqJ+cmtuFg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.15.4.tgz",
+      "integrity": "sha512-9WB/GUTO6lvJU3XQsSr6J/WKvBC2hcs4Pew8YxZagi6GkTdniyqp8On5kqdK8MN0LMeu0mGbhPN+O049NV/9FQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.14.5.tgz",
+      "integrity": "sha512-r1uilDthkgXW8Z1vJz2dKYLV1tuw2xsbrp3MrZmD99Wh9vsfKoob+JTgri5VUb/JqyKRXotlOtwgu4stIYCmnw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.15.1.tgz",
+      "integrity": "sha512-yQZ/i/pUCJAHI/LbtZr413S3VT26qNrEm0M5RRxQJA947/YNYwbZbBaXGDrq6CG5QsZycI1VIP6d7pQaBfP+8Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz",
+      "integrity": "sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-jsx": "^7.14.5",
+        "@babel/types": "^7.14.9"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.14.5.tgz",
+      "integrity": "sha512-xLucks6T1VmGsTB+GWK5Pl9Jl5+nRXD1uoFdA5TSO6xtiNjtXTjKkmPdFXVLGlK5A2/or/wQMKfmQ2Y0XJfn5g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.14.6.tgz",
+      "integrity": "sha512-Zr0x0YroFJku7n7+/HH3A2eIrGMjbmAIbJSVv0IZ+t3U2WUQUA64S/oeied2e+MaGSjmt4alzBCsK9E8gh+fag==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.14.5.tgz",
+      "integrity": "sha512-22btZeURqiepOfuy/VkFr+zStqlujWaarpMErvay7goJS6BWwdd6BY9zQyDLDa4x2S3VugxFb162IZ4m/S/+Gg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/template": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
+          "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/traverse": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.9.tgz",
-      "integrity": "sha512-bldh6dtB49L8q9bUyB7bC20UKgU+EFDwKJylwl234Kv+ySZeMD31Xeht6URyueQ6LrRRpF2tmkfcZooZR9/e8g==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.9",
+        "@babel/generator": "^7.15.0",
         "@babel/helper-function-name": "^7.14.5",
         "@babel/helper-hoist-variables": "^7.14.5",
         "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.14.9",
-        "@babel/types": "^7.14.9",
+        "@babel/parser": "^7.15.0",
+        "@babel/types": "^7.15.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
-      "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.9",
@@ -8943,6 +13638,785 @@
         }
       }
     },
+    "@graphql-codegen/cli": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-2.2.0.tgz",
+      "integrity": "sha512-f4EsScASza57aPM1z6eKAaYmwz83B/LsmiyBb8phy1NfbWea2IBUCfEgtvOHN85xbiMpdQfNtckE2mC84yH80w==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/core": "2.1.0",
+        "@graphql-codegen/plugin-helpers": "^2.1.0",
+        "@graphql-tools/apollo-engine-loader": "^7.0.5",
+        "@graphql-tools/code-file-loader": "^7.0.6",
+        "@graphql-tools/git-loader": "^7.0.5",
+        "@graphql-tools/github-loader": "^7.0.5",
+        "@graphql-tools/graphql-file-loader": "^7.0.5",
+        "@graphql-tools/json-file-loader": "^7.1.2",
+        "@graphql-tools/load": "^7.3.0",
+        "@graphql-tools/prisma-loader": "^7.0.6",
+        "@graphql-tools/url-loader": "^7.0.11",
+        "@graphql-tools/utils": "^8.1.1",
+        "ansi-escapes": "^4.3.1",
+        "chalk": "^4.1.0",
+        "change-case-all": "1.0.14",
+        "chokidar": "^3.5.2",
+        "common-tags": "^1.8.0",
+        "cosmiconfig": "^7.0.0",
+        "debounce": "^1.2.0",
+        "dependency-graph": "^0.11.0",
+        "detect-indent": "^6.0.0",
+        "glob": "^7.1.6",
+        "globby": "^11.0.4",
+        "graphql-config": "^4.0.1",
+        "inquirer": "^7.3.3",
+        "is-glob": "^4.0.1",
+        "json-to-pretty-yaml": "^1.2.2",
+        "latest-version": "5.1.0",
+        "listr": "^0.14.3",
+        "listr-update-renderer": "^0.5.0",
+        "log-symbols": "^4.0.0",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^1.0.4",
+        "string-env-interpolation": "^1.0.1",
+        "ts-log": "^2.2.3",
+        "tslib": "~2.3.0",
+        "valid-url": "^1.0.9",
+        "wrap-ansi": "^7.0.0",
+        "yaml": "^1.10.0",
+        "yargs": "^17.0.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+          "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          }
+        },
+        "import-fresh": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.1.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
+          "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        }
+      }
+    },
+    "@graphql-codegen/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-pNzpBZWP+B7doPtANN61CMoBq382KMuGierbZXyilrO6RAqgN/DgU4UEIaQFat1BfiVA5GFDAQryysOv4glU8g==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^2.1.0",
+        "@graphql-tools/schema": "^8.1.2",
+        "@graphql-tools/utils": "^8.1.1",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/plugin-helpers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.1.1.tgz",
+      "integrity": "sha512-7jjN9fekMQkpd7cRTbaBxgqt/hkR3CXeOUSsEyHFDDHKtvCrnev3iyc75IeWXpO9tOwDE8mVPTzEZnu4QukrNA==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^8.1.1",
+        "change-case-all": "1.0.14",
+        "common-tags": "1.8.0",
+        "import-from": "4.0.0",
+        "lodash": "~4.17.0",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/typescript": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.2.1.tgz",
+      "integrity": "sha512-U3sJwgw+x9pascy9BTdD+MiLLyvDfldQYahaJBBmaA3OuTihn+GMiOC5+zaoizf5PN5M6pjs2H4aejXbvUWw/A==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^2.1.1",
+        "@graphql-codegen/visitor-plugin-common": "2.2.0",
+        "auto-bind": "~4.0.0",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/typescript-operations": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-2.1.3.tgz",
+      "integrity": "sha512-CGRc2mu7NVW+U6J+a66YdLn7UAZFrVO1axBSzgQOCR9OaSJ9Kr2K3Iq/R8PX31YHWu6hDI93Nf8zc2TIiRLDwQ==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^2.1.1",
+        "@graphql-codegen/typescript": "^2.2.0",
+        "@graphql-codegen/visitor-plugin-common": "2.2.0",
+        "auto-bind": "~4.0.0",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/visitor-plugin-common": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.2.0.tgz",
+      "integrity": "sha512-DxLWp+Y7PRb2BnNK4U/bhNPYzU90SVpt/9MM/bVB/cl93bFxxqtKJhuu7UhsP9QdlT1uJ++gN5EOYbPxJrDshw==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^2.1.1",
+        "@graphql-tools/optimize": "^1.0.1",
+        "@graphql-tools/relay-operation-optimizer": "^6.3.7",
+        "@graphql-tools/utils": "8.2.1",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.14",
+        "dependency-graph": "^0.11.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.2.1.tgz",
+          "integrity": "sha512-xjyetFpDy2/MY8P4+NiE7i1czCrAI36Twjm+jcoBfPctMnJegZkZnLfepmjwYQ92Sv9hnhr+x52OUQAddj29CQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.3.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/apollo-engine-loader": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-7.1.0.tgz",
+      "integrity": "sha512-JKK34xQiB1l2sBfi8G5c1HZZkleQbwOlLAkySycKTrU+VMzu5lEjhzYwowIbLLjTthjUHQkRFANHkxvB42t5SQ==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^8.2.0",
+        "cross-fetch": "^3.1.4",
+        "sync-fetch": "0.3.0",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/batch-execute": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.1.0.tgz",
+      "integrity": "sha512-PPf8SZto4elBtkaV65RldkjvxCuwYV7tLYKH+w6QnsxogfjrtiwijmewtqIlfnpPRnuhmMzmOlhoDyf0I8EwHw==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^8.2.0",
+        "dataloader": "2.0.0",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.10"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/code-file-loader": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.1.0.tgz",
+      "integrity": "sha512-1EVuKGzTDcZoPQAjJYy0Fw2vwLN1ZnWYDlCZLaqml87tCUzJcqcHlQw26SRhDEvVnJC/oCV+mH+2QE55UxqWuA==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/graphql-tag-pluck": "^7.1.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "globby": "^11.0.3",
+        "tslib": "~2.3.0",
+        "unixify": "^1.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/delegate": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.2.1.tgz",
+      "integrity": "sha512-fvQjSrCJCfchSQlLNHPcj1TwojyV1CPtXmwtSEVKvyp9axokuP37WGyliOWUYCepfwpklklLFUeTEiWlCoxv2Q==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/batch-execute": "^8.1.0",
+        "@graphql-tools/schema": "^8.2.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "dataloader": "2.0.0",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.10"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/git-loader": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-7.1.0.tgz",
+      "integrity": "sha512-n6JBKc7Po8aE9/pueH0wO2EXicueuCT3VCo9YcFcCkdEl1tUZwIoIUgNUqgki2eS8u2Z76F2EWZwWBWO2ipXEw==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/graphql-tag-pluck": "^7.1.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "is-glob": "4.0.1",
+        "micromatch": "^4.0.4",
+        "tslib": "~2.3.0",
+        "unixify": "^1.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/github-loader": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-7.1.0.tgz",
+      "integrity": "sha512-RL8bREscN+CO/gP58BE+aA+PXUIwMY7okmrWtrupjRyo1IYv0bfaZXKHRF+qb2gqlJxksM5Q9HevO/MIj6T1eQ==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/graphql-tag-pluck": "^7.1.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "cross-fetch": "3.1.4",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/graphql-file-loader": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.1.0.tgz",
+      "integrity": "sha512-VWGetkBuyWrUxSpMnbpzZs2yHWBFeo9nTYjc8+o+xyJKpG/CRfvQrhBRNRFfV/5C0j5/Z1FMfUgsroEAG5H3HQ==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/import": "^6.4.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "globby": "^11.0.3",
+        "tslib": "~2.3.0",
+        "unixify": "^1.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/graphql-tag-pluck": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.1.0.tgz",
+      "integrity": "sha512-Y0iRqHKoB0i1RCpskuFKmvnehBcKSu9awEq7ml4/RWSMHRkVlJs8PAFuChyOO6jASC2ttkyfssB6qLJugvc+DQ==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "7.15.3",
+        "@babel/traverse": "7.15.0",
+        "@babel/types": "7.15.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/import": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.4.0.tgz",
+      "integrity": "sha512-jfE01oPcmc4vzAcYLs6xT7XC4jJWrM1HNtIwc7HyyHTxrC3nf36XrF3txEZ2l20GT53+OWnMgYx1HhauLGdJmA==",
+      "dev": true,
+      "requires": {
+        "resolve-from": "5.0.0",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/json-file-loader": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.2.0.tgz",
+      "integrity": "sha512-YMGjYtjYoalmGHUynypSqxm99fSBOXWqoDeDVYTHAZy970yo61yTi72owEtg7dwB4fQndL2wCoh6ZDS5ruiDDg==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^8.2.0",
+        "globby": "^11.0.3",
+        "tslib": "~2.3.0",
+        "unixify": "^1.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/load": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.3.0.tgz",
+      "integrity": "sha512-ZVipT7yzOpf/DJ2sLI3xGwnULVFp/icu7RFEgDo2ZX0WHiS7EjWZ0cegxEm87+WN4fMwpiysRLzWx67VIHwKGA==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/schema": "8.2.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "p-limit": "3.1.0",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/merge": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.1.2.tgz",
+      "integrity": "sha512-kFLd4kKNJXYXnKIhM8q9zgGAtbLmsy3WmGdDxYq3YHBJUogucAxnivQYyRIseUq37KGmSAIWu3pBQ23TKGsGOw==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^8.2.2",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/optimize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.1.0.tgz",
+      "integrity": "sha512-OW3tX3DHZ/5bRPPGI5UNgaQpaV7HihvV9zX6MYCLwERWRZTbc2DsNIq+H8L5Y5q2E2G8/H7vuz7q8LH8RgyP6A==",
+      "dev": true,
+      "requires": {
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/prisma-loader": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.1.0.tgz",
+      "integrity": "sha512-fehVzximGYuVkbl4mIbXjPz3XlL+7N4BlnXI5QEAif2DJ8fkTpPN7E9PoV80lxWkLDNokFFDHH6qq7hr99JyOg==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/url-loader": "^7.1.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "@types/js-yaml": "^4.0.0",
+        "@types/json-stable-stringify": "^1.0.32",
+        "@types/jsonwebtoken": "^8.5.0",
+        "chalk": "^4.1.0",
+        "debug": "^4.3.1",
+        "dotenv": "^10.0.0",
+        "graphql-request": "^3.3.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "isomorphic-fetch": "^3.0.0",
+        "js-yaml": "^4.0.0",
+        "json-stable-stringify": "^1.0.1",
+        "jsonwebtoken": "^8.5.1",
+        "lodash": "^4.17.20",
+        "replaceall": "^0.1.6",
+        "scuid": "^1.1.0",
+        "tslib": "~2.3.0",
+        "yaml-ast-parser": "^0.0.43"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/relay-operation-optimizer": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.4.0.tgz",
+      "integrity": "sha512-auNvHC8gHu9BHBPnLA5c8Iv5VAXQG866KZJz7ljhKpXPdlPevK4zjHlVJwqnF8H6clJ9NgZpizN4kNNCe/3R9g==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^8.2.0",
+        "relay-compiler": "11.0.2",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "relay-compiler": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-11.0.2.tgz",
+          "integrity": "sha512-nDVAURT1YncxSiDOKa39OiERkAr0DUcPmlHlg+C8zD+EiDo2Sgczf2R6cDsN4UcDvucYtkLlDLFErPwgLs8WzA==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.0.0",
+            "@babel/generator": "^7.5.0",
+            "@babel/parser": "^7.0.0",
+            "@babel/runtime": "^7.0.0",
+            "@babel/traverse": "^7.0.0",
+            "@babel/types": "^7.0.0",
+            "babel-preset-fbjs": "^3.3.0",
+            "chalk": "^4.0.0",
+            "fb-watchman": "^2.0.0",
+            "fbjs": "^3.0.0",
+            "glob": "^7.1.1",
+            "immutable": "~3.7.6",
+            "invariant": "^2.2.4",
+            "nullthrows": "^1.1.1",
+            "relay-runtime": "11.0.2",
+            "signedsource": "^1.0.0",
+            "yargs": "^15.3.1"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "@graphql-tools/schema": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.2.0.tgz",
+      "integrity": "sha512-ufmI5mJQa8NJczzfkh0pUttKvspqDcT5LLakA3jUmOrrE4d4NVj6onZlazdTzF5sAepSNqanFnwhrxZpCAJMKg==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/merge": "^8.1.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.10"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/url-loader": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.1.0.tgz",
+      "integrity": "sha512-h0NAcjPBei/Zf69OeFZWUbPXKA2aK5YXyfAZkAc+LP8pnBDBZW+mPr2lOZZJPJ8LMZPPjf5hwVHqXGImduHgmA==",
+      "dev": true,
+      "requires": {
+        "@ardatan/fetch-event-source": "2.0.2",
+        "@graphql-tools/delegate": "^8.2.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "@graphql-tools/wrap": "^8.1.0",
+        "@n1ru4l/graphql-live-query": "0.7.1",
+        "@types/websocket": "1.0.4",
+        "@types/ws": "^7.4.7",
+        "abort-controller": "3.0.0",
+        "cross-fetch": "3.1.4",
+        "extract-files": "11.0.0",
+        "form-data": "4.0.0",
+        "graphql-ws": "^5.4.1",
+        "is-promise": "4.0.0",
+        "isomorphic-ws": "4.0.1",
+        "lodash": "4.17.21",
+        "meros": "1.1.4",
+        "subscriptions-transport-ws": "^0.10.0",
+        "sync-fetch": "0.3.0",
+        "tslib": "~2.3.0",
+        "valid-url": "1.0.9",
+        "value-or-promise": "1.0.10",
+        "ws": "8.2.1"
+      },
+      "dependencies": {
+        "@n1ru4l/graphql-live-query": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/@n1ru4l/graphql-live-query/-/graphql-live-query-0.7.1.tgz",
+          "integrity": "sha512-5kJPe2FkPNsCGu9tocKIzUSNO986qAqdnbk8hIFqWlpVPBAmEAOYb1mr6PA18FYAlu7ojWm9Hm13k29aj2GGlQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "meros": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/meros/-/meros-1.1.4.tgz",
+          "integrity": "sha512-E9ZXfK9iQfG9s73ars9qvvvbSIkJZF5yOo9j4tcwM5tN8mUKfj/EKN5PzOr3ZH0y5wL7dLAHw3RVEfpQV9Q7VQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        },
+        "ws": {
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.1.tgz",
+          "integrity": "sha512-XkgWpJU3sHU7gX8f13NqTn6KQ85bd1WU7noBHTT8fSohx7OS1TPY8k+cyRPCzFkia7C4mM229yeHr1qK9sM4JQ==",
+          "dev": true,
+          "requires": {}
+        }
+      }
+    },
+    "@graphql-tools/utils": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.2.2.tgz",
+      "integrity": "sha512-29FFY5U4lpXuBiW9dRvuWnBVwGhWbGLa2leZcAMU/Pz47Cr/QLZGVgpLBV9rt+Gbs7wyIJM7t7EuksPs0RDm3g==",
+      "dev": true,
+      "requires": {
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/wrap": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.1.0.tgz",
+      "integrity": "sha512-WLT/bFewOIY8KJMzgOJSM/02fXJSFktFvI+JRu39wDH+hwFy1y7pFC0Bs1TP8B/hAEJ+t9+7JspX0LQWAUFjDg==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/delegate": "^8.2.0",
+        "@graphql-tools/schema": "^8.2.0",
+        "@graphql-tools/utils": "^8.2.0",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.10"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -8958,6 +14432,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+      "dev": true
+    },
+    "@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "dev": true
     },
     "@istanbuljs/load-nyc-config": {
@@ -9479,6 +14959,21 @@
         "fastq": "^1.6.0"
       }
     },
+    "@samverschueren/stream-to-observable": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
+      "integrity": "sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==",
+      "dev": true,
+      "requires": {
+        "any-observable": "^0.3.0"
+      }
+    },
+    "@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -9495,6 +14990,15 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "^1.0.1"
       }
     },
     "@tootallnate/once": {
@@ -9645,11 +15149,32 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "@types/js-yaml": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.3.tgz",
+      "integrity": "sha512-5t9BhoORasuF5uCPr+d5/hdB++zRFUTMIZOzbNkr+jZh3yQht4HYbRDyj9fY8n2TZT30iW9huzav73x4NikqWg==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.8",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
       "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
       "dev": true
+    },
+    "@types/json-stable-stringify": {
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.33.tgz",
+      "integrity": "sha512-qEWiQff6q2tA5gcJGWwzplQcXdJtm+0oy6IHGHzlOf3eFAkGE/FIPXZK9ofWgNSHVp8AFFI33PJJshS0ei3Gvw==",
+      "dev": true
+    },
+    "@types/jsonwebtoken": {
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.5.tgz",
+      "integrity": "sha512-OGqtHQ7N5/Ap/TUwO6IgHDuLiAoTmHhGpNvgkCm/F4N6pKzx/RBSfr2OXZSwC6vkfnsEdb6+7DNZVtiXiwdwFw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/lodash": {
       "version": "4.14.171",
@@ -9697,6 +15222,12 @@
         "form-data": "^3.0.0"
       }
     },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
     "@types/prettier": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
@@ -9708,6 +15239,24 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "@types/websocket": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.4.tgz",
+      "integrity": "sha512-qn1LkcFEKK8RPp459jkjzsfpbsx36BBt3oC3pITYtkoBw/aVX+EZFa5j3ThCRTNpLFvIMr5dSTD4RaMdilIOpA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "16.0.4",
@@ -9842,6 +15391,15 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "acorn": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
@@ -9929,6 +15487,12 @@
       "requires": {
         "color-convert": "^2.0.1"
       }
+    },
+    "any-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+      "dev": true
     },
     "anymatch": {
       "version": "3.1.2",
@@ -10062,6 +15626,12 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -10072,6 +15642,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "auto-bind": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
       "dev": true
     },
     "await-to-js": {
@@ -10105,6 +15681,15 @@
         "slash": "^3.0.0"
       }
     },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
@@ -10130,6 +15715,12 @@
         "@types/babel__traverse": "^7.0.6"
       }
     },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "7.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+      "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==",
+      "dev": true
+    },
     "babel-preset-current-node-syntax": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
@@ -10150,6 +15741,41 @@
         "@babel/plugin-syntax-top-level-await": "^7.8.3"
       }
     },
+    "babel-preset-fbjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.4.0.tgz",
+      "integrity": "sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-proposal-class-properties": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+        "@babel/plugin-syntax-class-properties": "^7.0.0",
+        "@babel/plugin-syntax-flow": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-classes": "^7.0.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.0.0",
+        "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+        "@babel/plugin-transform-for-of": "^7.0.0",
+        "@babel/plugin-transform-function-name": "^7.0.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-member-expression-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+        "@babel/plugin-transform-object-super": "^7.0.0",
+        "@babel/plugin-transform-parameters": "^7.0.0",
+        "@babel/plugin-transform-property-literals": "^7.0.0",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-template-literals": "^7.0.0",
+        "babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
+      }
+    },
     "babel-preset-jest": {
       "version": "27.0.6",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.0.6.tgz",
@@ -10160,10 +15786,28 @@
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
     },
     "boolbase": {
       "version": "1.0.0",
@@ -10232,16 +15876,64 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "dev": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "dev": true
+        }
+      }
     },
     "call-bind": {
       "version": "1.0.2",
@@ -10273,6 +15965,24 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
     },
+    "camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dev": true,
+      "requires": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -10285,6 +15995,25 @@
       "integrity": "sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw==",
       "dev": true
     },
+    "capital-case": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -10295,10 +16024,62 @@
         "supports-color": "^7.1.0"
       }
     },
+    "change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dev": true,
+      "requires": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "change-case-all": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
+      "integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
+      "dev": true,
+      "requires": {
+        "change-case": "^4.1.2",
+        "is-lower-case": "^2.0.2",
+        "is-upper-case": "^2.0.2",
+        "lower-case": "^2.0.2",
+        "lower-case-first": "^2.0.2",
+        "sponge-case": "^1.0.1",
+        "swap-case": "^2.0.2",
+        "title-case": "^3.0.3",
+        "upper-case": "^2.0.2",
+        "upper-case-first": "^2.0.2"
+      }
+    },
     "char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
     "cheerio": {
@@ -10337,6 +16118,22 @@
         "domutils": "^2.7.0"
       }
     },
+    "chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
+    },
     "ci-info": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
@@ -10347,6 +16144,74 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "dev": true
     },
     "cliui": {
@@ -10360,10 +16225,25 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "collect-v8-coverage": {
@@ -10408,10 +16288,35 @@
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
       "dev": true
     },
+    "common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
     },
     "convert-source-map": {
       "version": "1.8.0",
@@ -10443,13 +16348,29 @@
         "parse-json": "^4.0.0"
       }
     },
+    "cosmiconfig-toml-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-toml-loader/-/cosmiconfig-toml-loader-1.0.0.tgz",
+      "integrity": "sha512-H/2gurFWVi7xXvCyvsWRLCMekl4tITJcX0QEsDMpzxtuxDyM59xLatYNg4s/k9AA/HdtCYfj2su8mgA0GSDLDA==",
+      "dev": true,
+      "requires": {
+        "@iarna/toml": "^2.2.5"
+      }
+    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -10515,6 +16436,24 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "dataloader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==",
+      "dev": true
+    },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
+    "debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true
+    },
     "debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -10524,16 +16463,37 @@
         "ms": "2.1.2"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
     "decimal.js": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
     "deep-is": {
@@ -10546,6 +16506,12 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
+    },
+    "defer-to-connect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true
     },
     "define-properties": {
@@ -10566,6 +16532,18 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
       "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
+      "dev": true
+    },
+    "dependency-graph": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "dev": true
     },
     "detect-newline": {
@@ -10657,15 +16635,54 @@
         "domhandler": "^4.2.0"
       }
     },
+    "dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
     "dotenv": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
     },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.3.792",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.792.tgz",
       "integrity": "sha512-RM2O2xrNarM7Cs+XF/OE2qX/aBROyOZqqgP+8FXMXSuWuUqCfUUzg7NytQrzZU3aSqk1Qq6zqnVkJsbfMkIatg==",
+      "dev": true
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
     "emittery": {
@@ -10679,6 +16696,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "enquirer": {
       "version": "2.3.6",
@@ -11047,6 +17073,18 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true
+    },
+    "eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "dev": true
+    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -11097,6 +17135,34 @@
           "dev": true
         }
       }
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        }
+      }
+    },
+    "extract-files": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
+      "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -11152,6 +17218,27 @@
         "bser": "2.1.1"
       }
     },
+    "fbjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.0.tgz",
+      "integrity": "sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "fbjs-css-vars": "^1.0.0",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+      "dev": true
+    },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -11159,6 +17246,23 @@
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
+      }
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
       }
     },
     "file-entry-cache": {
@@ -11337,6 +17441,36 @@
         }
       }
     },
+    "got": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
@@ -11349,6 +17483,139 @@
       "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
       "requires": {
         "iterall": "^1.2.2"
+      }
+    },
+    "graphql-config": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-4.0.1.tgz",
+      "integrity": "sha512-JdXxFzBwjujJMGLHUZom9SrmP/M4gF57iTDa3fJVm3Q85+Xw2kj9jZIygaaSLpDKhaPnMQZqfJ5Hmc6afKxS9w==",
+      "dev": true,
+      "requires": {
+        "@endemolshinegroup/cosmiconfig-typescript-loader": "3.0.2",
+        "@graphql-tools/graphql-file-loader": "^7.0.1",
+        "@graphql-tools/json-file-loader": "^7.0.1",
+        "@graphql-tools/load": "^7.1.0",
+        "@graphql-tools/merge": "^6.2.16",
+        "@graphql-tools/url-loader": "^7.0.3",
+        "@graphql-tools/utils": "^8.0.1",
+        "cosmiconfig": "7.0.0",
+        "cosmiconfig-toml-loader": "1.0.0",
+        "minimatch": "3.0.4",
+        "string-env-interpolation": "1.0.1"
+      },
+      "dependencies": {
+        "@endemolshinegroup/cosmiconfig-typescript-loader": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz",
+          "integrity": "sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==",
+          "dev": true,
+          "requires": {
+            "lodash.get": "^4",
+            "make-error": "^1",
+            "ts-node": "^9",
+            "tslib": "^2"
+          }
+        },
+        "@graphql-tools/merge": {
+          "version": "6.2.17",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-6.2.17.tgz",
+          "integrity": "sha512-G5YrOew39fZf16VIrc49q3c8dBqQDD0ax5LYPiNja00xsXDi0T9zsEWVt06ApjtSdSF6HDddlu5S12QjeN8Tow==",
+          "dev": true,
+          "requires": {
+            "@graphql-tools/schema": "^8.0.2",
+            "@graphql-tools/utils": "8.0.2",
+            "tslib": "~2.3.0"
+          }
+        },
+        "@graphql-tools/utils": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.0.2.tgz",
+          "integrity": "sha512-gzkavMOgbhnwkHJYg32Adv6f+LxjbQmmbdD5Hty0+CWxvaiuJq+nU6tzb/7VSU4cwhbNLx/lGu2jbCPEW1McZQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.3.0"
+          }
+        },
+        "cosmiconfig": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+          "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          }
+        },
+        "import-fresh": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        },
+        "ts-node": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+          "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+          "dev": true,
+          "requires": {
+            "arg": "^4.1.0",
+            "create-require": "^1.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "source-map-support": "^0.5.17",
+            "yn": "3.1.1"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "graphql-request": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.5.0.tgz",
+      "integrity": "sha512-Io89QpfU4rqiMbqM/KwMBzKaDLOppi8FU8sEccCE4JqCgz95W9Q8bvxQ4NfPALLSMvg9nafgg8AkYRmgKSlukA==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.6",
+        "extract-files": "^9.0.0",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "extract-files": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+          "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
+          "dev": true
+        }
       }
     },
     "graphql-tag": {
@@ -11366,6 +17633,13 @@
         }
       }
     },
+    "graphql-ws": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.5.0.tgz",
+      "integrity": "sha512-WQepPMGQQoqS2VsrI2I3RMLCVz3CW4/6ZqGV6ABDOwH4R62DzjxwMlwZbj6vhSI/7IM3/C911yITwgs77iO/hw==",
+      "dev": true,
+      "requires": {}
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -11378,6 +17652,23 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
         "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
       }
     },
     "has-bigints": {
@@ -11401,6 +17692,24 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
+    },
+    "header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dev": true,
+      "requires": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -11428,6 +17737,12 @@
         "domutils": "^2.5.2",
         "entities": "^2.0.0"
       }
+    },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "dev": true
     },
     "http-proxy-agent": {
       "version": "4.0.1",
@@ -11465,10 +17780,22 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "immutable": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+      "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks=",
       "dev": true
     },
     "import-fresh": {
@@ -11487,6 +17814,12 @@
         }
       }
     },
+    "import-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+      "dev": true
+    },
     "import-local": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
@@ -11503,6 +17836,12 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -11517,6 +17856,33 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      }
+    },
     "internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -11525,6 +17891,25 @@
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "dev": true,
+      "requires": {
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
       }
     },
     "is-arrayish": {
@@ -11536,6 +17921,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
       "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA=="
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
     },
     "is-boolean-object": {
       "version": "1.1.1",
@@ -11605,6 +17999,23 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-2.0.2.tgz",
+      "integrity": "sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
     "is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
@@ -11621,10 +18032,25 @@
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
       "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw=="
     },
+    "is-observable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "^1.1.0"
+      }
+    },
     "is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true
     },
     "is-regex": {
@@ -11634,6 +18060,15 @@
       "requires": {
         "call-bind": "^1.0.2",
         "has-symbols": "^1.0.2"
+      }
+    },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dev": true,
+      "requires": {
+        "is-unc-path": "^1.0.0"
       }
     },
     "is-stream": {
@@ -11661,11 +18096,66 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dev": true,
+      "requires": {
+        "unc-path-regex": "^0.1.2"
+      }
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
+    },
+    "is-upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-2.0.2.tgz",
+      "integrity": "sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "dev": true,
+      "requires": {}
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -12950,10 +19440,22 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -12961,11 +19463,30 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json-to-pretty-yaml": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz",
+      "integrity": "sha1-9M0L0KXo/h3yWq9boRiwmf2ZLVs=",
+      "dev": true,
+      "requires": {
+        "remedial": "^1.0.7",
+        "remove-trailing-spaces": "^1.0.6"
+      }
     },
     "json5": {
       "version": "2.2.0",
@@ -12976,11 +19497,82 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "dev": true,
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dev": true,
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dev": true,
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
+    },
+    "latest-version": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+      "dev": true,
+      "requires": {
+        "package-json": "^6.3.0"
+      }
     },
     "leven": {
       "version": "3.1.0",
@@ -12998,6 +19590,12 @@
         "type-check": "~0.3.2"
       }
     },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
     "linkify-it": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
@@ -13005,6 +19603,239 @@
       "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
+      }
+    },
+    "listr": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+      "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+      "dev": true,
+      "requires": {
+        "@samverschueren/stream-to-observable": "^0.3.0",
+        "is-observable": "^1.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.5.0",
+        "listr-verbose-renderer": "^0.5.0",
+        "p-map": "^2.0.0",
+        "rxjs": "^6.3.3"
+      },
+      "dependencies": {
+        "is-promise": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+          "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+      "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^2.3.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+      "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "cli-cursor": "^2.1.0",
+        "date-fns": "^1.27.2",
+        "figures": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "locate-path": {
@@ -13038,10 +19869,52 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+      "dev": true
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+      "dev": true
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+      "dev": true
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -13058,6 +19931,159 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.xorby/-/lodash.xorby-4.7.0.tgz",
       "integrity": "sha1-nBmm+fBjputT3QPBtocXmYAUY9c="
+    },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      }
+    },
+    "log-update": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "cli-cursor": "^2.0.0",
+        "wrap-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+          "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
+          }
+        }
+      }
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "lower-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-2.0.2.tgz",
+      "integrity": "sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -13089,6 +20115,12 @@
       "requires": {
         "tmpl": "1.0.x"
       }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
     },
     "markdown-it": {
       "version": "10.0.0",
@@ -13173,6 +20205,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
     "minimatch": {
@@ -13316,6 +20354,24 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dev": true,
+      "requires": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
@@ -13345,6 +20401,12 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "normalize-url": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "dev": true
+    },
     "npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -13363,10 +20425,28 @@
         "boolbase": "^1.0.0"
       }
     },
+    "nullthrows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "dev": true
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
     "nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-inspect": {
@@ -13453,6 +20533,12 @@
         "os-tmpdir": "^1.0.0"
       }
     },
+    "p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "dev": true
+    },
     "p-each-series": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
@@ -13477,11 +20563,47 @@
         "p-limit": "^2.2.0"
       }
     },
+    "p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
+    },
+    "package-json": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+      "dev": true,
+      "requires": {
+        "got": "^9.6.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.0.0",
+        "semver": "^6.2.0"
+      }
+    },
+    "param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dev": true,
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
     },
     "parent-module": {
       "version": "1.0.1",
@@ -13498,6 +20620,17 @@
           "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
           "dev": true
         }
+      }
+    },
+    "parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "dev": true,
+      "requires": {
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
       }
     },
     "parse-json": {
@@ -13541,6 +20674,42 @@
         "parse5": "^6.0.1"
       }
     },
+    "pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dev": true,
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -13562,6 +20731,21 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "dev": true,
+      "requires": {
+        "path-root-regex": "^0.1.0"
+      }
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true
     },
     "path-type": {
@@ -13604,6 +20788,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
     "prettier": {
@@ -13663,6 +20853,15 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
     "prompts": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.1.tgz",
@@ -13678,6 +20877,16 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -13700,6 +20909,26 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        }
+      }
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -13715,10 +20944,78 @@
         "mute-stream": "~0.0.4"
       }
     },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true
+    },
+    "registry-auth-token": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+      "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.2.8"
+      }
+    },
+    "registry-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.2.8"
+      }
+    },
+    "relay-runtime": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-11.0.2.tgz",
+      "integrity": "sha512-xxZkIRnL8kNE1cxmwDXX8P+wSeWLR+0ACFyAiAhvfWWAyjXb+bhjJ2FSsRGlNYfkqaTNEuDqpnodQV1/fF7Idw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "fbjs": "^3.0.0",
+        "invariant": "^2.2.4"
+      }
+    },
+    "remedial": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
+      "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==",
+      "dev": true
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "remove-trailing-spaces": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/remove-trailing-spaces/-/remove-trailing-spaces-1.0.8.tgz",
+      "integrity": "sha512-O3vsMYfWighyFbTd8hk8VaSj9UAGENxAtX+//ugIst2RMk5e03h6RoIS+0ylsFxY1gvmPuAY/PO4It+gPEeySA==",
+      "dev": true
+    },
+    "replaceall": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/replaceall/-/replaceall-0.1.6.tgz",
+      "integrity": "sha1-gdgax663LX9cSUKt8ml6MiBojY4=",
       "dev": true
     },
     "require-directory": {
@@ -13731,6 +21028,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "resolve": {
@@ -13757,6 +21060,25 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
     },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -13772,6 +21094,12 @@
         "glob": "^7.1.3"
       }
     },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -13779,6 +21107,15 @@
       "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -13801,10 +21138,47 @@
         "xmlchars": "^2.2.0"
       }
     },
+    "scuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/scuid/-/scuid-1.1.0.tgz",
+      "integrity": "sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==",
+      "dev": true
+    },
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
+    },
+    "sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
     },
     "sha.js": {
@@ -13847,6 +21221,12 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "signedsource": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz",
+      "integrity": "sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo=",
+      "dev": true
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -13870,6 +21250,24 @@
         "is-fullwidth-code-point": "^3.0.0"
       }
     },
+    "snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dev": true,
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -13882,6 +21280,23 @@
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "sponge-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
+      "integrity": "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
       }
     },
     "sprintf-js": {
@@ -13897,6 +21312,12 @@
       "requires": {
         "escape-string-regexp": "^2.0.0"
       }
+    },
+    "string-env-interpolation": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz",
+      "integrity": "sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==",
+      "dev": true
     },
     "string-length": {
       "version": "4.0.2",
@@ -13964,6 +21385,19 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "subscriptions-transport-ws": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.10.0.tgz",
+      "integrity": "sha512-k28LhLn3abJ1mowFW+LP4QGggE0e3hrk55zXbMHyAeZkCUYtC0owepiwqMD3zX8DglQVaxnhE760pESrNSEzpg==",
+      "dev": true,
+      "requires": {
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -13983,11 +21417,44 @@
         "supports-color": "^7.0.0"
       }
     },
+    "swap-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-2.0.2.tgz",
+      "integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "dev": true
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "sync-fetch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/sync-fetch/-/sync-fetch-0.3.0.tgz",
+      "integrity": "sha512-dJp4qg+x4JwSEW1HibAuMi0IIrBI3wuQr2GimmqB7OXR50wmwzfdusG+p39R9w3R6aFtZ2mzvxvWKQ3Bd/vx3g==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.7.0",
+        "node-fetch": "^2.6.1"
+      }
     },
     "table": {
       "version": "6.7.1",
@@ -14056,6 +21523,29 @@
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
     },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "title-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
+      "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
     "tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -14075,6 +21565,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
       "dev": true
     },
     "to-regex-range": {
@@ -14142,6 +21638,12 @@
           }
         }
       }
+    },
+    "ts-log": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.3.tgz",
+      "integrity": "sha512-XvB+OdKSJ708Dmf9ore4Uf/q62AYDTzFcAdxc8KNML1mmAWywRFVt/dn1KYJH8Agt5UJNujfM3znU5PxgAzA2w==",
+      "dev": true
     },
     "ts-node": {
       "version": "8.10.2",
@@ -14221,6 +21723,12 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA=="
     },
+    "ua-parser-js": {
+      "version": "0.7.28",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+      "dev": true
+    },
     "uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -14238,6 +21746,12 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "dev": true
+    },
     "underscore": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
@@ -14249,6 +21763,60 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "unixify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+      "integrity": "sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
+      }
+    },
+    "upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
     },
     "uri-js": {
       "version": "4.4.1",
@@ -14264,6 +21832,15 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
       "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
       "dev": true
+    },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^2.0.0"
+      }
     },
     "util.promisify": {
       "version": "1.1.1",
@@ -14307,6 +21884,18 @@
           "dev": true
         }
       }
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
+      "dev": true
+    },
+    "value-or-promise": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.10.tgz",
+      "integrity": "sha512-1OwTzvcfXkAfabk60UVr5NdjtjJ0Fg0T5+B1bhxtrOEwSH2fe8y4DnLgoksfCyd8yZCOQQHB0qLMQnwgCjbXLQ==",
+      "dev": true
     },
     "vsce": {
       "version": "1.96.1",
@@ -14570,6 +22159,12 @@
         "iconv-lite": "0.4.24"
       }
     },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
+    },
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -14607,6 +22202,12 @@
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
       }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
     },
     "word-wrap": {
       "version": "1.2.3",
@@ -14678,6 +22279,18 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true
+    },
+    "yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true
+    },
     "yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -14722,6 +22335,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     },
     "zen-observable": {
       "version": "0.8.15",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "publish-extension": "npm run _internal:prepare-extension && npx vsce publish -p $VS_MARKETPLACE_TOKEN --baseContentUrl https://raw.githubusercontent.com/apollographql/vscode-graphql && npm run _internal:cleanup-extension",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --ext .ts",
-    "test-unit": "jest"
+    "test-unit": "jest",
+    "codegen": "graphql-codegen"
   },
   "engines": {
     "vscode": "^1.30.0"
@@ -60,6 +61,8 @@
     "vscode-uri": "1.0.6"
   },
   "devDependencies": {
+    "@graphql-codegen/cli": "^2.2.0",
+    "@graphql-codegen/typescript-operations": "^2.1.3",
     "@types/cosmiconfig": "5.0.3",
     "@types/glob": "7.1.1",
     "@types/jest": "^26.0.24",

--- a/src/language-server/engine/index.ts
+++ b/src/language-server/engine/index.ts
@@ -1,7 +1,7 @@
 import { GraphQLDataSource } from "./GraphQLDataSource";
 import { DefaultEngineConfig } from "../config";
 import { SCHEMA_TAGS_AND_FIELD_STATS } from "./operations/schemaTagsAndFieldStats";
-import { SchemaTagsAndFieldStats } from "../graphqlTypes";
+import { SchemaTagsAndFieldStatsQuery } from "../graphqlTypes";
 
 export interface ClientIdentity {
   name?: string;
@@ -53,7 +53,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
   }
 
   async loadSchemaTagsAndFieldStats(serviceID: string) {
-    const { data, errors } = await this.execute<SchemaTagsAndFieldStats>({
+    const { data, errors } = await this.execute<SchemaTagsAndFieldStatsQuery>({
       query: SCHEMA_TAGS_AND_FIELD_STATS,
       variables: {
         id: serviceID,
@@ -87,7 +87,10 @@ export class ApolloEngineClient extends GraphQLDataSource {
         fieldStats.get(parentType) ||
         fieldStats.set(parentType, new Map()).get(parentType)!;
 
-      fieldsMap.set(fieldName, fieldStat.metrics.fieldHistogram.durationMs);
+      fieldsMap.set(
+        fieldName,
+        fieldStat.metrics.fieldHistogram.durationMs ?? null
+      );
     });
 
     return { schemaTags, fieldStats };

--- a/src/language-server/engine/index.ts
+++ b/src/language-server/engine/index.ts
@@ -87,10 +87,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
         fieldStats.get(parentType) ||
         fieldStats.set(parentType, new Map()).get(parentType)!;
 
-      fieldsMap.set(
-        fieldName,
-        fieldStat.metrics.fieldHistogram.durationMs ?? null
-      );
+      fieldsMap.set(fieldName, fieldStat.metrics.fieldHistogram.durationMs);
     });
 
     return { schemaTags, fieldStats };

--- a/src/language-server/graphqlTypes.ts
+++ b/src/language-server/graphqlTypes.ts
@@ -2183,6 +2183,8 @@ export type ServiceStatsWindow = {
   errorStats: Array<ServiceErrorStatsRecord>;
   fieldLatencies: Array<ServiceFieldLatenciesRecord>;
   fieldStats: Array<ServiceFieldStatsRecord>;
+  fieldUsage: Array<ServiceFieldUsageRecord>;
+  operationCheckStats: Array<ServiceOperationCheckStatsRecord>;
   queryStats: Array<ServiceQueryStatsRecord>;
   /** From field rounded down to the nearest resolution. */
   roundedDownFrom: Scalars['Timestamp'];
@@ -2222,6 +2224,22 @@ export type ServiceStatsWindowFieldStatsArgs = {
   filter?: Maybe<ServiceFieldStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<Array<ServiceFieldStatsOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given service. */
+export type ServiceStatsWindowFieldUsageArgs = {
+  filter?: Maybe<ServiceFieldUsageFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<ServiceFieldUsageOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given service. */
+export type ServiceStatsWindowOperationCheckStatsArgs = {
+  filter?: Maybe<ServiceOperationCheckStatsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<ServiceOperationCheckStatsOrderBySpec>>;
 };
 
 
@@ -2615,6 +2633,172 @@ export type ServiceFieldStatsMetrics = {
   errorsCount: Scalars['Long'];
   fieldHistogram: DurationHistogram;
   requestCount: Scalars['Long'];
+};
+
+/** Filter for data in ServiceFieldUsage. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type ServiceFieldUsageFilter = {
+  and?: Maybe<Array<ServiceFieldUsageFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
+  field?: Maybe<Scalars['String']>;
+  in?: Maybe<ServiceFieldUsageFilterIn>;
+  not?: Maybe<ServiceFieldUsageFilter>;
+  or?: Maybe<Array<ServiceFieldUsageFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in ServiceFieldUsage. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type ServiceFieldUsageFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type ServiceFieldUsageOrderBySpec = {
+  column: ServiceFieldUsageColumn;
+  direction: Ordering;
+};
+
+/** Columns of ServiceFieldUsage. */
+export enum ServiceFieldUsageColumn {
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  ExecutionCount = 'EXECUTION_COUNT',
+  Field = 'FIELD',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  ReferencingOperationCount = 'REFERENCING_OPERATION_COUNT',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  Timestamp = 'TIMESTAMP'
+}
+
+export type ServiceFieldUsageRecord = {
+  __typename?: 'ServiceFieldUsageRecord';
+  /** Dimensions of ServiceFieldUsage that can be grouped by. */
+  groupBy: ServiceFieldUsageDimensions;
+  /** Metrics of ServiceFieldUsage that can be aggregated over. */
+  metrics: ServiceFieldUsageMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type ServiceFieldUsageDimensions = {
+  __typename?: 'ServiceFieldUsageDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  field?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+};
+
+export type ServiceFieldUsageMetrics = {
+  __typename?: 'ServiceFieldUsageMetrics';
+  executionCount: Scalars['Long'];
+  referencingOperationCount: Scalars['Long'];
+};
+
+/** Filter for data in ServiceOperationCheckStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type ServiceOperationCheckStatsFilter = {
+  and?: Maybe<Array<ServiceOperationCheckStatsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  in?: Maybe<ServiceOperationCheckStatsFilterIn>;
+  not?: Maybe<ServiceOperationCheckStatsFilter>;
+  or?: Maybe<Array<ServiceOperationCheckStatsFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in ServiceOperationCheckStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type ServiceOperationCheckStatsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type ServiceOperationCheckStatsOrderBySpec = {
+  column: ServiceOperationCheckStatsColumn;
+  direction: Ordering;
+};
+
+/** Columns of ServiceOperationCheckStats. */
+export enum ServiceOperationCheckStatsColumn {
+  CachedRequestsCount = 'CACHED_REQUESTS_COUNT',
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  QueryId = 'QUERY_ID',
+  SchemaTag = 'SCHEMA_TAG',
+  Timestamp = 'TIMESTAMP',
+  UncachedRequestsCount = 'UNCACHED_REQUESTS_COUNT'
+}
+
+export type ServiceOperationCheckStatsRecord = {
+  __typename?: 'ServiceOperationCheckStatsRecord';
+  /** Dimensions of ServiceOperationCheckStats that can be grouped by. */
+  groupBy: ServiceOperationCheckStatsDimensions;
+  /** Metrics of ServiceOperationCheckStats that can be aggregated over. */
+  metrics: ServiceOperationCheckStatsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type ServiceOperationCheckStatsDimensions = {
+  __typename?: 'ServiceOperationCheckStatsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  schemaTag?: Maybe<Scalars['String']>;
+};
+
+export type ServiceOperationCheckStatsMetrics = {
+  __typename?: 'ServiceOperationCheckStatsMetrics';
+  cachedRequestsCount: Scalars['Long'];
+  uncachedRequestsCount: Scalars['Long'];
 };
 
 /** Filter for data in ServiceQueryStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
@@ -3349,6 +3533,8 @@ export type AccountStatsWindow = {
   errorStats: Array<AccountErrorStatsRecord>;
   fieldLatencies: Array<AccountFieldLatenciesRecord>;
   fieldStats: Array<AccountFieldStatsRecord>;
+  fieldUsage: Array<AccountFieldUsageRecord>;
+  operationCheckStats: Array<AccountOperationCheckStatsRecord>;
   queryStats: Array<AccountQueryStatsRecord>;
   /** From field rounded down to the nearest resolution. */
   roundedDownFrom: Scalars['Timestamp'];
@@ -3388,6 +3574,22 @@ export type AccountStatsWindowFieldStatsArgs = {
   filter?: Maybe<AccountFieldStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<Array<AccountFieldStatsOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given account. */
+export type AccountStatsWindowFieldUsageArgs = {
+  filter?: Maybe<AccountFieldUsageFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<AccountFieldUsageOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given account. */
+export type AccountStatsWindowOperationCheckStatsArgs = {
+  filter?: Maybe<AccountOperationCheckStatsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<AccountOperationCheckStatsOrderBySpec>>;
 };
 
 
@@ -3776,6 +3978,184 @@ export type AccountFieldStatsMetrics = {
   errorsCount: Scalars['Long'];
   fieldHistogram: DurationHistogram;
   requestCount: Scalars['Long'];
+};
+
+/** Filter for data in AccountFieldUsage. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type AccountFieldUsageFilter = {
+  and?: Maybe<Array<AccountFieldUsageFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
+  field?: Maybe<Scalars['String']>;
+  in?: Maybe<AccountFieldUsageFilterIn>;
+  not?: Maybe<AccountFieldUsageFilter>;
+  or?: Maybe<Array<AccountFieldUsageFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in AccountFieldUsage. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type AccountFieldUsageFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+};
+
+export type AccountFieldUsageOrderBySpec = {
+  column: AccountFieldUsageColumn;
+  direction: Ordering;
+};
+
+/** Columns of AccountFieldUsage. */
+export enum AccountFieldUsageColumn {
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  ExecutionCount = 'EXECUTION_COUNT',
+  Field = 'FIELD',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  ReferencingOperationCount = 'REFERENCING_OPERATION_COUNT',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  Timestamp = 'TIMESTAMP'
+}
+
+export type AccountFieldUsageRecord = {
+  __typename?: 'AccountFieldUsageRecord';
+  /** Dimensions of AccountFieldUsage that can be grouped by. */
+  groupBy: AccountFieldUsageDimensions;
+  /** Metrics of AccountFieldUsage that can be aggregated over. */
+  metrics: AccountFieldUsageMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type AccountFieldUsageDimensions = {
+  __typename?: 'AccountFieldUsageDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  field?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+export type AccountFieldUsageMetrics = {
+  __typename?: 'AccountFieldUsageMetrics';
+  executionCount: Scalars['Long'];
+  referencingOperationCount: Scalars['Long'];
+};
+
+/** Filter for data in AccountOperationCheckStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type AccountOperationCheckStatsFilter = {
+  and?: Maybe<Array<AccountOperationCheckStatsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  in?: Maybe<AccountOperationCheckStatsFilterIn>;
+  not?: Maybe<AccountOperationCheckStatsFilter>;
+  or?: Maybe<Array<AccountOperationCheckStatsFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in AccountOperationCheckStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type AccountOperationCheckStatsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+};
+
+export type AccountOperationCheckStatsOrderBySpec = {
+  column: AccountOperationCheckStatsColumn;
+  direction: Ordering;
+};
+
+/** Columns of AccountOperationCheckStats. */
+export enum AccountOperationCheckStatsColumn {
+  CachedRequestsCount = 'CACHED_REQUESTS_COUNT',
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  QueryId = 'QUERY_ID',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  Timestamp = 'TIMESTAMP',
+  UncachedRequestsCount = 'UNCACHED_REQUESTS_COUNT'
+}
+
+export type AccountOperationCheckStatsRecord = {
+  __typename?: 'AccountOperationCheckStatsRecord';
+  /** Dimensions of AccountOperationCheckStats that can be grouped by. */
+  groupBy: AccountOperationCheckStatsDimensions;
+  /** Metrics of AccountOperationCheckStats that can be aggregated over. */
+  metrics: AccountOperationCheckStatsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type AccountOperationCheckStatsDimensions = {
+  __typename?: 'AccountOperationCheckStatsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+export type AccountOperationCheckStatsMetrics = {
+  __typename?: 'AccountOperationCheckStatsMetrics';
+  cachedRequestsCount: Scalars['Long'];
+  uncachedRequestsCount: Scalars['Long'];
 };
 
 /** Filter for data in AccountQueryStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
@@ -4200,6 +4580,8 @@ export type StatsWindow = {
   errorStats: Array<ErrorStatsRecord>;
   fieldLatencies: Array<FieldLatenciesRecord>;
   fieldStats: Array<FieldStatsRecord>;
+  fieldUsage: Array<FieldUsageRecord>;
+  operationCheckStats: Array<OperationCheckStatsRecord>;
   queryStats: Array<QueryStatsRecord>;
   /** From field rounded down to the nearest resolution. */
   roundedDownFrom: Scalars['Timestamp'];
@@ -4239,6 +4621,22 @@ export type StatsWindowFieldStatsArgs = {
   filter?: Maybe<FieldStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<Array<FieldStatsOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity. */
+export type StatsWindowFieldUsageArgs = {
+  filter?: Maybe<FieldUsageFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<FieldUsageOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity. */
+export type StatsWindowOperationCheckStatsArgs = {
+  filter?: Maybe<OperationCheckStatsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<OperationCheckStatsOrderBySpec>>;
 };
 
 
@@ -4639,6 +5037,184 @@ export type FieldStatsMetrics = {
   errorsCount: Scalars['Long'];
   fieldHistogram: DurationHistogram;
   requestCount: Scalars['Long'];
+};
+
+/** Filter for data in FieldUsage. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type FieldUsageFilter = {
+  and?: Maybe<Array<FieldUsageFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
+  field?: Maybe<Scalars['String']>;
+  in?: Maybe<FieldUsageFilterIn>;
+  not?: Maybe<FieldUsageFilter>;
+  or?: Maybe<Array<FieldUsageFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in FieldUsage. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type FieldUsageFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+};
+
+export type FieldUsageOrderBySpec = {
+  column: FieldUsageColumn;
+  direction: Ordering;
+};
+
+/** Columns of FieldUsage. */
+export enum FieldUsageColumn {
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  ExecutionCount = 'EXECUTION_COUNT',
+  Field = 'FIELD',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  ReferencingOperationCount = 'REFERENCING_OPERATION_COUNT',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  Timestamp = 'TIMESTAMP'
+}
+
+export type FieldUsageRecord = {
+  __typename?: 'FieldUsageRecord';
+  /** Dimensions of FieldUsage that can be grouped by. */
+  groupBy: FieldUsageDimensions;
+  /** Metrics of FieldUsage that can be aggregated over. */
+  metrics: FieldUsageMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type FieldUsageDimensions = {
+  __typename?: 'FieldUsageDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  field?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+export type FieldUsageMetrics = {
+  __typename?: 'FieldUsageMetrics';
+  executionCount: Scalars['Long'];
+  referencingOperationCount: Scalars['Long'];
+};
+
+/** Filter for data in OperationCheckStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type OperationCheckStatsFilter = {
+  and?: Maybe<Array<OperationCheckStatsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  in?: Maybe<OperationCheckStatsFilterIn>;
+  not?: Maybe<OperationCheckStatsFilter>;
+  or?: Maybe<Array<OperationCheckStatsFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in OperationCheckStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type OperationCheckStatsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+};
+
+export type OperationCheckStatsOrderBySpec = {
+  column: OperationCheckStatsColumn;
+  direction: Ordering;
+};
+
+/** Columns of OperationCheckStats. */
+export enum OperationCheckStatsColumn {
+  CachedRequestsCount = 'CACHED_REQUESTS_COUNT',
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  QueryId = 'QUERY_ID',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  Timestamp = 'TIMESTAMP',
+  UncachedRequestsCount = 'UNCACHED_REQUESTS_COUNT'
+}
+
+export type OperationCheckStatsRecord = {
+  __typename?: 'OperationCheckStatsRecord';
+  /** Dimensions of OperationCheckStats that can be grouped by. */
+  groupBy: OperationCheckStatsDimensions;
+  /** Metrics of OperationCheckStats that can be aggregated over. */
+  metrics: OperationCheckStatsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type OperationCheckStatsDimensions = {
+  __typename?: 'OperationCheckStatsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+export type OperationCheckStatsMetrics = {
+  __typename?: 'OperationCheckStatsMetrics';
+  cachedRequestsCount: Scalars['Long'];
+  uncachedRequestsCount: Scalars['Long'];
 };
 
 /** Filter for data in QueryStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */

--- a/src/language-server/graphqlTypes.ts
+++ b/src/language-server/graphqlTypes.ts
@@ -1,1036 +1,6940 @@
-/* tslint:disable */
-/* eslint-disable */
-// @generated
-// This file was automatically generated and should not be edited.
+export type Maybe<T> = T | null;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  /** ISO 8601, extended format with nanoseconds, Zulu (or '[+-]seconds' for times relative to now) */
+  Timestamp: any;
+  /** Long type */
+  Long: any;
+  GraphQLDocument: any;
+  /** Arbitrary JSON object */
+  Object: any;
+  /** A blob (base64'ed in JSON & GraphQL) */
+  Blob: any;
+  StringOrInt: any;
+  /** Always null */
+  Void: any;
+  /** A lowercase hexadecimal SHA-256 */
+  SHA256: any;
+};
 
-// ====================================================
-// GraphQL query operation: SchemaTagsAndFieldStats
-// ====================================================
-
-export interface SchemaTagsAndFieldStats_service_schemaTags {
-  __typename: "SchemaTag";
-  tag: string;
-}
-
-export interface SchemaTagsAndFieldStats_service_stats_fieldStats_groupBy {
-  __typename: "ServiceFieldStatsDimensions";
-  field: string | null;
-}
-
-export interface SchemaTagsAndFieldStats_service_stats_fieldStats_metrics_fieldHistogram {
-  __typename: "DurationHistogram";
-  durationMs: number | null;
-}
-
-export interface SchemaTagsAndFieldStats_service_stats_fieldStats_metrics {
-  __typename: "ServiceFieldStatsMetrics";
-  fieldHistogram: SchemaTagsAndFieldStats_service_stats_fieldStats_metrics_fieldHistogram;
-}
-
-export interface SchemaTagsAndFieldStats_service_stats_fieldStats {
-  __typename: "ServiceFieldStatsRecord";
+export type Query = {
+  __typename?: 'Query';
+  _odysseyFakeField?: Maybe<Scalars['Boolean']>;
+  /** Account by ID */
+  account?: Maybe<Account>;
+  /** Whether an account ID is available for mutation{newAccount(id:)} */
+  accountIDAvailable: Scalars['Boolean'];
+  /** All accounts */
+  allAccounts?: Maybe<Array<Account>>;
+  /** All available plans */
+  allPlans: Array<BillingPlan>;
+  /** All services */
+  allServices?: Maybe<Array<Service>>;
+  /** All timezones with their offsets from UTC */
+  allTimezoneOffsets: Array<TimezoneOffset>;
+  /** All users */
+  allUsers?: Maybe<Array<User>>;
+  /** If this is true, the user is an Apollo administrator who can ignore restrictions based purely on billing plan. */
+  canBypassPlanRestrictions: Scalars['Boolean'];
+  diffSchemas: Array<Change>;
+  /** Get the unsubscribe settings for a given email. */
+  emailPreferences?: Maybe<EmailPreferences>;
+  experimentalFeatures: GlobalExperimentalFeatures;
+  frontendUrlRoot: Scalars['String'];
+  internalActiveCronJobs: Array<CronJob>;
+  internalAdminUsers?: Maybe<Array<InternalAdminUser>>;
+  internalUnresolvedCronExecutionFailures: Array<CronExecution>;
+  /** Current identity, null if not authenticated */
+  me?: Maybe<Identity>;
+  /** Look up a plan by ID */
+  plan?: Maybe<BillingPlan>;
+  /** Service by ID */
+  service?: Maybe<Service>;
+  /** Query statistics across all services. For admins only; normal users must go through AccountsStatsWindow or ServiceStatsWindow. */
+  stats: StatsWindow;
+  /** Get the studio settings for the current user */
+  studioSettings?: Maybe<UserSettings>;
+  /** The plan started by AccountMutation.startTeamSubscription */
+  teamPlan: BillingPlan;
+  /** The plan started by AccountMutation.startTrial */
+  trialPlan: BillingPlan;
+  /** User by ID */
+  user?: Maybe<User>;
   /**
-   * Dimensions of ServiceFieldStats that can be grouped by.
+   * Access a variant by reference of the form `graphID@variantName`, or `graphID` for the default `current` variant.
+   * Returns null when the graph or variant do not exist, or when the graph cannot be accessed.
+   * Note that we can return more types implementing Error in the future.
    */
-  groupBy: SchemaTagsAndFieldStats_service_stats_fieldStats_groupBy;
+  variant?: Maybe<GraphVariantLookup>;
+};
+
+
+export type QueryAccountArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type QueryAccountIdAvailableArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type QueryAllAccountsArgs = {
+  search?: Maybe<Scalars['String']>;
+  tier?: Maybe<BillingPlanTier>;
+};
+
+
+export type QueryAllServicesArgs = {
+  search?: Maybe<Scalars['String']>;
+};
+
+
+export type QueryAllUsersArgs = {
+  search?: Maybe<Scalars['String']>;
+};
+
+
+export type QueryDiffSchemasArgs = {
+  baseSchema: Scalars['String'];
+  nextSchema: Scalars['String'];
+};
+
+
+export type QueryEmailPreferencesArgs = {
+  email: Scalars['String'];
+  token: Scalars['String'];
+};
+
+
+export type QueryPlanArgs = {
+  id?: Maybe<Scalars['ID']>;
+};
+
+
+export type QueryServiceArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type QueryStatsArgs = {
+  from: Scalars['Timestamp'];
+  resolution?: Maybe<Resolution>;
+  to?: Maybe<Scalars['Timestamp']>;
+};
+
+
+export type QueryTeamPlanArgs = {
+  billingPeriod: BillingPeriod;
+};
+
+
+export type QueryUserArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type QueryVariantArgs = {
+  ref: Scalars['ID'];
+};
+
+export type Account = {
+  __typename?: 'Account';
+  auditLogExports?: Maybe<Array<AuditLogExport>>;
+  /** These are the roles that the account is able to use */
+  availableRoles: Array<UserPermission>;
   /**
-   * Metrics of ServiceFieldStats that can be aggregated over.
+   * Get an URL to which an avatar image can be uploaded. Client uploads by sending a PUT request
+   * with the image data to MediaUploadInfo.url. Client SHOULD set the "Content-Type" header to the
+   * browser-inferred MIME type, and SHOULD set the "x-apollo-content-filename" header to the
+   * filename, if such information is available. Client MUST set the "x-apollo-csrf-token" header to
+   * MediaUploadInfo.csrfToken.
    */
-  metrics: SchemaTagsAndFieldStats_service_stats_fieldStats_metrics;
+  avatarUpload?: Maybe<AvatarUploadResult>;
+  /**
+   * Get an image URL for the account's avatar. Note that CORS is not enabled for these URLs. The size
+   * argument is used for bandwidth reduction, and should be the size of the image as displayed in the
+   * application. Apollo's media server will downscale larger images to at least the requested size,
+   * but this will not happen for third-party media servers.
+   */
+  avatarUrl?: Maybe<Scalars['String']>;
+  billingInfo?: Maybe<BillingInfo>;
+  companyUrl?: Maybe<Scalars['String']>;
+  currentBillingMonth?: Maybe<BillingMonth>;
+  currentPlan: BillingPlan;
+  currentSubscription?: Maybe<BillingSubscription>;
+  experimentalFeatures: AccountExperimentalFeatures;
+  expiredTrialSubscription?: Maybe<BillingSubscription>;
+  graphIDAvailable: Scalars['Boolean'];
+  hasBeenOnTrial: Scalars['Boolean'];
+  id: Scalars['ID'];
+  /**
+   * Internal immutable identifier for the account. Only visible to Apollo admins (because it really
+   * shouldn't be used in normal client apps).
+   */
+  internalID: Scalars['ID'];
+  invitations?: Maybe<Array<AccountInvitation>>;
+  invoices?: Maybe<Array<Invoice>>;
+  isOnExpiredTrial: Scalars['Boolean'];
+  isOnTrial: Scalars['Boolean'];
+  memberships?: Maybe<Array<AccountMembership>>;
+  name: Scalars['String'];
+  provisionedAt?: Maybe<Scalars['Timestamp']>;
+  recurlyEmail?: Maybe<Scalars['String']>;
+  requests?: Maybe<Scalars['Long']>;
+  requestsInCurrentBillingPeriod?: Maybe<Scalars['Long']>;
+  roles?: Maybe<AccountRoles>;
+  /** How many seats would be included in your next bill, as best estimated today */
+  seatCountForNextBill?: Maybe<Scalars['Int']>;
+  seats?: Maybe<Seats>;
+  secondaryIDs: Array<Scalars['ID']>;
+  services: Array<Service>;
+  /**
+   * If non-null, this organization tracks its members through an upstream, eg PingOne;
+   * invitations are not possible on SSO-synchronized account.
+   */
+  sso?: Maybe<OrganizationSso>;
+  state?: Maybe<AccountState>;
+  /** A list of reusable invitations for the organization. */
+  staticInvitations?: Maybe<Array<OrganizationInviteLink>>;
+  /** @deprecated use Account.statsWindow instead */
+  stats: AccountStatsWindow;
+  statsWindow?: Maybe<AccountStatsWindow>;
+  subscriptions?: Maybe<Array<BillingSubscription>>;
+  /** Gets a ticket for this org, by id */
+  ticket?: Maybe<ZendeskTicket>;
+  /** List of Zendesk tickets submitted for this org */
+  tickets?: Maybe<Array<ZendeskTicket>>;
+};
+
+
+export type AccountAvatarUrlArgs = {
+  size?: Scalars['Int'];
+};
+
+
+export type AccountGraphIdAvailableArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type AccountInvitationsArgs = {
+  includeAccepted?: Scalars['Boolean'];
+};
+
+
+export type AccountRequestsArgs = {
+  from: Scalars['Timestamp'];
+  to: Scalars['Timestamp'];
+};
+
+
+export type AccountServicesArgs = {
+  includeDeleted?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type AccountStatsArgs = {
+  from: Scalars['Timestamp'];
+  resolution?: Maybe<Resolution>;
+  to?: Maybe<Scalars['Timestamp']>;
+};
+
+
+export type AccountStatsWindowArgs = {
+  from: Scalars['Timestamp'];
+  resolution?: Maybe<Resolution>;
+  to?: Maybe<Scalars['Timestamp']>;
+};
+
+
+export type AccountTicketArgs = {
+  id: Scalars['ID'];
+};
+
+export type AuditLogExport = {
+  __typename?: 'AuditLogExport';
+  actors?: Maybe<Array<Identity>>;
+  bigqueryTriggeredAt?: Maybe<Scalars['Timestamp']>;
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  createdAt: Scalars['Timestamp'];
+  exportedFiles?: Maybe<Array<Scalars['String']>>;
+  from: Scalars['Timestamp'];
+  graphs?: Maybe<Array<Service>>;
+  id: Scalars['ID'];
+  requester?: Maybe<User>;
+  status: AuditStatus;
+  to: Scalars['Timestamp'];
+};
+
+export type Identity = {
+  asActor: Actor;
+  id: Scalars['ID'];
+  name: Scalars['String'];
+};
+
+export type Actor = {
+  __typename?: 'Actor';
+  actorId: Scalars['ID'];
+  type: ActorType;
+};
+
+export enum ActorType {
+  AnonymousUser = 'ANONYMOUS_USER',
+  Backfill = 'BACKFILL',
+  Cron = 'CRON',
+  Graph = 'GRAPH',
+  InternalIdentity = 'INTERNAL_IDENTITY',
+  Synchronization = 'SYNCHRONIZATION',
+  User = 'USER'
 }
 
-export interface SchemaTagsAndFieldStats_service_stats {
-  __typename: "ServiceStatsWindow";
-  fieldStats: SchemaTagsAndFieldStats_service_stats_fieldStats[];
-}
-
-export interface SchemaTagsAndFieldStats_service {
-  __typename: "Service";
+export type Service = Identity & {
+  __typename?: 'Service';
+  account?: Maybe<Account>;
+  accountId?: Maybe<Scalars['ID']>;
+  apiKeys?: Maybe<Array<GraphApiKey>>;
+  asActor: Actor;
+  /**
+   * Get an URL to which an avatar image can be uploaded. Client uploads by sending a PUT request
+   * with the image data to MediaUploadInfo.url. Client SHOULD set the "Content-Type" header to the
+   * browser-inferred MIME type, and SHOULD set the "x-apollo-content-filename" header to the
+   * filename, if such information is available. Client MUST set the "x-apollo-csrf-token" header to
+   * MediaUploadInfo.csrfToken.
+   */
+  avatarUpload?: Maybe<AvatarUploadResult>;
+  /**
+   * Get an image URL for the service's avatar. Note that CORS is not enabled for these URLs. The size
+   * argument is used for bandwidth reduction, and should be the size of the image as displayed in the
+   * application. Apollo's media server will downscale larger images to at least the requested size,
+   * but this will not happen for third-party media servers.
+   */
+  avatarUrl?: Maybe<Scalars['String']>;
+  /** Get available notification endpoints */
+  channels?: Maybe<Array<Channel>>;
+  /** Get check configuration for this graph. */
+  checkConfiguration?: Maybe<CheckConfiguration>;
+  /**
+   * List of options available for filtering checks for this graph by author.
+   * If a filter is passed, constrains results to match the filter.
+   */
+  checksAuthorOptions: Array<Scalars['String']>;
+  /**
+   * List of options available for filtering checks for this graph by branch.
+   * If a filter is passed, constrains results to match the filter.
+   */
+  checksBranchOptions: Array<Scalars['String']>;
+  /**
+   * List of options available for filtering checks for this graph by subgraph name.
+   * If a filter is passed, constrains results to match the filter.
+   */
+  checksSubgraphOptions: Array<Scalars['String']>;
+  /** Get a check workflow for this graph by its ID */
+  checkWorkflow?: Maybe<CheckWorkflow>;
+  /** Get check workflows for this graph ordered by creation time, most recent first. */
+  checkWorkflows: Array<CheckWorkflow>;
+  /** Given a graphCompositionID, return the results of composition. This can represent either a validation or a publish. */
+  compositionResultById?: Maybe<CompositionResult>;
+  createdAt: Scalars['Timestamp'];
+  createdBy?: Maybe<Identity>;
+  datadogMetricsConfig?: Maybe<DatadogMetricsConfig>;
+  deletedAt?: Maybe<Scalars['Timestamp']>;
+  description?: Maybe<Scalars['String']>;
+  devGraphOwner?: Maybe<User>;
+  firstReportedAt?: Maybe<Scalars['Timestamp']>;
+  /**
+   * When this is true, this graph will be hidden from non-admin members of the org who haven't been explicitly assigned a
+   * role on this graph.
+   */
+  hiddenFromUninvitedNonAdminAccountMembers: Scalars['Boolean'];
+  id: Scalars['ID'];
+  /**
+   * List of implementing services that comprise a graph. A non-federated graph should have a single implementing service.
+   * Set includeDeleted to see deleted implementing services.
+   */
+  implementingServices?: Maybe<GraphImplementors>;
+  lastReportedAt?: Maybe<Scalars['Timestamp']>;
+  /** Current identity, null if not authenticated. */
+  me?: Maybe<Identity>;
+  /**
+   * This returns the composition result that was most recently published to the graph.
+   * Only identities that canQuerySchemas and canQueryImplementingServices have access
+   * to this field
+   */
+  mostRecentCompositionPublish?: Maybe<CompositionPublishResult>;
+  myRole?: Maybe<UserPermission>;
+  /** @deprecated Use Service.title */
+  name: Scalars['String'];
+  operation?: Maybe<Operation>;
+  /** Gets the operations and their approved changes for this graph, checkID, and operationID. */
+  operationsAcceptedChanges: Array<OperationAcceptedChange>;
+  /** Get an operations check result for a specific check ID */
+  operationsCheck?: Maybe<OperationsCheckResult>;
+  /** Get query triggers for a given variant. If variant is null all the triggers for this service will be gotten. */
+  queryTriggers?: Maybe<Array<QueryTrigger>>;
+  readme?: Maybe<Readme>;
+  /**
+   * Whether registry subscriptions (with any options) are enabled. If variant is not passed, returns true if configuration is present for any variant
+   * @deprecated This field will be removed
+   */
+  registrySubscriptionsEnabled: Scalars['Boolean'];
+  reportingEnabled: Scalars['Boolean'];
+  /** The list of members that can access this graph, accounting for graph role overrides */
+  roleOverrides?: Maybe<Array<RoleOverride>>;
+  /** Which permissions the current user has for interacting with this service */
+  roles?: Maybe<ServiceRoles>;
+  scheduledSummaries: Array<ScheduledSummary>;
+  /** Get a schema by hash OR current tag */
+  schema?: Maybe<Schema>;
+  /** Get the schema tag */
+  schemaTag?: Maybe<SchemaTag>;
+  schemaTagById?: Maybe<SchemaTag>;
   /**
    * Get schema tags, with optional filtering to a set of tags. Always sorted by creation
    * date in reverse chronological order.
    */
-  schemaTags: SchemaTagsAndFieldStats_service_schemaTags[] | null;
-  stats: SchemaTagsAndFieldStats_service_stats;
+  schemaTags?: Maybe<Array<SchemaTag>>;
+  /** @deprecated use Service.statsWindow instead */
+  stats: ServiceStatsWindow;
+  statsWindow?: Maybe<ServiceStatsWindow>;
+  /** Generate a test schema publish notification body */
+  testSchemaPublishBody: Scalars['String'];
+  title: Scalars['String'];
+  trace?: Maybe<Trace>;
+  traceStorageEnabled: Scalars['Boolean'];
+  /** A particular variant (sometimes called "tag") of the graph, often representing a live traffic environment (such as "prod"). Each variant can represent a specific URL or destination to query at, analytics, and its own schema history. */
+  variant?: Maybe<GraphVariant>;
+  /** The list of variants that exist for this graph */
+  variants: Array<GraphVariant>;
+};
+
+
+export type ServiceAvatarUrlArgs = {
+  size?: Scalars['Int'];
+};
+
+
+export type ServiceChannelsArgs = {
+  channelIds?: Maybe<Array<Scalars['ID']>>;
+};
+
+
+export type ServiceChecksAuthorOptionsArgs = {
+  filter?: Maybe<CheckFilterInput>;
+};
+
+
+export type ServiceChecksBranchOptionsArgs = {
+  filter?: Maybe<CheckFilterInput>;
+};
+
+
+export type ServiceChecksSubgraphOptionsArgs = {
+  filter?: Maybe<CheckFilterInput>;
+};
+
+
+export type ServiceCheckWorkflowArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type ServiceCheckWorkflowsArgs = {
+  filter?: Maybe<CheckFilterInput>;
+  limit?: Scalars['Int'];
+};
+
+
+export type ServiceCompositionResultByIdArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type ServiceImplementingServicesArgs = {
+  graphVariant: Scalars['String'];
+  includeDeleted?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type ServiceLastReportedAtArgs = {
+  graphVariant?: Maybe<Scalars['String']>;
+};
+
+
+export type ServiceMostRecentCompositionPublishArgs = {
+  graphVariant: Scalars['String'];
+};
+
+
+export type ServiceOperationArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type ServiceOperationsAcceptedChangesArgs = {
+  checkID: Scalars['ID'];
+  operationID: Scalars['String'];
+};
+
+
+export type ServiceOperationsCheckArgs = {
+  checkID: Scalars['ID'];
+};
+
+
+export type ServiceQueryTriggersArgs = {
+  graphVariant?: Maybe<Scalars['String']>;
+  operationNames?: Maybe<Array<Scalars['String']>>;
+};
+
+
+export type ServiceRegistrySubscriptionsEnabledArgs = {
+  graphVariant?: Maybe<Scalars['String']>;
+};
+
+
+export type ServiceSchemaArgs = {
+  hash?: Maybe<Scalars['ID']>;
+  tag?: Maybe<Scalars['String']>;
+};
+
+
+export type ServiceSchemaTagArgs = {
+  tag: Scalars['String'];
+};
+
+
+export type ServiceSchemaTagByIdArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type ServiceSchemaTagsArgs = {
+  tags?: Maybe<Array<Scalars['String']>>;
+};
+
+
+export type ServiceStatsArgs = {
+  from: Scalars['Timestamp'];
+  resolution?: Maybe<Resolution>;
+  to?: Maybe<Scalars['Timestamp']>;
+};
+
+
+export type ServiceStatsWindowArgs = {
+  from: Scalars['Timestamp'];
+  resolution?: Maybe<Resolution>;
+  to?: Maybe<Scalars['Timestamp']>;
+};
+
+
+export type ServiceTestSchemaPublishBodyArgs = {
+  variant: Scalars['String'];
+};
+
+
+export type ServiceTraceArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type ServiceVariantArgs = {
+  name: Scalars['String'];
+};
+
+export type GraphApiKey = ApiKey & {
+  __typename?: 'GraphApiKey';
+  createdAt: Scalars['Timestamp'];
+  createdBy?: Maybe<Identity>;
+  id: Scalars['ID'];
+  keyName?: Maybe<Scalars['String']>;
+  role: UserPermission;
+  token: Scalars['String'];
+};
+
+export type ApiKey = {
+  id: Scalars['ID'];
+  keyName?: Maybe<Scalars['String']>;
+  token: Scalars['String'];
+};
+
+export enum UserPermission {
+  BillingManager = 'BILLING_MANAGER',
+  Consumer = 'CONSUMER',
+  Contributor = 'CONTRIBUTOR',
+  GraphAdmin = 'GRAPH_ADMIN',
+  LegacyGraphKey = 'LEGACY_GRAPH_KEY',
+  Observer = 'OBSERVER',
+  OrgAdmin = 'ORG_ADMIN'
 }
 
-export interface SchemaTagsAndFieldStats {
+export type AvatarUploadResult = AvatarUploadError | MediaUploadInfo;
+
+export type AvatarUploadError = {
+  __typename?: 'AvatarUploadError';
+  clientMessage: Scalars['String'];
+  code: AvatarUploadErrorCode;
+  serverMessage: Scalars['String'];
+};
+
+export enum AvatarUploadErrorCode {
+  SsoUsersCannotUploadSelfAvatar = 'SSO_USERS_CANNOT_UPLOAD_SELF_AVATAR'
+}
+
+export type MediaUploadInfo = {
+  __typename?: 'MediaUploadInfo';
+  csrfToken: Scalars['String'];
+  maxContentLength: Scalars['Int'];
+  url: Scalars['String'];
+};
+
+/** Destination for notifications */
+export type Channel = {
+  id: Scalars['ID'];
+  name: Scalars['String'];
+  subscriptions: Array<ChannelSubscription>;
+};
+
+export type ChannelSubscription = {
+  channels: Array<Channel>;
+  enabled: Scalars['Boolean'];
+  id: Scalars['ID'];
+  variant?: Maybe<Scalars['String']>;
+};
+
+export type CheckConfiguration = {
+  __typename?: 'CheckConfiguration';
+  /** Time when check configuration was created */
+  createdAt: Scalars['Timestamp'];
+  /** Clients to ignore during validation */
+  excludedClients: Array<ClientFilter>;
+  /** Operations to ignore during validation */
+  excludedOperations: Array<ExcludedOperation>;
+  /** Graph that this check configuration belongs to */
+  graphID: Scalars['ID'];
+  /** ID of the check configuration */
+  id: Scalars['ID'];
+  /** Default configuration to include operations on the base variant. */
+  includeBaseVariant: Scalars['Boolean'];
+  /** Variant overrides for validation */
+  includedVariants: Array<Scalars['String']>;
+  /** Minimum number of requests within the window for an operation to be considered. */
+  operationCountThreshold: Scalars['Int'];
   /**
-   * Service by ID
+   * Number of requests within the window for an operation to be considered, relative to
+   * total request count. Expected values are between 0 and 0.05 (minimum 5% of
+   * total request volume)
    */
-  service: SchemaTagsAndFieldStats_service | null;
-}
-
-export interface SchemaTagsAndFieldStatsVariables {
-  id: string;
-}
-
-/* tslint:disable */
-/* eslint-disable */
-// @generated
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL query operation: GetSchemaByTag
-// ====================================================
-
-export interface GetSchemaByTag_service_schema___schema_queryType {
-  __typename: "IntrospectionType";
-  name: string | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_mutationType {
-  __typename: "IntrospectionType";
-  name: string | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_subscriptionType {
-  __typename: "IntrospectionType";
-  name: string | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_args_type {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_args {
-  __typename: "IntrospectionInputValue";
-  name: string;
-  description: string | null;
-  type: GetSchemaByTag_service_schema___schema_types_fields_args_type;
-  defaultValue: string | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_type_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields_type {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_fields_type_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_fields {
-  __typename: "IntrospectionField";
-  name: string;
-  description: string | null;
-  args: GetSchemaByTag_service_schema___schema_types_fields_args[];
-  type: GetSchemaByTag_service_schema___schema_types_fields_type;
-  isDeprecated: boolean;
-  deprecationReason: string | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_inputFields_type {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_inputFields {
-  __typename: "IntrospectionInputValue";
-  name: string;
-  description: string | null;
-  type: GetSchemaByTag_service_schema___schema_types_inputFields_type;
-  defaultValue: string | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_interfaces_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_interfaces {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_interfaces_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_enumValues {
-  __typename: "IntrospectionEnumValue";
-  name: string;
-  description: string | null;
-  isDeprecated: boolean;
-  deprecationReason: string | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types_possibleTypes {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_types {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  description: string | null;
-  fields: GetSchemaByTag_service_schema___schema_types_fields[] | null;
-  inputFields:
-    | GetSchemaByTag_service_schema___schema_types_inputFields[]
-    | null;
-  interfaces: GetSchemaByTag_service_schema___schema_types_interfaces[] | null;
-  enumValues: GetSchemaByTag_service_schema___schema_types_enumValues[] | null;
-  possibleTypes:
-    | GetSchemaByTag_service_schema___schema_types_possibleTypes[]
-    | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_directives_args_type_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_directives_args_type {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: GetSchemaByTag_service_schema___schema_directives_args_type_ofType | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_directives_args {
-  __typename: "IntrospectionInputValue";
-  name: string;
-  description: string | null;
-  type: GetSchemaByTag_service_schema___schema_directives_args_type;
-  defaultValue: string | null;
-}
-
-export interface GetSchemaByTag_service_schema___schema_directives {
-  __typename: "IntrospectionDirective";
-  name: string;
-  description: string | null;
-  locations: IntrospectionDirectiveLocation[];
-  args: GetSchemaByTag_service_schema___schema_directives_args[];
-}
-
-export interface GetSchemaByTag_service_schema___schema {
-  __typename: "IntrospectionSchema";
-  queryType: GetSchemaByTag_service_schema___schema_queryType;
-  mutationType: GetSchemaByTag_service_schema___schema_mutationType | null;
-  subscriptionType: GetSchemaByTag_service_schema___schema_subscriptionType | null;
-  types: GetSchemaByTag_service_schema___schema_types[];
-  directives: GetSchemaByTag_service_schema___schema_directives[];
-}
-
-export interface GetSchemaByTag_service_schema {
-  __typename: "Schema";
-  hash: string;
-  __schema: GetSchemaByTag_service_schema___schema;
-}
-
-export interface GetSchemaByTag_service {
-  __typename: "Service";
+  operationCountThresholdPercentage: Scalars['Float'];
   /**
-   * Get a schema by hash OR current tag
+   * Only check operations from the last <timeRangeSeconds> seconds.
+   * The default is 7 days (604,800 seconds).
    */
-  schema: GetSchemaByTag_service_schema | null;
+  timeRangeSeconds: Scalars['Long'];
+  /** Time when check configuration was last updated */
+  updatedAt: Scalars['Timestamp'];
+  /** Identity of the last user to update the check configuration */
+  updatedBy?: Maybe<Identity>;
+};
+
+/** Client filter configuration for a graph. */
+export type ClientFilter = {
+  __typename?: 'ClientFilter';
+  /** name of the client set by the user and reported alongside metrics */
+  name?: Maybe<Scalars['String']>;
+  /** ID, often the name, of the client set by the user and reported alongside metrics */
+  referenceID?: Maybe<Scalars['ID']>;
+  /** version of the client set by the user and reported alongside metrics */
+  version?: Maybe<Scalars['String']>;
+};
+
+/** Excluded operation for a graph. */
+export type ExcludedOperation = {
+  __typename?: 'ExcludedOperation';
+  /** Operation ID to exclude from schema check. */
+  ID: Scalars['ID'];
+};
+
+/** Filter options available when listing checks. */
+export type CheckFilterInput = {
+  authors?: Maybe<Array<Scalars['String']>>;
+  branches?: Maybe<Array<Scalars['String']>>;
+  status?: Maybe<CheckFilterInputStatusOption>;
+  subgraphs?: Maybe<Array<Scalars['String']>>;
+};
+
+/** Options for filtering CheckWorkflows by status */
+export enum CheckFilterInputStatusOption {
+  Failed = 'FAILED',
+  Passed = 'PASSED',
+  Pending = 'PENDING'
 }
 
-export interface GetSchemaByTag {
+export type CheckWorkflow = {
+  __typename?: 'CheckWorkflow';
   /**
-   * Service by ID
+   * The variant provided as a base to check against.  Only the differences from the
+   * base schema will be tested in operations checks.
    */
-  service: GetSchemaByTag_service | null;
-}
-
-export interface GetSchemaByTagVariables {
-  tag: string;
-  id: string;
-}
-
-/* tslint:disable */
-/* eslint-disable */
-// @generated
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL fragment: IntrospectionFullType
-// ====================================================
-
-export interface IntrospectionFullType_fields_args_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-}
-
-export interface IntrospectionFullType_fields_args_type_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_fields_args_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_fields_args_type_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_fields_args_type_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_fields_args_type_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_fields_args_type_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_fields_args_type_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_fields_args_type_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_fields_args_type_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_fields_args_type_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_fields_args_type_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_fields_args_type_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_fields_args_type {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_fields_args_type_ofType | null;
-}
-
-export interface IntrospectionFullType_fields_args {
-  __typename: "IntrospectionInputValue";
-  name: string;
-  description: string | null;
-  type: IntrospectionFullType_fields_args_type;
-  defaultValue: string | null;
-}
-
-export interface IntrospectionFullType_fields_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-}
-
-export interface IntrospectionFullType_fields_type_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_fields_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_fields_type_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_fields_type_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_fields_type_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_fields_type_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_fields_type_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_fields_type_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_fields_type_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_fields_type_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_fields_type_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_fields_type_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_fields_type {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_fields_type_ofType | null;
-}
-
-export interface IntrospectionFullType_fields {
-  __typename: "IntrospectionField";
-  name: string;
-  description: string | null;
-  args: IntrospectionFullType_fields_args[];
-  type: IntrospectionFullType_fields_type;
-  isDeprecated: boolean;
-  deprecationReason: string | null;
-}
-
-export interface IntrospectionFullType_inputFields_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-}
-
-export interface IntrospectionFullType_inputFields_type_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_inputFields_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_inputFields_type_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_inputFields_type_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_inputFields_type_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_inputFields_type_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_inputFields_type_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_inputFields_type_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_inputFields_type_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_inputFields_type_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_inputFields_type_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_inputFields_type_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_inputFields_type {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_inputFields_type_ofType | null;
-}
-
-export interface IntrospectionFullType_inputFields {
-  __typename: "IntrospectionInputValue";
-  name: string;
-  description: string | null;
-  type: IntrospectionFullType_inputFields_type;
-  defaultValue: string | null;
-}
-
-export interface IntrospectionFullType_interfaces_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-}
-
-export interface IntrospectionFullType_interfaces_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_interfaces_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_interfaces_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_interfaces_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_interfaces_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_interfaces_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_interfaces_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_interfaces_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_interfaces_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_interfaces_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_interfaces_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_interfaces_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_interfaces {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_interfaces_ofType | null;
-}
-
-export interface IntrospectionFullType_enumValues {
-  __typename: "IntrospectionEnumValue";
-  name: string;
-  description: string | null;
-  isDeprecated: boolean;
-  deprecationReason: string | null;
-}
-
-export interface IntrospectionFullType_possibleTypes_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-}
-
-export interface IntrospectionFullType_possibleTypes_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_possibleTypes_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_possibleTypes_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_possibleTypes_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_possibleTypes_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_possibleTypes_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_possibleTypes_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_possibleTypes_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_possibleTypes_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_possibleTypes_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_possibleTypes_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_possibleTypes_ofType_ofType | null;
-}
-
-export interface IntrospectionFullType_possibleTypes {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionFullType_possibleTypes_ofType | null;
-}
-
-export interface IntrospectionFullType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  description: string | null;
-  fields: IntrospectionFullType_fields[] | null;
-  inputFields: IntrospectionFullType_inputFields[] | null;
-  interfaces: IntrospectionFullType_interfaces[] | null;
-  enumValues: IntrospectionFullType_enumValues[] | null;
-  possibleTypes: IntrospectionFullType_possibleTypes[] | null;
-}
-
-/* tslint:disable */
-/* eslint-disable */
-// @generated
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL fragment: IntrospectionInputValue
-// ====================================================
-
-export interface IntrospectionInputValue_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-}
-
-export interface IntrospectionInputValue_type_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionInputValue_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionInputValue_type_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionInputValue_type_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionInputValue_type_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionInputValue_type_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionInputValue_type_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionInputValue_type_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionInputValue_type_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionInputValue_type_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionInputValue_type_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionInputValue_type_ofType_ofType | null;
-}
-
-export interface IntrospectionInputValue_type {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionInputValue_type_ofType | null;
-}
-
-export interface IntrospectionInputValue {
-  __typename: "IntrospectionInputValue";
-  name: string;
-  description: string | null;
-  type: IntrospectionInputValue_type;
-  defaultValue: string | null;
-}
-
-/* tslint:disable */
-/* eslint-disable */
-// @generated
-// This file was automatically generated and should not be edited.
-
-// ====================================================
-// GraphQL fragment: IntrospectionTypeRef
-// ====================================================
-
-export interface IntrospectionTypeRef_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-}
-
-export interface IntrospectionTypeRef_ofType_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionTypeRef_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionTypeRef_ofType_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionTypeRef_ofType_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionTypeRef_ofType_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionTypeRef_ofType_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionTypeRef_ofType_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionTypeRef_ofType_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionTypeRef_ofType_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionTypeRef_ofType_ofType_ofType | null;
-}
-
-export interface IntrospectionTypeRef_ofType {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionTypeRef_ofType_ofType | null;
-}
-
-export interface IntrospectionTypeRef {
-  __typename: "IntrospectionType";
-  kind: IntrospectionTypeKind | null;
-  name: string | null;
-  ofType: IntrospectionTypeRef_ofType | null;
-}
-
-/* tslint:disable */
-/* eslint-disable */
-// @generated
-// This file was automatically generated and should not be edited.
-
-//==============================================================
-// START Enums and Input Objects
-//==============================================================
+  baseVariant?: Maybe<GraphVariant>;
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  createdAt: Scalars['Timestamp'];
+  /** Contextual parameters supplied by the runtime environment where the check was run. */
+  gitContext?: Maybe<GitContext>;
+  id: Scalars['ID'];
+  /** The name of the implementing service that was responsible for triggering the validation. */
+  implementingServiceName?: Maybe<Scalars['String']>;
+  /** If this check was created by rerunning, the original check that was rerun. */
+  rerunOf?: Maybe<CheckWorkflow>;
+  /** Checks created by re-running this check, most recent first. */
+  reruns?: Maybe<Array<CheckWorkflow>>;
+  startedAt?: Maybe<Scalars['Timestamp']>;
+  /** Overall status of the workflow, based on the underlying task statuses. */
+  status: CheckWorkflowStatus;
+  /** The set of check tasks associated with this workflow, e.g. OperationsCheck, GraphComposition, etc. */
+  tasks: Array<CheckWorkflowTask>;
+  /** Configuration of validation at the time the check was run. */
+  validationConfig?: Maybe<SchemaDiffValidationConfig>;
+};
+
+
+export type CheckWorkflowRerunsArgs = {
+  limit?: Scalars['Int'];
+};
+
+/** A variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariant = {
+  __typename?: 'GraphVariant';
+  /** As new schema tags keep getting published, activeSchemaPublish refers to the latest. */
+  activeSchemaPublish?: Maybe<SchemaTag>;
+  /** Explorer setting for default headers for a graph */
+  defaultHeaders?: Maybe<Scalars['String']>;
+  derivedVariantCount: Scalars['Int'];
+  /** Graph the variant belongs to */
+  graph: Service;
+  /** Graph ID of the variant. Prefer using graph { id } when feasible. */
+  graphId: Scalars['String'];
+  /** Global identifier for the graph variant, in the form `graph@variant`. */
+  id: Scalars['ID'];
+  /** Returns whether the variant is a contract variant */
+  isContract?: Maybe<Scalars['Boolean']>;
+  /** Is this variant one of the current user's favorite variants? */
+  isFavoriteOfCurrentUser: Scalars['Boolean'];
+  /** If the variant is protected */
+  isProtected: Scalars['Boolean'];
+  isPublic: Scalars['Boolean'];
+  latestLaunch?: Maybe<Launch>;
+  launch?: Maybe<Launch>;
+  launchHistory: Array<Launch>;
+  links?: Maybe<Array<LinkInfo>>;
+  /** Name of the variant, like `variant`. */
+  name: Scalars['String'];
+  /** Which permissions the current user has for interacting with this variant */
+  permissions: GraphVariantPermissions;
+  /** Explorer setting for preflight script to run before the actual GraphQL operations is run. */
+  preflightScript?: Maybe<Scalars['String']>;
+  readme?: Maybe<Readme>;
+  /** The total number of requests for this variant in the last 24 hours */
+  requestsInLastDay?: Maybe<Scalars['Long']>;
+  /** If the graphql endpoint is set up to accept cookies */
+  sendCookies?: Maybe<Scalars['Boolean']>;
+  sourceVariant?: Maybe<GraphVariant>;
+  /** URL where the graph subscription can be queried. */
+  subscriptionUrl?: Maybe<Scalars['String']>;
+  /** A list of supported directives */
+  supportedDirectives?: Maybe<Array<DirectiveSupportStatus>>;
+  /** URL where the graph can be queried. */
+  url?: Maybe<Scalars['String']>;
+  /** The last instant that usage information (e.g. operation stat, client stats) was reported for this variant */
+  usageLastReportedAt?: Maybe<Scalars['Timestamp']>;
+};
+
+
+/** A variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantLaunchArgs = {
+  id: Scalars['ID'];
+};
+
+
+/** A variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantLaunchHistoryArgs = {
+  limit?: Scalars['Int'];
+};
+
+export type SchemaTag = {
+  __typename?: 'SchemaTag';
+  /** The composition result that corresponds to this schema repo tag, if it exists. */
+  compositionResult?: Maybe<CompositionResult>;
+  createdAt: Scalars['Timestamp'];
+  diffToPrevious?: Maybe<SchemaDiff>;
+  gitContext?: Maybe<GitContext>;
+  /**
+   * List of previously uploaded SchemaTags under the same tag name, starting with
+   * the selected published schema record. Sorted in reverse chronological order
+   * by creation date (newest publish first).
+   *
+   * Note: This does not include the history of checked schemas
+   */
+  history: Array<SchemaTag>;
+  /**
+   * Number of tagged schemas created under the same tag name.
+   * Also represents the maximum size of the history's limit argument.
+   */
+  historyLength: Scalars['Int'];
+  /**
+   * Number of schemas tagged prior to this one under the same tag name, its position
+   * in the tag history.
+   */
+  historyOrder: Scalars['Int'];
+  /**
+   * The identifier for this particular schema tag, which may be either a particular
+   * run of a check or a specific publish. This ID can be used alongside `schemaTagByID`
+   * in order to look up a particular entry.
+   */
+  id: Scalars['ID'];
+  /**
+   * Indicates this schema is "published" meaning that our users correspond this schema
+   * with a long-running or permanent initiative. Published schemas appear in the UI
+   * when exploring a service's schemas, and typically refer to either active environments
+   * with metrics (e.g. "staging") or git branches that are constantly used as a base
+   * (e.g. "main"). If this field is not found, the schema is "private" to Engine
+   * and is uploaded but not promoted to published yet. The other benefit is this makes
+   * for nice UX around publishing events
+   */
+  publishedAt: Scalars['Timestamp'];
+  /**
+   * The Identity that published this schema and their client info, or null if this isn't
+   * a publish. Sub-fields may be null if they weren't recorded.
+   */
+  publishedBy?: Maybe<IdentityAndClientInfo>;
+  /**
+   * Indicates the schemaTag of the schema's original upload, null if this is the
+   * first upload of the schema.
+   */
+  reversionFrom?: Maybe<SchemaTag>;
+  schema: Schema;
+  slackNotificationBody?: Maybe<Scalars['String']>;
+  /** @deprecated Please use variant { name } instead */
+  tag: Scalars['String'];
+  /** The graph variant this schema tag belongs to. */
+  variant: GraphVariant;
+  webhookNotificationBody: Scalars['String'];
+};
+
+
+export type SchemaTagHistoryArgs = {
+  includeUnchanged?: Scalars['Boolean'];
+  limit?: Scalars['Int'];
+  offset?: Maybe<Scalars['Int']>;
+};
+
+
+export type SchemaTagSlackNotificationBodyArgs = {
+  graphDisplayName: Scalars['String'];
+};
+
+/** Result of a composition, either as the result of a composition validation or a publish. */
+export type CompositionResult = {
+  /**
+   * Supergraph SDL generated by composition (this is not the CSDL, that is a deprecated format).
+   * @deprecated Use supergraphSdl instead
+   */
+  csdl?: Maybe<Scalars['GraphQLDocument']>;
+  /**
+   * List of errors during composition. Errors mean that Apollo was unable to compose the
+   * graph's implementing services into a GraphQL schema. This partial schema should not be
+   * published to the implementing service if there were any errors encountered
+   */
+  errors: Array<SchemaCompositionError>;
+  /** ID that points to the results of this composition. */
+  graphCompositionID: Scalars['ID'];
+  /** List of subgraphs that are included in this composition. */
+  subgraphConfigs: Array<SubgraphConfig>;
+  /** Supergraph SDL generated by composition. */
+  supergraphSdl?: Maybe<Scalars['GraphQLDocument']>;
+};
+
+/** Represents an error from running schema composition on a list of service definitions. */
+export type SchemaCompositionError = {
+  __typename?: 'SchemaCompositionError';
+  code?: Maybe<Scalars['String']>;
+  locations: Array<Maybe<SourceLocation>>;
+  message: Scalars['String'];
+};
+
+export type SourceLocation = {
+  __typename?: 'SourceLocation';
+  column: Scalars['Int'];
+  line: Scalars['Int'];
+};
+
+export type SubgraphConfig = {
+  __typename?: 'SubgraphConfig';
+  id: Scalars['ID'];
+  name: Scalars['String'];
+  schemaHash: Scalars['String'];
+  sdl: Scalars['String'];
+  url: Scalars['String'];
+};
+
+export type SchemaDiff = {
+  __typename?: 'SchemaDiff';
+  /**
+   * Clients affected by all changes in diff
+   * @deprecated Unsupported.
+   */
+  affectedClients?: Maybe<Array<AffectedClient>>;
+  /** Operations affected by all changes in diff */
+  affectedQueries?: Maybe<Array<AffectedQuery>>;
+  /** List of schema changes with associated affected clients and operations */
+  changes: Array<Change>;
+  /** Summary/counts for all changes in diff */
+  changeSummary: ChangeSummary;
+  /** Number of affected query operations that are neither marked as SAFE or IGNORED */
+  numberOfAffectedOperations: Scalars['Int'];
+  /** Number of operations that were validated during schema diff */
+  numberOfCheckedOperations?: Maybe<Scalars['Int']>;
+  /** Indication of the success of the change, either failure, warning, or notice. */
+  severity: ChangeSeverity;
+  /** The tag against which this diff was created */
+  tag?: Maybe<Scalars['String']>;
+  /** @deprecated use severity instead */
+  type: ChangeType;
+  /** Configuration of validation */
+  validationConfig?: Maybe<SchemaDiffValidationConfig>;
+};
+
+export type AffectedClient = {
+  __typename?: 'AffectedClient';
+  /** ID, often the name, of the client set by the user and reported alongside metrics */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** version of the client set by the user and reported alongside metrics */
+  clientVersion?: Maybe<Scalars['String']>;
+};
+
+export type AffectedQuery = {
+  __typename?: 'AffectedQuery';
+  /** If the operation would be approved if the check ran again. Returns null if queried from SchemaDiff.changes.affectedQueries.alreadyApproved */
+  alreadyApproved?: Maybe<Scalars['Boolean']>;
+  /** If the operation would be ignored if the check ran again */
+  alreadyIgnored?: Maybe<Scalars['Boolean']>;
+  /** List of changes affecting this query. Returns null if queried from SchemaDiff.changes.affectedQueries.changes */
+  changes?: Maybe<Array<ChangeOnOperation>>;
+  /** Name to display to the user for the operation */
+  displayName?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  /** Determines if this query validates against the proposed schema */
+  isValid?: Maybe<Scalars['Boolean']>;
+  /** Whether this operation was ignored and its severity was downgraded for that reason */
+  markedAsIgnored?: Maybe<Scalars['Boolean']>;
+  /** Whether the changes were marked as safe and its severity was downgraded for that reason */
+  markedAsSafe?: Maybe<Scalars['Boolean']>;
+  /** Name provided for the operation, which can be empty string if it is an anonymous operation */
+  name?: Maybe<Scalars['String']>;
+  /** First 128 characters of query signature for display */
+  signature?: Maybe<Scalars['String']>;
+};
+
+/** Info about a change in the context of an operation it affects */
+export type ChangeOnOperation = {
+  __typename?: 'ChangeOnOperation';
+  /** Human-readable explanation of the impact of this change on the operation */
+  impact?: Maybe<Scalars['String']>;
+  /** The semantic info about this change, i.e. info about the change that doesn't depend on the operation */
+  semanticChange: SemanticChange;
+};
+
+export type SemanticChange = {
+  __typename?: 'SemanticChange';
+  /** Target arg of change made. */
+  argNode?: Maybe<NamedIntrospectionArg>;
+  /**
+   * Node related to the top level node that was changed, such as a field in an object,
+   * a value in an enum or the object of an interface
+   */
+  childNode?: Maybe<NamedIntrospectionValue>;
+  /** Semantic metadata about the type of change */
+  definition: ChangeDefinition;
+  /** Top level node affected by the change */
+  parentNode?: Maybe<NamedIntrospectionType>;
+};
+
+export type NamedIntrospectionArg = {
+  __typename?: 'NamedIntrospectionArg';
+  description?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+};
 
 /**
- * __DirectiveLocation introspection type
+ * Introspection values that can be children of other types for changes, such
+ * as input fields, objects in interfaces, enum values. In the future, this
+ * value could become an interface to allow fields specific to the types
+ * returned.
  */
-export enum IntrospectionDirectiveLocation {
-  ARGUMENT_DEFINITION = "ARGUMENT_DEFINITION",
-  ENUM = "ENUM",
-  ENUM_VALUE = "ENUM_VALUE",
-  FIELD = "FIELD",
-  FIELD_DEFINITION = "FIELD_DEFINITION",
-  FRAGMENT_DEFINITION = "FRAGMENT_DEFINITION",
-  FRAGMENT_SPREAD = "FRAGMENT_SPREAD",
-  INLINE_FRAGMENT = "INLINE_FRAGMENT",
-  INPUT_FIELD_DEFINITION = "INPUT_FIELD_DEFINITION",
-  INPUT_OBJECT = "INPUT_OBJECT",
-  INTERFACE = "INTERFACE",
-  MUTATION = "MUTATION",
-  OBJECT = "OBJECT",
-  QUERY = "QUERY",
-  SCALAR = "SCALAR",
-  SCHEMA = "SCHEMA",
-  SUBSCRIPTION = "SUBSCRIPTION",
-  UNION = "UNION",
-  VARIABLE_DEFINITION = "VARIABLE_DEFINITION",
+export type NamedIntrospectionValue = {
+  __typename?: 'NamedIntrospectionValue';
+  description?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  printedType?: Maybe<Scalars['String']>;
+};
+
+/**
+ * Represents the tuple of static information
+ * about a particular kind of schema change.
+ */
+export type ChangeDefinition = {
+  __typename?: 'ChangeDefinition';
+  category: ChangeCategory;
+  code: ChangeCode;
+  defaultSeverity: ChangeSeverity;
+};
+
+/**
+ * Defines a set of categories that a schema change
+ * can be grouped by.
+ */
+export enum ChangeCategory {
+  Addition = 'ADDITION',
+  Deprecation = 'DEPRECATION',
+  Edit = 'EDIT',
+  Removal = 'REMOVAL'
 }
+
+/**
+ * These schema change codes represent all of the possible changes that can
+ * occur during the schema diff algorithm.
+ */
+export enum ChangeCode {
+  /** Type of the argument was changed. */
+  ArgChangedType = 'ARG_CHANGED_TYPE',
+  /** Argument was changed from nullable to non-nullable. */
+  ArgChangedTypeOptionalToRequired = 'ARG_CHANGED_TYPE_OPTIONAL_TO_REQUIRED',
+  /** Default value added or changed for the argument. */
+  ArgDefaultValueChange = 'ARG_DEFAULT_VALUE_CHANGE',
+  /** Description was added, removed, or updated for argument. */
+  ArgDescriptionChange = 'ARG_DESCRIPTION_CHANGE',
+  /** Argument to a field was removed. */
+  ArgRemoved = 'ARG_REMOVED',
+  /** Argument to the directive was removed. */
+  DirectiveArgRemoved = 'DIRECTIVE_ARG_REMOVED',
+  /** Location of the directive was removed. */
+  DirectiveLocationRemoved = 'DIRECTIVE_LOCATION_REMOVED',
+  /** Directive was removed. */
+  DirectiveRemoved = 'DIRECTIVE_REMOVED',
+  /** Repeatable flag was removed for directive. */
+  DirectiveRepeatableRemoved = 'DIRECTIVE_REPEATABLE_REMOVED',
+  /** Enum was deprecated. */
+  EnumDeprecated = 'ENUM_DEPRECATED',
+  /** Reason for enum deprecation changed. */
+  EnumDeprecatedReasonChange = 'ENUM_DEPRECATED_REASON_CHANGE',
+  /** Enum deprecation was removed. */
+  EnumDeprecationRemoved = 'ENUM_DEPRECATION_REMOVED',
+  /** Description was added, removed, or updated for enum value. */
+  EnumValueDescriptionChange = 'ENUM_VALUE_DESCRIPTION_CHANGE',
+  /** Field was added to the type. */
+  FieldAdded = 'FIELD_ADDED',
+  /** Return type for the field was changed. */
+  FieldChangedType = 'FIELD_CHANGED_TYPE',
+  /** Field was deprecated. */
+  FieldDeprecated = 'FIELD_DEPRECATED',
+  /** Reason for field deprecation changed. */
+  FieldDeprecatedReasonChange = 'FIELD_DEPRECATED_REASON_CHANGE',
+  /** Field deprecation removed. */
+  FieldDeprecationRemoved = 'FIELD_DEPRECATION_REMOVED',
+  /** Description was added, removed, or updated for field. */
+  FieldDescriptionChange = 'FIELD_DESCRIPTION_CHANGE',
+  /** Type of the field in the input object was changed. */
+  FieldOnInputObjectChangedType = 'FIELD_ON_INPUT_OBJECT_CHANGED_TYPE',
+  /** Field was removed from the type. */
+  FieldRemoved = 'FIELD_REMOVED',
+  /** Field was removed from the input object. */
+  FieldRemovedFromInputObject = 'FIELD_REMOVED_FROM_INPUT_OBJECT',
+  /** Non-nullable field was added to the input object. */
+  NonNullableFieldAddedToInputObject = 'NON_NULLABLE_FIELD_ADDED_TO_INPUT_OBJECT',
+  /** Nullable field was added to the input type. */
+  NullableFieldAddedToInputObject = 'NULLABLE_FIELD_ADDED_TO_INPUT_OBJECT',
+  /** Nullable argument was added to the field. */
+  OptionalArgAdded = 'OPTIONAL_ARG_ADDED',
+  /** Non-nullable argument was added to the field. */
+  RequiredArgAdded = 'REQUIRED_ARG_ADDED',
+  /** Non-nullable argument added to directive. */
+  RequiredDirectiveArgAdded = 'REQUIRED_DIRECTIVE_ARG_ADDED',
+  /** Type was added to the schema. */
+  TypeAdded = 'TYPE_ADDED',
+  /** Type now implements the interface. */
+  TypeAddedToInterface = 'TYPE_ADDED_TO_INTERFACE',
+  /** A new value was added to the enum. */
+  TypeAddedToUnion = 'TYPE_ADDED_TO_UNION',
+  /**
+   * Type was changed from one kind to another.
+   * Ex: scalar to object or enum to union.
+   */
+  TypeChangedKind = 'TYPE_CHANGED_KIND',
+  /** Description was added, removed, or updated for type. */
+  TypeDescriptionChange = 'TYPE_DESCRIPTION_CHANGE',
+  /** Type (object or scalar) was removed from the schema. */
+  TypeRemoved = 'TYPE_REMOVED',
+  /** Type no longer implements the interface. */
+  TypeRemovedFromInterface = 'TYPE_REMOVED_FROM_INTERFACE',
+  /** Type is no longer included in the union. */
+  TypeRemovedFromUnion = 'TYPE_REMOVED_FROM_UNION',
+  /** A new value was added to the enum. */
+  ValueAddedToEnum = 'VALUE_ADDED_TO_ENUM',
+  /** Value was removed from the enum. */
+  ValueRemovedFromEnum = 'VALUE_REMOVED_FROM_ENUM'
+}
+
+export enum ChangeSeverity {
+  Failure = 'FAILURE',
+  Notice = 'NOTICE'
+}
+
+/**
+ * The shared fields for a named introspection type. Currently this is returned for the
+ * top level value affected by a change. In the future, we may update this
+ * type to be an interface, which is extended by the more specific types:
+ * scalar, object, input object, union, interface, and enum
+ *
+ * For an in-depth look at where these types come from, see:
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/659eb50d3/types/graphql/utilities/introspectionQuery.d.ts#L31-L37
+ */
+export type NamedIntrospectionType = {
+  __typename?: 'NamedIntrospectionType';
+  description?: Maybe<Scalars['String']>;
+  kind?: Maybe<IntrospectionTypeKind>;
+  name?: Maybe<Scalars['String']>;
+};
 
 export enum IntrospectionTypeKind {
-  ENUM = "ENUM",
-  INPUT_OBJECT = "INPUT_OBJECT",
-  INTERFACE = "INTERFACE",
-  LIST = "LIST",
-  NON_NULL = "NON_NULL",
-  OBJECT = "OBJECT",
-  SCALAR = "SCALAR",
-  UNION = "UNION",
+  /** Indicates this type is an enum. 'enumValues' is a valid field. */
+  Enum = 'ENUM',
+  /** Indicates this type is an input object. 'inputFields' is a valid field. */
+  InputObject = 'INPUT_OBJECT',
+  /**
+   * Indicates this type is an interface. 'fields' and 'possibleTypes' are valid
+   * fields
+   */
+  Interface = 'INTERFACE',
+  /** Indicates this type is a list. 'ofType' is a valid field. */
+  List = 'LIST',
+  /** Indicates this type is a non-null. 'ofType' is a valid field. */
+  NonNull = 'NON_NULL',
+  /** Indicates this type is an object. 'fields' and 'interfaces' are valid fields. */
+  Object = 'OBJECT',
+  /** Indicates this type is a scalar. */
+  Scalar = 'SCALAR',
+  /** Indicates this type is a union. 'possibleTypes' is a valid field. */
+  Union = 'UNION'
 }
 
-//==============================================================
-// END Enums and Input Objects
-//==============================================================
+export type Change = {
+  __typename?: 'Change';
+  affectedQueries?: Maybe<Array<AffectedQuery>>;
+  /** Target arg of change made. */
+  argNode?: Maybe<NamedIntrospectionArg>;
+  /** Indication of the category of the change (e.g. addition, removal, edit). */
+  category: ChangeCategory;
+  /**
+   * Node related to the top level node that was changed, such as a field in an object,
+   * a value in an enum or the object of an interface
+   */
+  childNode?: Maybe<NamedIntrospectionValue>;
+  /** Indication of the kind of target and action of the change, e.g. 'TYPE_REMOVED'. */
+  code: Scalars['String'];
+  /** Explanation of both the target of the change and how it was changed. */
+  description: Scalars['String'];
+  /** Top level node affected by the change */
+  parentNode?: Maybe<NamedIntrospectionType>;
+  /** Indication of the success of the overall change, either failure, warning, or notice. */
+  severity: ChangeSeverity;
+  /**
+   * Indication of the success of the overall change, either failure, warning, or notice.
+   * @deprecated use severity instead
+   */
+  type: ChangeType;
+};
+
+export enum ChangeType {
+  Failure = 'FAILURE',
+  Notice = 'NOTICE'
+}
+
+/**
+ * Summary of the changes for a schema diff, computed by placing the changes into categories and then
+ * counting the size of each category. This categorization can be done in different ways, and
+ * accordingly there are multiple fields here for each type of categorization.
+ *
+ * Note that if an object or interface field is added/removed, there won't be any addition/removal
+ * changes generated for its arguments or @deprecated usages. If an enum type is added/removed, there
+ * will be addition/removal changes generated for its values, but not for those values' @deprecated
+ * usages. Description changes won't be generated for a schema element if that element (or an
+ * ancestor) was added/removed.
+ */
+export type ChangeSummary = {
+  __typename?: 'ChangeSummary';
+  /** Counts for changes to fields of objects, input objects, and interfaces. */
+  field: FieldChangeSummaryCounts;
+  /** Counts for all changes. */
+  total: TotalChangeSummaryCounts;
+  /**
+   * Counts for changes to non-field aspects of objects, input objects, and interfaces,
+   * and all aspects of enums, unions, and scalars.
+   */
+  type: TypeChangeSummaryCounts;
+};
+
+export type FieldChangeSummaryCounts = {
+  __typename?: 'FieldChangeSummaryCounts';
+  /** Number of changes that are additions of fields to object and interface types. */
+  additions: Scalars['Int'];
+  /**
+   * Number of changes that are field edits. This includes fields changing type and any field
+   * deprecation and description changes, but also includes any argument changes and any input object
+   * field changes.
+   */
+  edits: Scalars['Int'];
+  /** Number of changes that are removals of fields from object and interface types. */
+  removals: Scalars['Int'];
+};
+
+export type TotalChangeSummaryCounts = {
+  __typename?: 'TotalChangeSummaryCounts';
+  /**
+   * Number of changes that are additions. This includes adding types, adding fields to object, input
+   * object, and interface types, adding values to enums, adding members to interfaces and unions, and
+   * adding arguments.
+   */
+  additions: Scalars['Int'];
+  /** Number of changes that are new usages of the @deprecated directive. */
+  deprecations: Scalars['Int'];
+  /**
+   * Number of changes that are edits. This includes types changing kind, fields and arguments
+   * changing type, arguments changing default value, and any description changes. This also includes
+   * edits to @deprecated reason strings.
+   */
+  edits: Scalars['Int'];
+  /**
+   * Number of changes that are removals. This includes removing types, removing fields from object,
+   * input object, and interface types, removing values from enums, removing members from interfaces
+   * and unions, and removing arguments. This also includes removing @deprecated usages.
+   */
+  removals: Scalars['Int'];
+};
+
+export type TypeChangeSummaryCounts = {
+  __typename?: 'TypeChangeSummaryCounts';
+  /** Number of changes that are additions of types. */
+  additions: Scalars['Int'];
+  /**
+   * Number of changes that are edits. This includes types changing kind and any type description
+   * changes, but also includes adding/removing values from enums, adding/removing members from
+   * interfaces and unions, and any enum value deprecation and description changes.
+   */
+  edits: Scalars['Int'];
+  /** Number of changes that are removals of types. */
+  removals: Scalars['Int'];
+};
+
+export type SchemaDiffValidationConfig = {
+  __typename?: 'SchemaDiffValidationConfig';
+  /** Clients to ignore during validation. */
+  excludedClients?: Maybe<Array<ClientInfoFilterOutput>>;
+  /**
+   * delta in seconds from current time that determines the start of the window
+   * for reported metrics included in a schema diff. A day window from the present
+   * day would have a `from` value of -86400. In rare cases, this could be an ISO
+   * timestamp if the user passed one in on diff creation
+   */
+  from?: Maybe<Scalars['Timestamp']>;
+  /** Operation IDs to ignore during validation. */
+  ignoredOperations?: Maybe<Array<Scalars['ID']>>;
+  /** Variants to include during validation. */
+  includedVariants?: Maybe<Array<Scalars['String']>>;
+  /** Minimum number of requests within the window for a query to be considered. */
+  queryCountThreshold?: Maybe<Scalars['Int']>;
+  /**
+   * Number of requests within the window for a query to be considered, relative to
+   * total request count. Expected values are between 0 and 0.05 (minimum 5% of
+   * total request volume)
+   */
+  queryCountThresholdPercentage?: Maybe<Scalars['Float']>;
+  /**
+   * delta in seconds from current time that determines the end of the
+   * window for reported metrics included in a schema diff. A day window
+   * from the present day would have a `to` value of -0. In rare
+   * cases, this could be an ISO timestamp if the user passed one in on diff
+   * creation
+   */
+  to?: Maybe<Scalars['Timestamp']>;
+};
+
+/** Filter options to exclude clients. Used as an output type for SchemaDiffValidationConfig. */
+export type ClientInfoFilterOutput = {
+  __typename?: 'ClientInfoFilterOutput';
+  name?: Maybe<Scalars['String']>;
+  referenceID?: Maybe<Scalars['ID']>;
+  version?: Maybe<Scalars['String']>;
+};
+
+export type GitContext = {
+  __typename?: 'GitContext';
+  branch?: Maybe<Scalars['String']>;
+  commit?: Maybe<Scalars['ID']>;
+  committer?: Maybe<Scalars['String']>;
+  commitUrl?: Maybe<Scalars['String']>;
+  message?: Maybe<Scalars['String']>;
+  remoteHost?: Maybe<GitRemoteHost>;
+  remoteUrl?: Maybe<Scalars['String']>;
+};
+
+export enum GitRemoteHost {
+  Bitbucket = 'BITBUCKET',
+  Github = 'GITHUB',
+  Gitlab = 'GITLAB'
+}
+
+/** An actor's identity and info about the client they used to perform the action */
+export type IdentityAndClientInfo = {
+  __typename?: 'IdentityAndClientInfo';
+  /** The clientName given to Apollo Cloud when the actor performed the action */
+  clientName?: Maybe<Scalars['String']>;
+  /** The clientVersion given to Apollo Cloud when the actor performed the action */
+  clientVersion?: Maybe<Scalars['String']>;
+  /** Identity info about the actor */
+  identity?: Maybe<Identity>;
+};
+
+export type Schema = {
+  __typename?: 'Schema';
+  createdAt: Scalars['Timestamp'];
+  createTemporaryURL?: Maybe<TemporaryUrl>;
+  document: Scalars['GraphQLDocument'];
+  /** The number of fields; this includes user defined fields only, excluding built-in types and fields */
+  fieldCount: Scalars['Int'];
+  gitContext?: Maybe<GitContext>;
+  hash: Scalars['ID'];
+  introspection: IntrospectionSchema;
+  /** The number of types; this includes user defined types only, excluding built-in types */
+  typeCount: Scalars['Int'];
+};
+
+
+export type SchemaCreateTemporaryUrlArgs = {
+  expiresInSeconds?: Scalars['Int'];
+};
+
+export type TemporaryUrl = {
+  __typename?: 'TemporaryURL';
+  url: Scalars['String'];
+};
+
+export type IntrospectionSchema = {
+  __typename?: 'IntrospectionSchema';
+  directives: Array<IntrospectionDirective>;
+  mutationType?: Maybe<IntrospectionType>;
+  queryType: IntrospectionType;
+  subscriptionType?: Maybe<IntrospectionType>;
+  types: Array<IntrospectionType>;
+};
+
+
+export type IntrospectionSchemaTypesArgs = {
+  filter?: Maybe<TypeFilterConfig>;
+};
+
+export type IntrospectionDirective = {
+  __typename?: 'IntrospectionDirective';
+  args: Array<IntrospectionInputValue>;
+  description?: Maybe<Scalars['String']>;
+  locations: Array<IntrospectionDirectiveLocation>;
+  name: Scalars['String'];
+};
+
+/** Values associated with introspection result for an input field */
+export type IntrospectionInputValue = {
+  __typename?: 'IntrospectionInputValue';
+  defaultValue?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
+  type: IntrospectionType;
+};
+
+/** Object containing all possible values for an introspectionType */
+export type IntrospectionType = {
+  __typename?: 'IntrospectionType';
+  /** the base kind of the type this references, ignoring lists and nullability */
+  baseKind?: Maybe<IntrospectionTypeKind>;
+  description?: Maybe<Scalars['String']>;
+  enumValues?: Maybe<Array<IntrospectionEnumValue>>;
+  fields?: Maybe<Array<IntrospectionField>>;
+  inputFields?: Maybe<Array<IntrospectionInputValue>>;
+  interfaces?: Maybe<Array<IntrospectionType>>;
+  kind?: Maybe<IntrospectionTypeKind>;
+  name?: Maybe<Scalars['String']>;
+  ofType?: Maybe<IntrospectionType>;
+  possibleTypes?: Maybe<Array<IntrospectionType>>;
+  /** printed representation of type, including nested nullability and list ofTypes */
+  printed: Scalars['String'];
+};
+
+
+/** Object containing all possible values for an introspectionType */
+export type IntrospectionTypeEnumValuesArgs = {
+  includeDeprecated?: Maybe<Scalars['Boolean']>;
+};
+
+/** Values associated with introspection result for an enum value */
+export type IntrospectionEnumValue = {
+  __typename?: 'IntrospectionEnumValue';
+  /** @deprecated Use deprecationReason instead */
+  depreactionReason?: Maybe<Scalars['String']>;
+  deprecationReason?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  isDeprecated: Scalars['Boolean'];
+  name: Scalars['String'];
+};
+
+/** Values associated with introspection result for field */
+export type IntrospectionField = {
+  __typename?: 'IntrospectionField';
+  args: Array<IntrospectionInputValue>;
+  deprecationReason?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  isDeprecated: Scalars['Boolean'];
+  name: Scalars['String'];
+  type: IntrospectionType;
+};
+
+/** __DirectiveLocation introspection type */
+export enum IntrospectionDirectiveLocation {
+  /** Location adjacent to an argument definition. */
+  ArgumentDefinition = 'ARGUMENT_DEFINITION',
+  /** Location adjacent to an enum definition. */
+  Enum = 'ENUM',
+  /** Location adjacent to an enum value definition. */
+  EnumValue = 'ENUM_VALUE',
+  /** Location adjacent to a field. */
+  Field = 'FIELD',
+  /** Location adjacent to a field definition. */
+  FieldDefinition = 'FIELD_DEFINITION',
+  /** Location adjacent to a fragment definition. */
+  FragmentDefinition = 'FRAGMENT_DEFINITION',
+  /** Location adjacent to a fragment spread. */
+  FragmentSpread = 'FRAGMENT_SPREAD',
+  /** Location adjacent to an inline fragment. */
+  InlineFragment = 'INLINE_FRAGMENT',
+  /** Location adjacent to an input object field definition. */
+  InputFieldDefinition = 'INPUT_FIELD_DEFINITION',
+  /** Location adjacent to an input object type definition. */
+  InputObject = 'INPUT_OBJECT',
+  /** Location adjacent to an interface definition. */
+  Interface = 'INTERFACE',
+  /** Location adjacent to a mutation operation. */
+  Mutation = 'MUTATION',
+  /** Location adjacent to an object type definition. */
+  Object = 'OBJECT',
+  /** Location adjacent to a query operation. */
+  Query = 'QUERY',
+  /** Location adjacent to a scalar definition. */
+  Scalar = 'SCALAR',
+  /** Location adjacent to a schema definition. */
+  Schema = 'SCHEMA',
+  /** Location adjacent to a subscription operation. */
+  Subscription = 'SUBSCRIPTION',
+  /** Location adjacent to a union definition. */
+  Union = 'UNION',
+  /** Location adjacent to a variable definition. */
+  VariableDefinition = 'VARIABLE_DEFINITION'
+}
+
+/**
+ * the TypeFilterConfig is used to isolate
+ * types, and subsequent fields, through
+ * various configuration settings.
+ *
+ * It defaults to filter towards user defined
+ * types only
+ */
+export type TypeFilterConfig = {
+  /** include abstract types (interfaces and unions) */
+  includeAbstractTypes?: Maybe<Scalars['Boolean']>;
+  /** include built in scalars (i.e. Boolean, Int, etc) */
+  includeBuiltInTypes?: Maybe<Scalars['Boolean']>;
+  /** include reserved introspection types (i.e. __Type) */
+  includeIntrospectionTypes?: Maybe<Scalars['Boolean']>;
+};
+
+export type Launch = {
+  __typename?: 'Launch';
+  approvedAt?: Maybe<Scalars['Timestamp']>;
+  build?: Maybe<Build>;
+  buildInput: BuildInput;
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  createdAt: Scalars['Timestamp'];
+  downstreamLaunches?: Maybe<Array<Launch>>;
+  id: Scalars['ID'];
+  isAvailable?: Maybe<Scalars['Boolean']>;
+  isCompleted?: Maybe<Scalars['Boolean']>;
+  isPublished?: Maybe<Scalars['Boolean']>;
+  isTarget?: Maybe<Scalars['Boolean']>;
+  latestSequenceStep?: Maybe<LaunchSequenceStep>;
+  results: Array<LaunchResult>;
+  schemaTag?: Maybe<SchemaTag>;
+  sequence: Array<LaunchSequenceStep>;
+  shortenedID: Scalars['String'];
+  status: LaunchStatus;
+  subgraphChanges?: Maybe<Array<SubgraphChange>>;
+  supersededAt?: Maybe<Scalars['Timestamp']>;
+  supersededBy?: Maybe<Launch>;
+};
+
+export type Build = {
+  __typename?: 'Build';
+  input: BuildInput;
+  result?: Maybe<BuildResult>;
+};
+
+export type BuildInput = CompositionBuildInput | FilterBuildInput;
+
+export type CompositionBuildInput = {
+  __typename?: 'CompositionBuildInput';
+  subgraphs: Array<Subgraph>;
+  version?: Maybe<Scalars['String']>;
+};
+
+export type Subgraph = {
+  __typename?: 'Subgraph';
+  hash: Scalars['String'];
+  name: Scalars['String'];
+  routingURL: Scalars['String'];
+};
+
+export type FilterBuildInput = {
+  __typename?: 'FilterBuildInput';
+  filterConfig: FilterConfig;
+  schemaHash: Scalars['String'];
+};
+
+export type FilterConfig = {
+  __typename?: 'FilterConfig';
+  exclude: Array<Scalars['String']>;
+  include: Array<Scalars['String']>;
+};
+
+export type BuildResult = BuildFailure | BuildSuccess;
+
+export type BuildFailure = {
+  __typename?: 'BuildFailure';
+  errorMessages: Array<BuildError>;
+};
+
+export type BuildError = {
+  __typename?: 'BuildError';
+  code?: Maybe<Scalars['String']>;
+  locations: Array<SourceLocation>;
+  message: Scalars['String'];
+};
+
+export type BuildSuccess = {
+  __typename?: 'BuildSuccess';
+  coreSchema: CoreSchema;
+};
+
+export type CoreSchema = {
+  __typename?: 'CoreSchema';
+  apiDocument: Scalars['GraphQLDocument'];
+  coreDocument: Scalars['GraphQLDocument'];
+  coreHash: Scalars['String'];
+};
+
+export type LaunchSequenceStep = LaunchSequenceBuildStep | LaunchSequenceCheckStep | LaunchSequenceCompletedStep | LaunchSequenceInitiatedStep | LaunchSequencePublishStep | LaunchSequenceSupersededStep;
+
+export type LaunchSequenceBuildStep = {
+  __typename?: 'LaunchSequenceBuildStep';
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  startedAt?: Maybe<Scalars['Timestamp']>;
+};
+
+export type LaunchSequenceCheckStep = {
+  __typename?: 'LaunchSequenceCheckStep';
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  startedAt?: Maybe<Scalars['Timestamp']>;
+};
+
+export type LaunchSequenceCompletedStep = {
+  __typename?: 'LaunchSequenceCompletedStep';
+  completedAt?: Maybe<Scalars['Timestamp']>;
+};
+
+export type LaunchSequenceInitiatedStep = {
+  __typename?: 'LaunchSequenceInitiatedStep';
+  startedAt?: Maybe<Scalars['Timestamp']>;
+};
+
+export type LaunchSequencePublishStep = {
+  __typename?: 'LaunchSequencePublishStep';
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  startedAt?: Maybe<Scalars['Timestamp']>;
+};
+
+export type LaunchSequenceSupersededStep = {
+  __typename?: 'LaunchSequenceSupersededStep';
+  completedAt?: Maybe<Scalars['Timestamp']>;
+};
+
+/** more result types will be supported in the future */
+export type LaunchResult = ChangelogLaunchResult;
+
+export type ChangelogLaunchResult = {
+  __typename?: 'ChangelogLaunchResult';
+  createdAt: Scalars['Timestamp'];
+  schemaTagID: Scalars['ID'];
+};
+
+export enum LaunchStatus {
+  LaunchCompleted = 'LAUNCH_COMPLETED',
+  LaunchFailed = 'LAUNCH_FAILED',
+  LaunchInitiated = 'LAUNCH_INITIATED'
+}
+
+export type SubgraphChange = {
+  __typename?: 'SubgraphChange';
+  name: Scalars['ID'];
+  type: SubgraphChangeType;
+};
+
+export enum SubgraphChangeType {
+  Addition = 'ADDITION',
+  Deletion = 'DELETION',
+  Modification = 'MODIFICATION'
+}
+
+export type LinkInfo = {
+  __typename?: 'LinkInfo';
+  createdAt: Scalars['Timestamp'];
+  id: Scalars['ID'];
+  title?: Maybe<Scalars['String']>;
+  type: LinkInfoType;
+  url: Scalars['String'];
+};
+
+export enum LinkInfoType {
+  DeveloperPortal = 'DEVELOPER_PORTAL',
+  Other = 'OTHER',
+  Repository = 'REPOSITORY'
+}
+
+/** A map from permission String to boolean that the current user is allowed for the root graph variant */
+export type GraphVariantPermissions = {
+  __typename?: 'GraphVariantPermissions';
+  canManageBuildConfig: Scalars['Boolean'];
+  canManageExplorerSettings: Scalars['Boolean'];
+  canPushSchemas: Scalars['Boolean'];
+  canQueryBuildConfig: Scalars['Boolean'];
+  /**
+   * Whether the current user can access the schema for this variant. This will be anded with
+   * the ServiceRoles.canQuerySchemas, this will be true when the service schema permission is
+   * false for Services with public variants
+   */
+  canQuerySchemas: Scalars['Boolean'];
+  canUpdateVariantLinkInfo: Scalars['Boolean'];
+  canUpdateVariantReadme: Scalars['Boolean'];
+};
+
+export type Readme = {
+  __typename?: 'Readme';
+  content: Scalars['String'];
+  id: Scalars['ID'];
+  lastUpdatedAt: Scalars['Timestamp'];
+  lastUpdatedBy?: Maybe<Identity>;
+};
+
+/** Support for a single directive on a graph variant */
+export type DirectiveSupportStatus = {
+  __typename?: 'DirectiveSupportStatus';
+  /** whether the directive is supported on the current graph variant */
+  enabled: Scalars['Boolean'];
+  /** name of the directive */
+  name: Scalars['String'];
+};
+
+export enum CheckWorkflowStatus {
+  Failed = 'FAILED',
+  Passed = 'PASSED',
+  Pending = 'PENDING'
+}
+
+export type CheckWorkflowTask = {
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  createdAt: Scalars['Timestamp'];
+  id: Scalars['ID'];
+  status: CheckWorkflowTaskStatus;
+  /** The workflow that this task belongs to. */
+  workflow: CheckWorkflow;
+};
+
+export enum CheckWorkflowTaskStatus {
+  Blocked = 'BLOCKED',
+  Failed = 'FAILED',
+  Passed = 'PASSED',
+  Pending = 'PENDING'
+}
+
+export type DatadogMetricsConfig = {
+  __typename?: 'DatadogMetricsConfig';
+  apiKey: Scalars['String'];
+  apiRegion: DatadogApiRegion;
+  enabled: Scalars['Boolean'];
+  legacyMetricNames: Scalars['Boolean'];
+};
+
+export enum DatadogApiRegion {
+  Eu = 'EU',
+  Us = 'US'
+}
+
+export type User = Identity & {
+  __typename?: 'User';
+  acceptedPrivacyPolicyAt?: Maybe<Scalars['Timestamp']>;
+  /** @deprecated Replaced with User.memberships.account */
+  accounts: Array<Account>;
+  apiKeys: Array<UserApiKey>;
+  asActor: Actor;
+  /**
+   * Get an URL to which an avatar image can be uploaded. Client uploads by sending a PUT request
+   * with the image data to MediaUploadInfo.url. Client SHOULD set the "Content-Type" header to the
+   * browser-inferred MIME type, and SHOULD set the "x-apollo-content-filename" header to the
+   * filename, if such information is available. Client MUST set the "x-apollo-csrf-token" header to
+   * MediaUploadInfo.csrfToken.
+   */
+  avatarUpload?: Maybe<AvatarUploadResult>;
+  /**
+   * Get an image URL for the user's avatar. Note that CORS is not enabled for these URLs. The size
+   * argument is used for bandwidth reduction, and should be the size of the image as displayed in the
+   * application. Apollo's media server will downscale larger images to at least the requested size,
+   * but this will not happen for third-party media servers.
+   */
+  avatarUrl?: Maybe<Scalars['String']>;
+  betaFeaturesOn: Scalars['Boolean'];
+  canUpdateAvatar: Scalars['Boolean'];
+  canUpdateEmail: Scalars['Boolean'];
+  canUpdateFullName: Scalars['Boolean'];
+  createdAt: Scalars['Timestamp'];
+  email?: Maybe<Scalars['String']>;
+  emailModifiedAt?: Maybe<Scalars['Timestamp']>;
+  emailVerified: Scalars['Boolean'];
+  experimentalFeatures: UserExperimentalFeatures;
+  featureIntros?: Maybe<FeatureIntros>;
+  fullName: Scalars['String'];
+  /** The user's GitHub username, if they log in via GitHub. May be null even for GitHub users in some edge cases. */
+  githubUsername?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  /**
+   * This role is reserved exclusively for internal MDG employees, and it controls what access they may have to other
+   * organizations. Only admins are allowed to see this field.
+   */
+  internalAdminRole?: Maybe<InternalMdgAdminRole>;
+  /** Last time any API token from this user was used against AGM services */
+  lastAuthenticatedAt?: Maybe<Scalars['Timestamp']>;
+  logoutAfterIdleMs?: Maybe<Scalars['Int']>;
+  memberships: Array<UserMembership>;
+  name: Scalars['String'];
+  odysseyCourses: Array<OdysseyCourse>;
+  odysseyTasks: Array<OdysseyTask>;
+  synchronized: Scalars['Boolean'];
+  /** List of Zendesk tickets this user has submitted */
+  tickets?: Maybe<Array<ZendeskTicket>>;
+  type: UserType;
+};
+
+
+export type UserApiKeysArgs = {
+  includeCookies?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type UserAvatarUrlArgs = {
+  size?: Scalars['Int'];
+};
+
+export type UserApiKey = ApiKey & {
+  __typename?: 'UserApiKey';
+  id: Scalars['ID'];
+  keyName?: Maybe<Scalars['String']>;
+  token: Scalars['String'];
+};
+
+export type UserExperimentalFeatures = {
+  __typename?: 'UserExperimentalFeatures';
+  exampleFeature: Scalars['Boolean'];
+};
+
+export type FeatureIntros = {
+  __typename?: 'FeatureIntros';
+  devGraph: Scalars['Boolean'];
+  federatedGraph: Scalars['Boolean'];
+  freeConsumerSeats: Scalars['Boolean'];
+};
+
+export enum InternalMdgAdminRole {
+  InternalMdgReadOnly = 'INTERNAL_MDG_READ_ONLY',
+  InternalMdgSales = 'INTERNAL_MDG_SALES',
+  InternalMdgSuperAdmin = 'INTERNAL_MDG_SUPER_ADMIN',
+  InternalMdgSupport = 'INTERNAL_MDG_SUPPORT'
+}
+
+export type UserMembership = {
+  __typename?: 'UserMembership';
+  account: Account;
+  createdAt: Scalars['Timestamp'];
+  permission: UserPermission;
+  user: User;
+};
+
+export type OdysseyCourse = {
+  __typename?: 'OdysseyCourse';
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  enrolledAt?: Maybe<Scalars['Timestamp']>;
+  id: Scalars['ID'];
+};
+
+export type OdysseyTask = {
+  __typename?: 'OdysseyTask';
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  id: Scalars['ID'];
+  value?: Maybe<Scalars['String']>;
+};
+
+export type ZendeskTicket = {
+  __typename?: 'ZendeskTicket';
+  createdAt: Scalars['Timestamp'];
+  description: Scalars['String'];
+  graph?: Maybe<Service>;
+  id: Scalars['Int'];
+  organization?: Maybe<Account>;
+  priority: TicketPriority;
+  status?: Maybe<TicketStatus>;
+  subject: Scalars['String'];
+  user?: Maybe<User>;
+};
+
+export enum TicketPriority {
+  P0 = 'P0',
+  P1 = 'P1',
+  P2 = 'P2',
+  P3 = 'P3'
+}
+
+export enum TicketStatus {
+  Closed = 'CLOSED',
+  Hold = 'HOLD',
+  New = 'NEW',
+  Open = 'OPEN',
+  Pending = 'PENDING',
+  Solved = 'SOLVED'
+}
+
+export enum UserType {
+  Apollo = 'APOLLO',
+  Github = 'GITHUB',
+  Sso = 'SSO'
+}
+
+/** A union of all combinations that can comprise the implementingServices for a Service */
+export type GraphImplementors = FederatedImplementingServices | NonFederatedImplementingService;
+
+/** List of federated implementing services that compose a graph */
+export type FederatedImplementingServices = {
+  __typename?: 'FederatedImplementingServices';
+  services: Array<FederatedImplementingService>;
+};
+
+export type FederatedImplementingService = {
+  __typename?: 'FederatedImplementingService';
+  /**
+   * An implementing service could have multiple inactive partial schemas that were previously uploaded
+   * activePartialSchema returns the one that is designated to be used for composition for a given graph-variant
+   */
+  activePartialSchema: PartialSchema;
+  /** Timestamp of when this implementing service was created */
+  createdAt: Scalars['Timestamp'];
+  /**
+   * Identifies which graph this implementing service belongs to.
+   * Formerly known as "service_id"
+   */
+  graphID: Scalars['String'];
+  /**
+   * Specifies which variant of a graph this implementing service belongs to".
+   * Formerly known as "tag"
+   */
+  graphVariant: Scalars['String'];
+  /** Name of the implementing service */
+  name: Scalars['String'];
+  /**
+   * A way to capture some customer-specific way of tracking which version / edition
+   * of the ImplementingService this is. Typically a Git SHA or docker image ID.
+   */
+  revision: Scalars['String'];
+  /** Timestamp for when this implementing service was updated */
+  updatedAt: Scalars['Timestamp'];
+  /** URL of the graphql endpoint of the implementing service */
+  url?: Maybe<Scalars['String']>;
+};
+
+/** Schema for an implementing service with associated metadata */
+export type PartialSchema = {
+  __typename?: 'PartialSchema';
+  /** Timestamp for when the partial schema was created */
+  createdAt: Scalars['Timestamp'];
+  /** If this sdl is currently actively composed in the gateway, this is true */
+  isLive: Scalars['Boolean'];
+  /** The enriched sdl of a partial schema */
+  sdl: Scalars['String'];
+  /** The path of deep storage to find the raw enriched partial schema file */
+  sdlPath: Scalars['String'];
+};
+
+/** A non-federated service for a monolithic graph */
+export type NonFederatedImplementingService = {
+  __typename?: 'NonFederatedImplementingService';
+  /** Timestamp of when this implementing service was created */
+  createdAt: Scalars['Timestamp'];
+  /**
+   * Identifies which graph this non-implementing service belongs to.
+   * Formerly known as "service_id"
+   */
+  graphID: Scalars['String'];
+  /**
+   * Specifies which variant of a graph this implementing service belongs to".
+   * Formerly known as "tag"
+   */
+  graphVariant: Scalars['String'];
+};
+
+/** Metadata about the result of composition run in the cloud */
+export type CompositionPublishResult = CompositionResult & {
+  __typename?: 'CompositionPublishResult';
+  /** The produced composition config. Will be null if there are any errors */
+  compositionConfig?: Maybe<CompositionConfig>;
+  /**
+   * Supergraph SDL generated by composition (this is not the CSDL, that is a deprecated format).
+   * @deprecated Use supergraphSdl instead
+   */
+  csdl?: Maybe<Scalars['GraphQLDocument']>;
+  /**
+   * List of errors during composition. Errors mean that Apollo was unable to compose the
+   * graph's implementing services into a GraphQL schema. This partial schema should not be
+   * published to the implementing service if there were any errors encountered
+   */
+  errors: Array<SchemaCompositionError>;
+  /** ID that points to the results of this composition. */
+  graphCompositionID: Scalars['ID'];
+  /** List of subgraphs that are included in this composition. */
+  subgraphConfigs: Array<SubgraphConfig>;
+  /** Supergraph SDL generated by composition. */
+  supergraphSdl?: Maybe<Scalars['GraphQLDocument']>;
+  /** Whether the gateway link was updated. */
+  updatedGateway: Scalars['Boolean'];
+  webhookNotificationBody?: Maybe<Scalars['String']>;
+};
+
+/** The composition config exposed to the gateway */
+export type CompositionConfig = {
+  __typename?: 'CompositionConfig';
+  /**
+   * List of GCS links for implementing services that comprise a composed graph
+   * @deprecated Soon we will stop writing to GCS locations
+   */
+  implementingServiceLocations: Array<ImplementingServiceLocation>;
+  /** Hash of the composed schema */
+  schemaHash: Scalars['String'];
+};
+
+/** The location of the implementing service config file in storage */
+export type ImplementingServiceLocation = {
+  __typename?: 'ImplementingServiceLocation';
+  /** The name of the implementing service */
+  name: Scalars['String'];
+  /** The path in storage to access the implementing service config file */
+  path: Scalars['String'];
+};
+
+export type Operation = {
+  __typename?: 'Operation';
+  id: Scalars['ID'];
+  name?: Maybe<Scalars['String']>;
+  signature?: Maybe<Scalars['String']>;
+  truncated: Scalars['Boolean'];
+};
+
+export type OperationAcceptedChange = {
+  __typename?: 'OperationAcceptedChange';
+  acceptedAt: Scalars['Timestamp'];
+  acceptedBy: Identity;
+  change: StoredApprovedChange;
+  checkID: Scalars['ID'];
+  graphID: Scalars['ID'];
+  id: Scalars['ID'];
+  operationID: Scalars['String'];
+};
+
+export type StoredApprovedChange = {
+  __typename?: 'StoredApprovedChange';
+  argNode?: Maybe<NamedIntrospectionArgNoDescription>;
+  childNode?: Maybe<NamedIntrospectionValueNoDescription>;
+  code: ChangeCode;
+  parentNode?: Maybe<NamedIntrospectionTypeNoDescription>;
+};
+
+export type NamedIntrospectionArgNoDescription = {
+  __typename?: 'NamedIntrospectionArgNoDescription';
+  name?: Maybe<Scalars['String']>;
+};
+
+export type NamedIntrospectionValueNoDescription = {
+  __typename?: 'NamedIntrospectionValueNoDescription';
+  name?: Maybe<Scalars['String']>;
+  printedType?: Maybe<Scalars['String']>;
+};
+
+export type NamedIntrospectionTypeNoDescription = {
+  __typename?: 'NamedIntrospectionTypeNoDescription';
+  name?: Maybe<Scalars['String']>;
+};
+
+export type OperationsCheckResult = {
+  __typename?: 'OperationsCheckResult';
+  /** Operations affected by all changes in diff */
+  affectedQueries?: Maybe<Array<AffectedQuery>>;
+  /** List of schema changes with associated affected clients and operations */
+  changes: Array<Change>;
+  /** Summary/counts for all changes in diff */
+  changeSummary: ChangeSummary;
+  /** The variant that was used as a base to check against */
+  checkedVariant: GraphVariant;
+  /** Indication of the success of the change, either failure, warning, or notice. */
+  checkSeverity: ChangeSeverity;
+  createdAt: Scalars['Timestamp'];
+  id: Scalars['ID'];
+  /** Number of affected query operations that are neither marked as SAFE or IGNORED */
+  numberOfAffectedOperations: Scalars['Int'];
+  /** Number of operations that were validated during schema diff */
+  numberOfCheckedOperations: Scalars['Int'];
+  workflowTask: OperationsCheckTask;
+};
+
+export type OperationsCheckTask = CheckWorkflowTask & {
+  __typename?: 'OperationsCheckTask';
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  createdAt: Scalars['Timestamp'];
+  id: Scalars['ID'];
+  /** The result of the check. */
+  result?: Maybe<OperationsCheckResult>;
+  status: CheckWorkflowTaskStatus;
+  workflow: CheckWorkflow;
+};
+
+/** Query Trigger */
+export type QueryTrigger = ChannelSubscription & {
+  __typename?: 'QueryTrigger';
+  channels: Array<Channel>;
+  comparisonOperator: ComparisonOperator;
+  enabled: Scalars['Boolean'];
+  excludedOperationNames: Array<Scalars['String']>;
+  id: Scalars['ID'];
+  metric: QueryTriggerMetric;
+  operationNames: Array<Scalars['String']>;
+  percentile?: Maybe<Scalars['Float']>;
+  scope: QueryTriggerScope;
+  serviceId: Scalars['String'];
+  state: QueryTriggerState;
+  threshold: Scalars['Float'];
+  variant?: Maybe<Scalars['String']>;
+  window: QueryTriggerWindow;
+};
+
+export enum ComparisonOperator {
+  Equals = 'EQUALS',
+  GreaterThan = 'GREATER_THAN',
+  GreaterThanOrEqualTo = 'GREATER_THAN_OR_EQUAL_TO',
+  LessThan = 'LESS_THAN',
+  LessThanOrEqualTo = 'LESS_THAN_OR_EQUAL_TO',
+  NotEquals = 'NOT_EQUALS',
+  Unrecognized = 'UNRECOGNIZED'
+}
+
+export enum QueryTriggerMetric {
+  /** Number of requests within the window that resulted in an error. Ignores `percentile`. */
+  ErrorCount = 'ERROR_COUNT',
+  /** Number of error requests divided by total number of requests. Ignores `percentile`. */
+  ErrorPercentage = 'ERROR_PERCENTAGE',
+  /** Number of requests within the window. Ignores `percentile`. */
+  RequestCount = 'REQUEST_COUNT',
+  /** Request latency in ms. Requires `percentile`. */
+  RequestServiceTime = 'REQUEST_SERVICE_TIME'
+}
+
+export enum QueryTriggerScope {
+  All = 'ALL',
+  Any = 'ANY',
+  Unrecognized = 'UNRECOGNIZED'
+}
+
+/** Query trigger state */
+export type QueryTriggerState = {
+  __typename?: 'QueryTriggerState';
+  evaluatedAt: Scalars['Timestamp'];
+  lastTriggeredAt?: Maybe<Scalars['Timestamp']>;
+  operations: Array<QueryTriggerStateOperation>;
+  triggered: Scalars['Boolean'];
+};
+
+export type QueryTriggerStateOperation = {
+  __typename?: 'QueryTriggerStateOperation';
+  count: Scalars['Long'];
+  operation: Scalars['String'];
+  triggered: Scalars['Boolean'];
+  value: Scalars['Float'];
+};
+
+export enum QueryTriggerWindow {
+  FifteenMinutes = 'FIFTEEN_MINUTES',
+  FiveMinutes = 'FIVE_MINUTES',
+  OneMinute = 'ONE_MINUTE',
+  Unrecognized = 'UNRECOGNIZED'
+}
+
+export type RoleOverride = {
+  __typename?: 'RoleOverride';
+  graph: Service;
+  lastUpdatedAt: Scalars['Timestamp'];
+  role: UserPermission;
+  user: User;
+};
+
+/** A map from role (permission) String to boolean that the current user is allowed for the root service */
+export type ServiceRoles = {
+  __typename?: 'ServiceRoles';
+  canCheckSchemas: Scalars['Boolean'];
+  canCreateVariants: Scalars['Boolean'];
+  canDelete: Scalars['Boolean'];
+  canManageAccess: Scalars['Boolean'];
+  canManageBuildConfig: Scalars['Boolean'];
+  canManageIntegrations: Scalars['Boolean'];
+  canManageKeys: Scalars['Boolean'];
+  canManageVariants: Scalars['Boolean'];
+  canQueryCheckConfiguration: Scalars['Boolean'];
+  canQueryDeletedImplementingServices: Scalars['Boolean'];
+  canQueryImplementingServices: Scalars['Boolean'];
+  canQueryIntegrations: Scalars['Boolean'];
+  canQueryPrivateInfo: Scalars['Boolean'];
+  canQueryPublicInfo: Scalars['Boolean'];
+  canQueryReadmeAuthor: Scalars['Boolean'];
+  canQueryRoleOverrides: Scalars['Boolean'];
+  canQuerySchemas: Scalars['Boolean'];
+  canQueryStats: Scalars['Boolean'];
+  canQueryTokens: Scalars['Boolean'];
+  canQueryTraces: Scalars['Boolean'];
+  canRegisterOperations: Scalars['Boolean'];
+  canStoreSchemasWithoutVariant: Scalars['Boolean'];
+  canUndelete: Scalars['Boolean'];
+  canUpdateAvatar: Scalars['Boolean'];
+  canUpdateDescription: Scalars['Boolean'];
+  canUpdateTitle: Scalars['Boolean'];
+  /** @deprecated Replaced with canQueryTraces and canQueryStats */
+  canVisualizeStats: Scalars['Boolean'];
+  canWriteCheckConfiguration: Scalars['Boolean'];
+  /** @deprecated Never worked, not replaced */
+  canWriteTraces: Scalars['Boolean'];
+};
+
+export type ScheduledSummary = ChannelSubscription & {
+  __typename?: 'ScheduledSummary';
+  /** @deprecated Use channels list instead */
+  channel?: Maybe<Channel>;
+  channels: Array<Channel>;
+  enabled: Scalars['Boolean'];
+  id: Scalars['ID'];
+  timezone: Scalars['String'];
+  variant: Scalars['String'];
+};
+
+export enum Resolution {
+  R15M = 'R15M',
+  R1D = 'R1D',
+  R1H = 'R1H',
+  R1M = 'R1M',
+  R5M = 'R5M',
+  R6H = 'R6H'
+}
+
+/** A time window with a specified granularity over a given service. */
+export type ServiceStatsWindow = {
+  __typename?: 'ServiceStatsWindow';
+  edgeServerInfos: Array<ServiceEdgeServerInfosRecord>;
+  errorStats: Array<ServiceErrorStatsRecord>;
+  fieldLatencies: Array<ServiceFieldLatenciesRecord>;
+  fieldStats: Array<ServiceFieldStatsRecord>;
+  queryStats: Array<ServiceQueryStatsRecord>;
+  /** From field rounded down to the nearest resolution. */
+  roundedDownFrom: Scalars['Timestamp'];
+  /** To field rounded up to the nearest resolution. */
+  roundedUpTo: Scalars['Timestamp'];
+  tracePathErrorsRefs: Array<ServiceTracePathErrorsRefsRecord>;
+  traceRefs: Array<ServiceTraceRefsRecord>;
+};
+
+
+/** A time window with a specified granularity over a given service. */
+export type ServiceStatsWindowEdgeServerInfosArgs = {
+  filter?: Maybe<ServiceEdgeServerInfosFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<ServiceEdgeServerInfosOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given service. */
+export type ServiceStatsWindowErrorStatsArgs = {
+  filter?: Maybe<ServiceErrorStatsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<ServiceErrorStatsOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given service. */
+export type ServiceStatsWindowFieldLatenciesArgs = {
+  filter?: Maybe<ServiceFieldLatenciesFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<ServiceFieldLatenciesOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given service. */
+export type ServiceStatsWindowFieldStatsArgs = {
+  filter?: Maybe<ServiceFieldStatsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<ServiceFieldStatsOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given service. */
+export type ServiceStatsWindowQueryStatsArgs = {
+  filter?: Maybe<ServiceQueryStatsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<ServiceQueryStatsOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given service. */
+export type ServiceStatsWindowTracePathErrorsRefsArgs = {
+  filter?: Maybe<ServiceTracePathErrorsRefsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<ServiceTracePathErrorsRefsOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given service. */
+export type ServiceStatsWindowTraceRefsArgs = {
+  filter?: Maybe<ServiceTraceRefsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<ServiceTraceRefsOrderBySpec>>;
+};
+
+/** Filter for data in ServiceEdgeServerInfos. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type ServiceEdgeServerInfosFilter = {
+  and?: Maybe<Array<ServiceEdgeServerInfosFilter>>;
+  /** Selects rows whose bootId dimension equals the given value if not null. To query for the null value, use {in: {bootId: [null]}} instead. */
+  bootId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose executableSchemaId dimension equals the given value if not null. To query for the null value, use {in: {executableSchemaId: [null]}} instead. */
+  executableSchemaId?: Maybe<Scalars['ID']>;
+  in?: Maybe<ServiceEdgeServerInfosFilterIn>;
+  /** Selects rows whose libraryVersion dimension equals the given value if not null. To query for the null value, use {in: {libraryVersion: [null]}} instead. */
+  libraryVersion?: Maybe<Scalars['String']>;
+  not?: Maybe<ServiceEdgeServerInfosFilter>;
+  or?: Maybe<Array<ServiceEdgeServerInfosFilter>>;
+  /** Selects rows whose platform dimension equals the given value if not null. To query for the null value, use {in: {platform: [null]}} instead. */
+  platform?: Maybe<Scalars['String']>;
+  /** Selects rows whose runtimeVersion dimension equals the given value if not null. To query for the null value, use {in: {runtimeVersion: [null]}} instead. */
+  runtimeVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serverId dimension equals the given value if not null. To query for the null value, use {in: {serverId: [null]}} instead. */
+  serverId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose userVersion dimension equals the given value if not null. To query for the null value, use {in: {userVersion: [null]}} instead. */
+  userVersion?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in ServiceEdgeServerInfos. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type ServiceEdgeServerInfosFilterIn = {
+  /** Selects rows whose bootId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  bootId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose executableSchemaId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  executableSchemaId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose libraryVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  libraryVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose platform dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  platform?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose runtimeVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  runtimeVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serverId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serverId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose userVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  userVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type ServiceEdgeServerInfosOrderBySpec = {
+  column: ServiceEdgeServerInfosColumn;
+  direction: Ordering;
+};
+
+/** Columns of ServiceEdgeServerInfos. */
+export enum ServiceEdgeServerInfosColumn {
+  BootId = 'BOOT_ID',
+  ExecutableSchemaId = 'EXECUTABLE_SCHEMA_ID',
+  LibraryVersion = 'LIBRARY_VERSION',
+  Platform = 'PLATFORM',
+  RuntimeVersion = 'RUNTIME_VERSION',
+  SchemaTag = 'SCHEMA_TAG',
+  ServerId = 'SERVER_ID',
+  Timestamp = 'TIMESTAMP',
+  UserVersion = 'USER_VERSION'
+}
+
+export enum Ordering {
+  Ascending = 'ASCENDING',
+  Descending = 'DESCENDING'
+}
+
+export type ServiceEdgeServerInfosRecord = {
+  __typename?: 'ServiceEdgeServerInfosRecord';
+  /** Dimensions of ServiceEdgeServerInfos that can be grouped by. */
+  groupBy: ServiceEdgeServerInfosDimensions;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type ServiceEdgeServerInfosDimensions = {
+  __typename?: 'ServiceEdgeServerInfosDimensions';
+  bootId?: Maybe<Scalars['ID']>;
+  executableSchemaId?: Maybe<Scalars['ID']>;
+  libraryVersion?: Maybe<Scalars['String']>;
+  platform?: Maybe<Scalars['String']>;
+  runtimeVersion?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serverId?: Maybe<Scalars['ID']>;
+  userVersion?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in ServiceErrorStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type ServiceErrorStatsFilter = {
+  and?: Maybe<Array<ServiceErrorStatsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  in?: Maybe<ServiceErrorStatsFilterIn>;
+  not?: Maybe<ServiceErrorStatsFilter>;
+  or?: Maybe<Array<ServiceErrorStatsFilter>>;
+  /** Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead. */
+  path?: Maybe<Scalars['String']>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in ServiceErrorStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type ServiceErrorStatsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  path?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type ServiceErrorStatsOrderBySpec = {
+  column: ServiceErrorStatsColumn;
+  direction: Ordering;
+};
+
+/** Columns of ServiceErrorStats. */
+export enum ServiceErrorStatsColumn {
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  ErrorsCount = 'ERRORS_COUNT',
+  Path = 'PATH',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  RequestsWithErrorsCount = 'REQUESTS_WITH_ERRORS_COUNT',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceVersion = 'SERVICE_VERSION',
+  Timestamp = 'TIMESTAMP'
+}
+
+export type ServiceErrorStatsRecord = {
+  __typename?: 'ServiceErrorStatsRecord';
+  /** Dimensions of ServiceErrorStats that can be grouped by. */
+  groupBy: ServiceErrorStatsDimensions;
+  /** Metrics of ServiceErrorStats that can be aggregated over. */
+  metrics: ServiceErrorStatsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type ServiceErrorStatsDimensions = {
+  __typename?: 'ServiceErrorStatsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  path?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+export type ServiceErrorStatsMetrics = {
+  __typename?: 'ServiceErrorStatsMetrics';
+  errorsCount: Scalars['Long'];
+  requestsWithErrorsCount: Scalars['Long'];
+};
+
+/** Filter for data in ServiceFieldLatencies. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type ServiceFieldLatenciesFilter = {
+  and?: Maybe<Array<ServiceFieldLatenciesFilter>>;
+  /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
+  field?: Maybe<Scalars['String']>;
+  in?: Maybe<ServiceFieldLatenciesFilterIn>;
+  not?: Maybe<ServiceFieldLatenciesFilter>;
+  or?: Maybe<Array<ServiceFieldLatenciesFilter>>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in ServiceFieldLatencies. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type ServiceFieldLatenciesFilterIn = {
+  /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type ServiceFieldLatenciesOrderBySpec = {
+  column: ServiceFieldLatenciesColumn;
+  direction: Ordering;
+};
+
+/** Columns of ServiceFieldLatencies. */
+export enum ServiceFieldLatenciesColumn {
+  Field = 'FIELD',
+  FieldHistogram = 'FIELD_HISTOGRAM',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  Timestamp = 'TIMESTAMP'
+}
+
+export type ServiceFieldLatenciesRecord = {
+  __typename?: 'ServiceFieldLatenciesRecord';
+  /** Dimensions of ServiceFieldLatencies that can be grouped by. */
+  groupBy: ServiceFieldLatenciesDimensions;
+  /** Metrics of ServiceFieldLatencies that can be aggregated over. */
+  metrics: ServiceFieldLatenciesMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type ServiceFieldLatenciesDimensions = {
+  __typename?: 'ServiceFieldLatenciesDimensions';
+  field?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+};
+
+export type ServiceFieldLatenciesMetrics = {
+  __typename?: 'ServiceFieldLatenciesMetrics';
+  fieldHistogram: DurationHistogram;
+};
+
+export type DurationHistogram = {
+  __typename?: 'DurationHistogram';
+  averageDurationMs?: Maybe<Scalars['Float']>;
+  buckets: Array<DurationHistogramBucket>;
+  durationMs?: Maybe<Scalars['Float']>;
+  /** Counts per durationBucket, where sequences of zeroes are replaced with the negative of their size */
+  sparseBuckets: Array<Scalars['Long']>;
+  totalCount: Scalars['Long'];
+  totalDurationMs: Scalars['Float'];
+};
+
+
+export type DurationHistogramDurationMsArgs = {
+  percentile: Scalars['Float'];
+};
+
+export type DurationHistogramBucket = {
+  __typename?: 'DurationHistogramBucket';
+  count: Scalars['Long'];
+  index: Scalars['Int'];
+  rangeBeginMs: Scalars['Float'];
+  rangeEndMs: Scalars['Float'];
+};
+
+/** Filter for data in ServiceFieldStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type ServiceFieldStatsFilter = {
+  and?: Maybe<Array<ServiceFieldStatsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
+  field?: Maybe<Scalars['String']>;
+  in?: Maybe<ServiceFieldStatsFilterIn>;
+  not?: Maybe<ServiceFieldStatsFilter>;
+  or?: Maybe<Array<ServiceFieldStatsFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in ServiceFieldStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type ServiceFieldStatsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type ServiceFieldStatsOrderBySpec = {
+  column: ServiceFieldStatsColumn;
+  direction: Ordering;
+};
+
+/** Columns of ServiceFieldStats. */
+export enum ServiceFieldStatsColumn {
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  ErrorsCount = 'ERRORS_COUNT',
+  Field = 'FIELD',
+  FieldHistogram = 'FIELD_HISTOGRAM',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  RequestCount = 'REQUEST_COUNT',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceVersion = 'SERVICE_VERSION',
+  Timestamp = 'TIMESTAMP'
+}
+
+export type ServiceFieldStatsRecord = {
+  __typename?: 'ServiceFieldStatsRecord';
+  /** Dimensions of ServiceFieldStats that can be grouped by. */
+  groupBy: ServiceFieldStatsDimensions;
+  /** Metrics of ServiceFieldStats that can be aggregated over. */
+  metrics: ServiceFieldStatsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type ServiceFieldStatsDimensions = {
+  __typename?: 'ServiceFieldStatsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  field?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+export type ServiceFieldStatsMetrics = {
+  __typename?: 'ServiceFieldStatsMetrics';
+  errorsCount: Scalars['Long'];
+  fieldHistogram: DurationHistogram;
+  requestCount: Scalars['Long'];
+};
+
+/** Filter for data in ServiceQueryStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type ServiceQueryStatsFilter = {
+  and?: Maybe<Array<ServiceQueryStatsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose fromEngineproxy dimension equals the given value if not null. To query for the null value, use {in: {fromEngineproxy: [null]}} instead. */
+  fromEngineproxy?: Maybe<Scalars['String']>;
+  in?: Maybe<ServiceQueryStatsFilterIn>;
+  not?: Maybe<ServiceQueryStatsFilter>;
+  or?: Maybe<Array<ServiceQueryStatsFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in ServiceQueryStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type ServiceQueryStatsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose fromEngineproxy dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  fromEngineproxy?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type ServiceQueryStatsOrderBySpec = {
+  column: ServiceQueryStatsColumn;
+  direction: Ordering;
+};
+
+/** Columns of ServiceQueryStats. */
+export enum ServiceQueryStatsColumn {
+  CacheTtlHistogram = 'CACHE_TTL_HISTOGRAM',
+  CachedHistogram = 'CACHED_HISTOGRAM',
+  CachedRequestsCount = 'CACHED_REQUESTS_COUNT',
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  ForbiddenOperationCount = 'FORBIDDEN_OPERATION_COUNT',
+  FromEngineproxy = 'FROM_ENGINEPROXY',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  RegisteredOperationCount = 'REGISTERED_OPERATION_COUNT',
+  RequestsWithErrorsCount = 'REQUESTS_WITH_ERRORS_COUNT',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceVersion = 'SERVICE_VERSION',
+  Timestamp = 'TIMESTAMP',
+  UncachedHistogram = 'UNCACHED_HISTOGRAM',
+  UncachedRequestsCount = 'UNCACHED_REQUESTS_COUNT'
+}
+
+export type ServiceQueryStatsRecord = {
+  __typename?: 'ServiceQueryStatsRecord';
+  /** Dimensions of ServiceQueryStats that can be grouped by. */
+  groupBy: ServiceQueryStatsDimensions;
+  /** Metrics of ServiceQueryStats that can be aggregated over. */
+  metrics: ServiceQueryStatsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type ServiceQueryStatsDimensions = {
+  __typename?: 'ServiceQueryStatsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  fromEngineproxy?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  querySignature?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+export type ServiceQueryStatsMetrics = {
+  __typename?: 'ServiceQueryStatsMetrics';
+  cachedHistogram: DurationHistogram;
+  cachedRequestsCount: Scalars['Long'];
+  cacheTtlHistogram: DurationHistogram;
+  forbiddenOperationCount: Scalars['Long'];
+  registeredOperationCount: Scalars['Long'];
+  requestsWithErrorsCount: Scalars['Long'];
+  totalLatencyHistogram: DurationHistogram;
+  totalRequestCount: Scalars['Long'];
+  uncachedHistogram: DurationHistogram;
+  uncachedRequestsCount: Scalars['Long'];
+};
+
+/** Filter for data in ServiceTracePathErrorsRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type ServiceTracePathErrorsRefsFilter = {
+  and?: Maybe<Array<ServiceTracePathErrorsRefsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
+  durationBucket?: Maybe<Scalars['Int']>;
+  /** Selects rows whose errorMessage dimension equals the given value if not null. To query for the null value, use {in: {errorMessage: [null]}} instead. */
+  errorMessage?: Maybe<Scalars['String']>;
+  in?: Maybe<ServiceTracePathErrorsRefsFilterIn>;
+  not?: Maybe<ServiceTracePathErrorsRefsFilter>;
+  or?: Maybe<Array<ServiceTracePathErrorsRefsFilter>>;
+  /** Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead. */
+  path?: Maybe<Scalars['String']>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
+  serviceVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose traceHttpStatusCode dimension equals the given value if not null. To query for the null value, use {in: {traceHttpStatusCode: [null]}} instead. */
+  traceHttpStatusCode?: Maybe<Scalars['Int']>;
+  /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
+  traceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in ServiceTracePathErrorsRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type ServiceTracePathErrorsRefsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  durationBucket?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  /** Selects rows whose errorMessage dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  errorMessage?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  path?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose traceHttpStatusCode dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  traceHttpStatusCode?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  traceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+};
+
+export type ServiceTracePathErrorsRefsOrderBySpec = {
+  column: ServiceTracePathErrorsRefsColumn;
+  direction: Ordering;
+};
+
+/** Columns of ServiceTracePathErrorsRefs. */
+export enum ServiceTracePathErrorsRefsColumn {
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  DurationBucket = 'DURATION_BUCKET',
+  ErrorMessage = 'ERROR_MESSAGE',
+  ErrorsCountInPath = 'ERRORS_COUNT_IN_PATH',
+  ErrorsCountInTrace = 'ERRORS_COUNT_IN_TRACE',
+  Path = 'PATH',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceVersion = 'SERVICE_VERSION',
+  Timestamp = 'TIMESTAMP',
+  TraceHttpStatusCode = 'TRACE_HTTP_STATUS_CODE',
+  TraceId = 'TRACE_ID',
+  TraceSizeBytes = 'TRACE_SIZE_BYTES',
+  TraceStartsAt = 'TRACE_STARTS_AT'
+}
+
+export type ServiceTracePathErrorsRefsRecord = {
+  __typename?: 'ServiceTracePathErrorsRefsRecord';
+  /** Dimensions of ServiceTracePathErrorsRefs that can be grouped by. */
+  groupBy: ServiceTracePathErrorsRefsDimensions;
+  /** Metrics of ServiceTracePathErrorsRefs that can be aggregated over. */
+  metrics: ServiceTracePathErrorsRefsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type ServiceTracePathErrorsRefsDimensions = {
+  __typename?: 'ServiceTracePathErrorsRefsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  durationBucket?: Maybe<Scalars['Int']>;
+  errorMessage?: Maybe<Scalars['String']>;
+  path?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceVersion?: Maybe<Scalars['String']>;
+  traceHttpStatusCode?: Maybe<Scalars['Int']>;
+  traceId?: Maybe<Scalars['ID']>;
+  traceStartsAt?: Maybe<Scalars['Timestamp']>;
+};
+
+export type ServiceTracePathErrorsRefsMetrics = {
+  __typename?: 'ServiceTracePathErrorsRefsMetrics';
+  errorsCountInPath: Scalars['Long'];
+  errorsCountInTrace: Scalars['Long'];
+  traceSizeBytes: Scalars['Long'];
+};
+
+/** Filter for data in ServiceTraceRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type ServiceTraceRefsFilter = {
+  and?: Maybe<Array<ServiceTraceRefsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
+  durationBucket?: Maybe<Scalars['Int']>;
+  in?: Maybe<ServiceTraceRefsFilterIn>;
+  not?: Maybe<ServiceTraceRefsFilter>;
+  or?: Maybe<Array<ServiceTraceRefsFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
+  serviceVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
+  traceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in ServiceTraceRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type ServiceTraceRefsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  durationBucket?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  traceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+};
+
+export type ServiceTraceRefsOrderBySpec = {
+  column: ServiceTraceRefsColumn;
+  direction: Ordering;
+};
+
+/** Columns of ServiceTraceRefs. */
+export enum ServiceTraceRefsColumn {
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  DurationBucket = 'DURATION_BUCKET',
+  DurationNs = 'DURATION_NS',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceVersion = 'SERVICE_VERSION',
+  Timestamp = 'TIMESTAMP',
+  TraceId = 'TRACE_ID',
+  TraceSizeBytes = 'TRACE_SIZE_BYTES'
+}
+
+export type ServiceTraceRefsRecord = {
+  __typename?: 'ServiceTraceRefsRecord';
+  /** Dimensions of ServiceTraceRefs that can be grouped by. */
+  groupBy: ServiceTraceRefsDimensions;
+  /** Metrics of ServiceTraceRefs that can be aggregated over. */
+  metrics: ServiceTraceRefsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type ServiceTraceRefsDimensions = {
+  __typename?: 'ServiceTraceRefsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  durationBucket?: Maybe<Scalars['Int']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  querySignature?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceVersion?: Maybe<Scalars['String']>;
+  traceId?: Maybe<Scalars['ID']>;
+};
+
+export type ServiceTraceRefsMetrics = {
+  __typename?: 'ServiceTraceRefsMetrics';
+  durationNs: Scalars['Long'];
+  traceSizeBytes: Scalars['Long'];
+};
+
+export type Trace = {
+  __typename?: 'Trace';
+  cacheMaxAgeMs?: Maybe<Scalars['Float']>;
+  cacheScope?: Maybe<CacheScope>;
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  durationMs: Scalars['Float'];
+  endTime: Scalars['Timestamp'];
+  http?: Maybe<TraceHttp>;
+  id: Scalars['ID'];
+  operationName?: Maybe<Scalars['String']>;
+  protobuf: Protobuf;
+  root: TraceNode;
+  signature: Scalars['String'];
+  signatureId: Scalars['ID'];
+  startTime: Scalars['Timestamp'];
+  variablesJSON: Array<StringToString>;
+};
+
+export enum CacheScope {
+  Private = 'PRIVATE',
+  Public = 'PUBLIC',
+  Unknown = 'UNKNOWN',
+  Unrecognized = 'UNRECOGNIZED'
+}
+
+export type TraceHttp = {
+  __typename?: 'TraceHTTP';
+  host?: Maybe<Scalars['String']>;
+  method: HttpMethod;
+  path?: Maybe<Scalars['String']>;
+  protocol?: Maybe<Scalars['String']>;
+  requestHeaders: Array<StringToString>;
+  responseHeaders: Array<StringToString>;
+  secure: Scalars['Boolean'];
+  statusCode: Scalars['Int'];
+};
+
+export enum HttpMethod {
+  Connect = 'CONNECT',
+  Delete = 'DELETE',
+  Get = 'GET',
+  Head = 'HEAD',
+  Options = 'OPTIONS',
+  Patch = 'PATCH',
+  Post = 'POST',
+  Put = 'PUT',
+  Trace = 'TRACE',
+  Unknown = 'UNKNOWN',
+  Unrecognized = 'UNRECOGNIZED'
+}
+
+export type StringToString = {
+  __typename?: 'StringToString';
+  key: Scalars['String'];
+  value: Scalars['String'];
+};
+
+export type Protobuf = {
+  __typename?: 'Protobuf';
+  json?: Maybe<Scalars['String']>;
+  object?: Maybe<Scalars['Object']>;
+  raw: Scalars['Blob'];
+  text: Scalars['String'];
+};
+
+export type TraceNode = {
+  __typename?: 'TraceNode';
+  cacheMaxAgeMs?: Maybe<Scalars['Float']>;
+  cacheScope?: Maybe<CacheScope>;
+  children: Array<TraceNode>;
+  childrenIds: Array<Scalars['ID']>;
+  descendants: Array<TraceNode>;
+  descendantsIds: Array<Scalars['ID']>;
+  endTime: Scalars['Timestamp'];
+  errors: Array<TraceError>;
+  id: Scalars['ID'];
+  key?: Maybe<Scalars['StringOrInt']>;
+  originalFieldName?: Maybe<Scalars['String']>;
+  parent: Scalars['ID'];
+  parentId?: Maybe<Scalars['ID']>;
+  path: Array<Scalars['String']>;
+  startTime: Scalars['Timestamp'];
+  type?: Maybe<Scalars['String']>;
+};
+
+export type TraceError = {
+  __typename?: 'TraceError';
+  json: Scalars['String'];
+  locations: Array<TraceSourceLocation>;
+  message: Scalars['String'];
+  timestamp?: Maybe<Scalars['Timestamp']>;
+};
+
+export type TraceSourceLocation = {
+  __typename?: 'TraceSourceLocation';
+  column: Scalars['Int'];
+  line: Scalars['Int'];
+};
+
+export enum AuditStatus {
+  Cancelled = 'CANCELLED',
+  Completed = 'COMPLETED',
+  Expired = 'EXPIRED',
+  Failed = 'FAILED',
+  InProgress = 'IN_PROGRESS',
+  Queued = 'QUEUED'
+}
+
+export type BillingInfo = {
+  __typename?: 'BillingInfo';
+  address: BillingAddress;
+  cardType?: Maybe<Scalars['String']>;
+  firstName?: Maybe<Scalars['String']>;
+  lastFour?: Maybe<Scalars['Int']>;
+  lastName?: Maybe<Scalars['String']>;
+  month?: Maybe<Scalars['Int']>;
+  vatNumber?: Maybe<Scalars['String']>;
+  year?: Maybe<Scalars['Int']>;
+};
+
+export type BillingAddress = {
+  __typename?: 'BillingAddress';
+  address1?: Maybe<Scalars['String']>;
+  address2?: Maybe<Scalars['String']>;
+  city?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  state?: Maybe<Scalars['String']>;
+  zip?: Maybe<Scalars['String']>;
+};
+
+export type BillingMonth = {
+  __typename?: 'BillingMonth';
+  end: Scalars['Timestamp'];
+  requests: Scalars['Long'];
+  start: Scalars['Timestamp'];
+};
+
+export type BillingPlan = {
+  __typename?: 'BillingPlan';
+  addons: Array<BillingPlanAddon>;
+  billingModel: BillingModel;
+  billingPeriod?: Maybe<BillingPeriod>;
+  capabilities: BillingPlanCapabilities;
+  description?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  isTrial: Scalars['Boolean'];
+  kind: BillingPlanKind;
+  name: Scalars['String'];
+  /** The price of every seat */
+  pricePerSeatInUsdCents?: Maybe<Scalars['Int']>;
+  /** The price of subscribing to this plan with a quantity of 1 (currently always the case) */
+  pricePerUnitInUsdCents: Scalars['Int'];
+  /** Whether the plan is accessible by all users in QueryRoot.allPlans, QueryRoot.plan, or AccountMutation.setPlan */
+  public: Scalars['Boolean'];
+  tier: BillingPlanTier;
+};
+
+export type BillingPlanAddon = {
+  __typename?: 'BillingPlanAddon';
+  id: Scalars['ID'];
+  pricePerUnitInUsdCents: Scalars['Int'];
+};
+
+export enum BillingModel {
+  RequestBased = 'REQUEST_BASED',
+  SeatBased = 'SEAT_BASED'
+}
+
+export enum BillingPeriod {
+  Monthly = 'MONTHLY',
+  Quarterly = 'QUARTERLY',
+  SemiAnnually = 'SEMI_ANNUALLY',
+  Yearly = 'YEARLY'
+}
+
+export type BillingPlanCapabilities = {
+  __typename?: 'BillingPlanCapabilities';
+  clients: Scalars['Boolean'];
+  contracts: Scalars['Boolean'];
+  datadog: Scalars['Boolean'];
+  errors: Scalars['Boolean'];
+  federation: Scalars['Boolean'];
+  launches: Scalars['Boolean'];
+  maxAuditInDays: Scalars['Int'];
+  maxRangeInDays?: Maybe<Scalars['Int']>;
+  maxRequestsPerMonth?: Maybe<Scalars['Long']>;
+  metrics: Scalars['Boolean'];
+  notifications: Scalars['Boolean'];
+  operationRegistry: Scalars['Boolean'];
+  ranges: Array<Scalars['String']>;
+  schemaValidation: Scalars['Boolean'];
+  traces: Scalars['Boolean'];
+  userRoles: Scalars['Boolean'];
+  webhooks: Scalars['Boolean'];
+};
+
+export enum BillingPlanKind {
+  Community = 'COMMUNITY',
+  EnterpriseInternal = 'ENTERPRISE_INTERNAL',
+  EnterprisePaid = 'ENTERPRISE_PAID',
+  EnterprisePilot = 'ENTERPRISE_PILOT',
+  TeamPaid = 'TEAM_PAID',
+  TeamTrial = 'TEAM_TRIAL'
+}
+
+export enum BillingPlanTier {
+  Community = 'COMMUNITY',
+  Enterprise = 'ENTERPRISE',
+  Team = 'TEAM'
+}
+
+export type BillingSubscription = {
+  __typename?: 'BillingSubscription';
+  activatedAt: Scalars['Timestamp'];
+  addons: Array<BillingSubscriptionAddon>;
+  autoRenew: Scalars['Boolean'];
+  /** The price of the subscription when ignoring add-ons (such as seats), ie quantity * pricePerUnitInUsdCents */
+  basePriceInUsdCents: Scalars['Long'];
+  canceledAt?: Maybe<Scalars['Timestamp']>;
+  currentPeriodEndsAt: Scalars['Timestamp'];
+  currentPeriodStartedAt: Scalars['Timestamp'];
+  expiresAt?: Maybe<Scalars['Timestamp']>;
+  plan: BillingPlan;
+  /** The price of every seat */
+  pricePerSeatInUsdCents?: Maybe<Scalars['Int']>;
+  /** The price of every unit in the subscription (hence multiplied by quantity to get to the basePriceInUsdCents) */
+  pricePerUnitInUsdCents: Scalars['Int'];
+  quantity: Scalars['Int'];
+  /** Total price of the subscription when it next renews, including add-ons (such as seats) */
+  renewalTotalPriceInUsdCents: Scalars['Long'];
+  state: SubscriptionState;
+  /** Total price of the subscription, including add-ons (such as seats) */
+  totalPriceInUsdCents: Scalars['Long'];
+  /**
+   * When this subscription's trial period expires (if it is a trial). Not the same as the
+   * subscription's Recurly expiration).
+   */
+  trialExpiresAt?: Maybe<Scalars['Timestamp']>;
+  uuid: Scalars['ID'];
+};
+
+export type BillingSubscriptionAddon = {
+  __typename?: 'BillingSubscriptionAddon';
+  id: Scalars['ID'];
+  pricePerUnitInUsdCents: Scalars['Int'];
+  quantity: Scalars['Int'];
+};
+
+export enum SubscriptionState {
+  Active = 'ACTIVE',
+  Canceled = 'CANCELED',
+  Expired = 'EXPIRED',
+  Future = 'FUTURE',
+  PastDue = 'PAST_DUE',
+  Paused = 'PAUSED',
+  Pending = 'PENDING',
+  Unknown = 'UNKNOWN'
+}
+
+export type AccountExperimentalFeatures = {
+  __typename?: 'AccountExperimentalFeatures';
+  auditLogs: Scalars['Boolean'];
+  championDashboard: Scalars['Boolean'];
+  contractsPreview: Scalars['Boolean'];
+  launchesPreview: Scalars['Boolean'];
+  preRequestPreview: Scalars['Boolean'];
+  publicVariants: Scalars['Boolean'];
+  sandboxesSchemaCheck: Scalars['Boolean'];
+  variantHomepage: Scalars['Boolean'];
+  webhooksPreview: Scalars['Boolean'];
+};
+
+export type AccountInvitation = {
+  __typename?: 'AccountInvitation';
+  /** An accepted invitation cannot be used anymore */
+  acceptedAt?: Maybe<Scalars['Timestamp']>;
+  /** Who accepted the invitation */
+  acceptedBy?: Maybe<User>;
+  /** Time the invitation was created */
+  createdAt: Scalars['Timestamp'];
+  /** Who created the invitation */
+  createdBy?: Maybe<User>;
+  email: Scalars['String'];
+  id: Scalars['ID'];
+  /** Last time we sent an email for the invitation */
+  lastSentAt?: Maybe<Scalars['Timestamp']>;
+  /** Access role for the invitee */
+  role: UserPermission;
+};
+
+export type Invoice = {
+  __typename?: 'Invoice';
+  closedAt?: Maybe<Scalars['Timestamp']>;
+  collectionMethod?: Maybe<Scalars['String']>;
+  createdAt: Scalars['Timestamp'];
+  invoiceNumber: Scalars['Int'];
+  state: InvoiceState;
+  totalInCents: Scalars['Int'];
+  updatedAt: Scalars['Timestamp'];
+  uuid: Scalars['ID'];
+};
+
+export enum InvoiceState {
+  Collected = 'COLLECTED',
+  Failed = 'FAILED',
+  Open = 'OPEN',
+  PastDue = 'PAST_DUE',
+  Unknown = 'UNKNOWN'
+}
+
+export type AccountMembership = {
+  __typename?: 'AccountMembership';
+  account: Account;
+  createdAt: Scalars['Timestamp'];
+  /** If this membership is a free seat (based on role) */
+  free?: Maybe<Scalars['Boolean']>;
+  permission: UserPermission;
+  user: User;
+};
+
+export type AccountRoles = {
+  __typename?: 'AccountRoles';
+  canAudit: Scalars['Boolean'];
+  canCreateDevGraph: Scalars['Boolean'];
+  canCreateService: Scalars['Boolean'];
+  canDelete: Scalars['Boolean'];
+  /** @deprecated Use canQueryBillingInfo instead */
+  canDownloadInvoice: Scalars['Boolean'];
+  canManageMembers: Scalars['Boolean'];
+  canQuery: Scalars['Boolean'];
+  canQueryBillingInfo: Scalars['Boolean'];
+  /** @deprecated Use canQueryBillingInfo instead */
+  canQueryInvoices: Scalars['Boolean'];
+  canQueryMembers: Scalars['Boolean'];
+  canQueryStats: Scalars['Boolean'];
+  canReadTickets: Scalars['Boolean'];
+  canRemoveMembers: Scalars['Boolean'];
+  canSetConstrainedPlan: Scalars['Boolean'];
+  canUpdateBillingInfo: Scalars['Boolean'];
+  canUpdateMetadata: Scalars['Boolean'];
+};
+
+/** How many seats of the given types does an organization have (regardless of plan type)? */
+export type Seats = {
+  __typename?: 'Seats';
+  /** How many members that are free in this organization. */
+  free: Scalars['Int'];
+  /** How many members that are not free in this organization. */
+  fullPrice: Scalars['Int'];
+};
+
+export type OrganizationSso = {
+  __typename?: 'OrganizationSSO';
+  defaultRole: UserPermission;
+  idpid: Scalars['ID'];
+  provider: OrganizationSsoProvider;
+};
+
+export enum OrganizationSsoProvider {
+  Pingone = 'PINGONE'
+}
+
+export enum AccountState {
+  Active = 'ACTIVE',
+  Closed = 'CLOSED',
+  Unknown = 'UNKNOWN',
+  Unprovisioned = 'UNPROVISIONED'
+}
+
+/** A reusable invite link for an organization. */
+export type OrganizationInviteLink = {
+  __typename?: 'OrganizationInviteLink';
+  createdAt: Scalars['Timestamp'];
+  /** A joinToken that can be passed to Mutation.joinAccount to join the organization. */
+  joinToken: Scalars['String'];
+  /** The role that the user will receive if they join the organization with this link. */
+  role: UserPermission;
+};
+
+/** A time window with a specified granularity over a given account. */
+export type AccountStatsWindow = {
+  __typename?: 'AccountStatsWindow';
+  edgeServerInfos: Array<AccountEdgeServerInfosRecord>;
+  errorStats: Array<AccountErrorStatsRecord>;
+  fieldLatencies: Array<AccountFieldLatenciesRecord>;
+  fieldStats: Array<AccountFieldStatsRecord>;
+  queryStats: Array<AccountQueryStatsRecord>;
+  /** From field rounded down to the nearest resolution. */
+  roundedDownFrom: Scalars['Timestamp'];
+  /** To field rounded up to the nearest resolution. */
+  roundedUpTo: Scalars['Timestamp'];
+  tracePathErrorsRefs: Array<AccountTracePathErrorsRefsRecord>;
+  traceRefs: Array<AccountTraceRefsRecord>;
+};
+
+
+/** A time window with a specified granularity over a given account. */
+export type AccountStatsWindowEdgeServerInfosArgs = {
+  filter?: Maybe<AccountEdgeServerInfosFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<AccountEdgeServerInfosOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given account. */
+export type AccountStatsWindowErrorStatsArgs = {
+  filter?: Maybe<AccountErrorStatsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<AccountErrorStatsOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given account. */
+export type AccountStatsWindowFieldLatenciesArgs = {
+  filter?: Maybe<AccountFieldLatenciesFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<AccountFieldLatenciesOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given account. */
+export type AccountStatsWindowFieldStatsArgs = {
+  filter?: Maybe<AccountFieldStatsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<AccountFieldStatsOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given account. */
+export type AccountStatsWindowQueryStatsArgs = {
+  filter?: Maybe<AccountQueryStatsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<AccountQueryStatsOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given account. */
+export type AccountStatsWindowTracePathErrorsRefsArgs = {
+  filter?: Maybe<AccountTracePathErrorsRefsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<AccountTracePathErrorsRefsOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given account. */
+export type AccountStatsWindowTraceRefsArgs = {
+  filter?: Maybe<AccountTraceRefsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<AccountTraceRefsOrderBySpec>>;
+};
+
+/** Filter for data in AccountEdgeServerInfos. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type AccountEdgeServerInfosFilter = {
+  and?: Maybe<Array<AccountEdgeServerInfosFilter>>;
+  /** Selects rows whose bootId dimension equals the given value if not null. To query for the null value, use {in: {bootId: [null]}} instead. */
+  bootId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose executableSchemaId dimension equals the given value if not null. To query for the null value, use {in: {executableSchemaId: [null]}} instead. */
+  executableSchemaId?: Maybe<Scalars['ID']>;
+  in?: Maybe<AccountEdgeServerInfosFilterIn>;
+  /** Selects rows whose libraryVersion dimension equals the given value if not null. To query for the null value, use {in: {libraryVersion: [null]}} instead. */
+  libraryVersion?: Maybe<Scalars['String']>;
+  not?: Maybe<AccountEdgeServerInfosFilter>;
+  or?: Maybe<Array<AccountEdgeServerInfosFilter>>;
+  /** Selects rows whose platform dimension equals the given value if not null. To query for the null value, use {in: {platform: [null]}} instead. */
+  platform?: Maybe<Scalars['String']>;
+  /** Selects rows whose runtimeVersion dimension equals the given value if not null. To query for the null value, use {in: {runtimeVersion: [null]}} instead. */
+  runtimeVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serverId dimension equals the given value if not null. To query for the null value, use {in: {serverId: [null]}} instead. */
+  serverId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose userVersion dimension equals the given value if not null. To query for the null value, use {in: {userVersion: [null]}} instead. */
+  userVersion?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in AccountEdgeServerInfos. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type AccountEdgeServerInfosFilterIn = {
+  /** Selects rows whose bootId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  bootId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose executableSchemaId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  executableSchemaId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose libraryVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  libraryVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose platform dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  platform?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose runtimeVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  runtimeVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serverId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serverId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose userVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  userVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type AccountEdgeServerInfosOrderBySpec = {
+  column: AccountEdgeServerInfosColumn;
+  direction: Ordering;
+};
+
+/** Columns of AccountEdgeServerInfos. */
+export enum AccountEdgeServerInfosColumn {
+  BootId = 'BOOT_ID',
+  ExecutableSchemaId = 'EXECUTABLE_SCHEMA_ID',
+  LibraryVersion = 'LIBRARY_VERSION',
+  Platform = 'PLATFORM',
+  RuntimeVersion = 'RUNTIME_VERSION',
+  SchemaTag = 'SCHEMA_TAG',
+  ServerId = 'SERVER_ID',
+  ServiceId = 'SERVICE_ID',
+  Timestamp = 'TIMESTAMP',
+  UserVersion = 'USER_VERSION'
+}
+
+export type AccountEdgeServerInfosRecord = {
+  __typename?: 'AccountEdgeServerInfosRecord';
+  /** Dimensions of AccountEdgeServerInfos that can be grouped by. */
+  groupBy: AccountEdgeServerInfosDimensions;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type AccountEdgeServerInfosDimensions = {
+  __typename?: 'AccountEdgeServerInfosDimensions';
+  bootId?: Maybe<Scalars['ID']>;
+  executableSchemaId?: Maybe<Scalars['ID']>;
+  libraryVersion?: Maybe<Scalars['String']>;
+  platform?: Maybe<Scalars['String']>;
+  runtimeVersion?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serverId?: Maybe<Scalars['ID']>;
+  serviceId?: Maybe<Scalars['ID']>;
+  userVersion?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in AccountErrorStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type AccountErrorStatsFilter = {
+  and?: Maybe<Array<AccountErrorStatsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  in?: Maybe<AccountErrorStatsFilterIn>;
+  not?: Maybe<AccountErrorStatsFilter>;
+  or?: Maybe<Array<AccountErrorStatsFilter>>;
+  /** Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead. */
+  path?: Maybe<Scalars['String']>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in AccountErrorStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type AccountErrorStatsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  path?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type AccountErrorStatsOrderBySpec = {
+  column: AccountErrorStatsColumn;
+  direction: Ordering;
+};
+
+/** Columns of AccountErrorStats. */
+export enum AccountErrorStatsColumn {
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  ErrorsCount = 'ERRORS_COUNT',
+  Path = 'PATH',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  RequestsWithErrorsCount = 'REQUESTS_WITH_ERRORS_COUNT',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  ServiceVersion = 'SERVICE_VERSION',
+  Timestamp = 'TIMESTAMP'
+}
+
+export type AccountErrorStatsRecord = {
+  __typename?: 'AccountErrorStatsRecord';
+  /** Dimensions of AccountErrorStats that can be grouped by. */
+  groupBy: AccountErrorStatsDimensions;
+  /** Metrics of AccountErrorStats that can be aggregated over. */
+  metrics: AccountErrorStatsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type AccountErrorStatsDimensions = {
+  __typename?: 'AccountErrorStatsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  path?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+export type AccountErrorStatsMetrics = {
+  __typename?: 'AccountErrorStatsMetrics';
+  errorsCount: Scalars['Long'];
+  requestsWithErrorsCount: Scalars['Long'];
+};
+
+/** Filter for data in AccountFieldLatencies. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type AccountFieldLatenciesFilter = {
+  and?: Maybe<Array<AccountFieldLatenciesFilter>>;
+  /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
+  field?: Maybe<Scalars['String']>;
+  in?: Maybe<AccountFieldLatenciesFilterIn>;
+  not?: Maybe<AccountFieldLatenciesFilter>;
+  or?: Maybe<Array<AccountFieldLatenciesFilter>>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in AccountFieldLatencies. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type AccountFieldLatenciesFilterIn = {
+  /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+};
+
+export type AccountFieldLatenciesOrderBySpec = {
+  column: AccountFieldLatenciesColumn;
+  direction: Ordering;
+};
+
+/** Columns of AccountFieldLatencies. */
+export enum AccountFieldLatenciesColumn {
+  Field = 'FIELD',
+  FieldHistogram = 'FIELD_HISTOGRAM',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  Timestamp = 'TIMESTAMP'
+}
+
+export type AccountFieldLatenciesRecord = {
+  __typename?: 'AccountFieldLatenciesRecord';
+  /** Dimensions of AccountFieldLatencies that can be grouped by. */
+  groupBy: AccountFieldLatenciesDimensions;
+  /** Metrics of AccountFieldLatencies that can be aggregated over. */
+  metrics: AccountFieldLatenciesMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type AccountFieldLatenciesDimensions = {
+  __typename?: 'AccountFieldLatenciesDimensions';
+  field?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+export type AccountFieldLatenciesMetrics = {
+  __typename?: 'AccountFieldLatenciesMetrics';
+  fieldHistogram: DurationHistogram;
+};
+
+/** Filter for data in AccountFieldStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type AccountFieldStatsFilter = {
+  and?: Maybe<Array<AccountFieldStatsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
+  field?: Maybe<Scalars['String']>;
+  in?: Maybe<AccountFieldStatsFilterIn>;
+  not?: Maybe<AccountFieldStatsFilter>;
+  or?: Maybe<Array<AccountFieldStatsFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in AccountFieldStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type AccountFieldStatsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type AccountFieldStatsOrderBySpec = {
+  column: AccountFieldStatsColumn;
+  direction: Ordering;
+};
+
+/** Columns of AccountFieldStats. */
+export enum AccountFieldStatsColumn {
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  ErrorsCount = 'ERRORS_COUNT',
+  Field = 'FIELD',
+  FieldHistogram = 'FIELD_HISTOGRAM',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  RequestCount = 'REQUEST_COUNT',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  ServiceVersion = 'SERVICE_VERSION',
+  Timestamp = 'TIMESTAMP'
+}
+
+export type AccountFieldStatsRecord = {
+  __typename?: 'AccountFieldStatsRecord';
+  /** Dimensions of AccountFieldStats that can be grouped by. */
+  groupBy: AccountFieldStatsDimensions;
+  /** Metrics of AccountFieldStats that can be aggregated over. */
+  metrics: AccountFieldStatsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type AccountFieldStatsDimensions = {
+  __typename?: 'AccountFieldStatsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  field?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+export type AccountFieldStatsMetrics = {
+  __typename?: 'AccountFieldStatsMetrics';
+  errorsCount: Scalars['Long'];
+  fieldHistogram: DurationHistogram;
+  requestCount: Scalars['Long'];
+};
+
+/** Filter for data in AccountQueryStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type AccountQueryStatsFilter = {
+  and?: Maybe<Array<AccountQueryStatsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose fromEngineproxy dimension equals the given value if not null. To query for the null value, use {in: {fromEngineproxy: [null]}} instead. */
+  fromEngineproxy?: Maybe<Scalars['String']>;
+  in?: Maybe<AccountQueryStatsFilterIn>;
+  not?: Maybe<AccountQueryStatsFilter>;
+  or?: Maybe<Array<AccountQueryStatsFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in AccountQueryStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type AccountQueryStatsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose fromEngineproxy dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  fromEngineproxy?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type AccountQueryStatsOrderBySpec = {
+  column: AccountQueryStatsColumn;
+  direction: Ordering;
+};
+
+/** Columns of AccountQueryStats. */
+export enum AccountQueryStatsColumn {
+  CacheTtlHistogram = 'CACHE_TTL_HISTOGRAM',
+  CachedHistogram = 'CACHED_HISTOGRAM',
+  CachedRequestsCount = 'CACHED_REQUESTS_COUNT',
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  ForbiddenOperationCount = 'FORBIDDEN_OPERATION_COUNT',
+  FromEngineproxy = 'FROM_ENGINEPROXY',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  RegisteredOperationCount = 'REGISTERED_OPERATION_COUNT',
+  RequestsWithErrorsCount = 'REQUESTS_WITH_ERRORS_COUNT',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  ServiceVersion = 'SERVICE_VERSION',
+  Timestamp = 'TIMESTAMP',
+  UncachedHistogram = 'UNCACHED_HISTOGRAM',
+  UncachedRequestsCount = 'UNCACHED_REQUESTS_COUNT'
+}
+
+export type AccountQueryStatsRecord = {
+  __typename?: 'AccountQueryStatsRecord';
+  /** Dimensions of AccountQueryStats that can be grouped by. */
+  groupBy: AccountQueryStatsDimensions;
+  /** Metrics of AccountQueryStats that can be aggregated over. */
+  metrics: AccountQueryStatsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type AccountQueryStatsDimensions = {
+  __typename?: 'AccountQueryStatsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  fromEngineproxy?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  querySignature?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+export type AccountQueryStatsMetrics = {
+  __typename?: 'AccountQueryStatsMetrics';
+  cachedHistogram: DurationHistogram;
+  cachedRequestsCount: Scalars['Long'];
+  cacheTtlHistogram: DurationHistogram;
+  forbiddenOperationCount: Scalars['Long'];
+  registeredOperationCount: Scalars['Long'];
+  requestsWithErrorsCount: Scalars['Long'];
+  totalLatencyHistogram: DurationHistogram;
+  totalRequestCount: Scalars['Long'];
+  uncachedHistogram: DurationHistogram;
+  uncachedRequestsCount: Scalars['Long'];
+};
+
+/** Filter for data in AccountTracePathErrorsRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type AccountTracePathErrorsRefsFilter = {
+  and?: Maybe<Array<AccountTracePathErrorsRefsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
+  durationBucket?: Maybe<Scalars['Int']>;
+  /** Selects rows whose errorMessage dimension equals the given value if not null. To query for the null value, use {in: {errorMessage: [null]}} instead. */
+  errorMessage?: Maybe<Scalars['String']>;
+  in?: Maybe<AccountTracePathErrorsRefsFilterIn>;
+  not?: Maybe<AccountTracePathErrorsRefsFilter>;
+  or?: Maybe<Array<AccountTracePathErrorsRefsFilter>>;
+  /** Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead. */
+  path?: Maybe<Scalars['String']>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
+  serviceVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose traceHttpStatusCode dimension equals the given value if not null. To query for the null value, use {in: {traceHttpStatusCode: [null]}} instead. */
+  traceHttpStatusCode?: Maybe<Scalars['Int']>;
+  /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
+  traceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in AccountTracePathErrorsRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type AccountTracePathErrorsRefsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  durationBucket?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  /** Selects rows whose errorMessage dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  errorMessage?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  path?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose traceHttpStatusCode dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  traceHttpStatusCode?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  traceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+};
+
+export type AccountTracePathErrorsRefsOrderBySpec = {
+  column: AccountTracePathErrorsRefsColumn;
+  direction: Ordering;
+};
+
+/** Columns of AccountTracePathErrorsRefs. */
+export enum AccountTracePathErrorsRefsColumn {
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  DurationBucket = 'DURATION_BUCKET',
+  ErrorMessage = 'ERROR_MESSAGE',
+  ErrorsCountInPath = 'ERRORS_COUNT_IN_PATH',
+  ErrorsCountInTrace = 'ERRORS_COUNT_IN_TRACE',
+  Path = 'PATH',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  ServiceVersion = 'SERVICE_VERSION',
+  Timestamp = 'TIMESTAMP',
+  TraceHttpStatusCode = 'TRACE_HTTP_STATUS_CODE',
+  TraceId = 'TRACE_ID',
+  TraceSizeBytes = 'TRACE_SIZE_BYTES',
+  TraceStartsAt = 'TRACE_STARTS_AT'
+}
+
+export type AccountTracePathErrorsRefsRecord = {
+  __typename?: 'AccountTracePathErrorsRefsRecord';
+  /** Dimensions of AccountTracePathErrorsRefs that can be grouped by. */
+  groupBy: AccountTracePathErrorsRefsDimensions;
+  /** Metrics of AccountTracePathErrorsRefs that can be aggregated over. */
+  metrics: AccountTracePathErrorsRefsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type AccountTracePathErrorsRefsDimensions = {
+  __typename?: 'AccountTracePathErrorsRefsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  durationBucket?: Maybe<Scalars['Int']>;
+  errorMessage?: Maybe<Scalars['String']>;
+  path?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+  serviceVersion?: Maybe<Scalars['String']>;
+  traceHttpStatusCode?: Maybe<Scalars['Int']>;
+  traceId?: Maybe<Scalars['ID']>;
+  traceStartsAt?: Maybe<Scalars['Timestamp']>;
+};
+
+export type AccountTracePathErrorsRefsMetrics = {
+  __typename?: 'AccountTracePathErrorsRefsMetrics';
+  errorsCountInPath: Scalars['Long'];
+  errorsCountInTrace: Scalars['Long'];
+  traceSizeBytes: Scalars['Long'];
+};
+
+/** Filter for data in AccountTraceRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type AccountTraceRefsFilter = {
+  and?: Maybe<Array<AccountTraceRefsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
+  durationBucket?: Maybe<Scalars['Int']>;
+  in?: Maybe<AccountTraceRefsFilterIn>;
+  not?: Maybe<AccountTraceRefsFilter>;
+  or?: Maybe<Array<AccountTraceRefsFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
+  serviceVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
+  traceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in AccountTraceRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type AccountTraceRefsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  durationBucket?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  traceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+};
+
+export type AccountTraceRefsOrderBySpec = {
+  column: AccountTraceRefsColumn;
+  direction: Ordering;
+};
+
+/** Columns of AccountTraceRefs. */
+export enum AccountTraceRefsColumn {
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  DurationBucket = 'DURATION_BUCKET',
+  DurationNs = 'DURATION_NS',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  ServiceVersion = 'SERVICE_VERSION',
+  Timestamp = 'TIMESTAMP',
+  TraceId = 'TRACE_ID',
+  TraceSizeBytes = 'TRACE_SIZE_BYTES'
+}
+
+export type AccountTraceRefsRecord = {
+  __typename?: 'AccountTraceRefsRecord';
+  /** Dimensions of AccountTraceRefs that can be grouped by. */
+  groupBy: AccountTraceRefsDimensions;
+  /** Metrics of AccountTraceRefs that can be aggregated over. */
+  metrics: AccountTraceRefsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type AccountTraceRefsDimensions = {
+  __typename?: 'AccountTraceRefsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  durationBucket?: Maybe<Scalars['Int']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  querySignature?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+  serviceVersion?: Maybe<Scalars['String']>;
+  traceId?: Maybe<Scalars['ID']>;
+};
+
+export type AccountTraceRefsMetrics = {
+  __typename?: 'AccountTraceRefsMetrics';
+  durationNs: Scalars['Long'];
+  traceSizeBytes: Scalars['Long'];
+};
+
+export type TimezoneOffset = {
+  __typename?: 'TimezoneOffset';
+  minutesOffsetFromUTC: Scalars['Int'];
+  zoneID: Scalars['String'];
+};
+
+export type EmailPreferences = {
+  __typename?: 'EmailPreferences';
+  email: Scalars['String'];
+  subscriptions: Array<EmailCategory>;
+  unsubscribedFromAll: Scalars['Boolean'];
+};
+
+export enum EmailCategory {
+  Educational = 'EDUCATIONAL'
+}
+
+export type GlobalExperimentalFeatures = {
+  __typename?: 'GlobalExperimentalFeatures';
+  sandboxesFullRelease: Scalars['Boolean'];
+  sandboxesPreview: Scalars['Boolean'];
+};
+
+export type CronJob = {
+  __typename?: 'CronJob';
+  group: Scalars['String'];
+  name: Scalars['String'];
+  recentExecutions: Array<CronExecution>;
+};
+
+
+export type CronJobRecentExecutionsArgs = {
+  n?: Maybe<Scalars['Int']>;
+};
+
+export type CronExecution = {
+  __typename?: 'CronExecution';
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  failure?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  job: CronJob;
+  resolvedAt?: Maybe<Scalars['Timestamp']>;
+  resolvedBy?: Maybe<Actor>;
+  schedule: Scalars['String'];
+  startedAt: Scalars['Timestamp'];
+};
+
+export type InternalAdminUser = {
+  __typename?: 'InternalAdminUser';
+  role: InternalMdgAdminRole;
+  userID: Scalars['String'];
+};
+
+/** A time window with a specified granularity. */
+export type StatsWindow = {
+  __typename?: 'StatsWindow';
+  edgeServerInfos: Array<EdgeServerInfosRecord>;
+  errorStats: Array<ErrorStatsRecord>;
+  fieldLatencies: Array<FieldLatenciesRecord>;
+  fieldStats: Array<FieldStatsRecord>;
+  queryStats: Array<QueryStatsRecord>;
+  /** From field rounded down to the nearest resolution. */
+  roundedDownFrom: Scalars['Timestamp'];
+  /** To field rounded up to the nearest resolution. */
+  roundedUpTo: Scalars['Timestamp'];
+  tracePathErrorsRefs: Array<TracePathErrorsRefsRecord>;
+  traceRefs: Array<TraceRefsRecord>;
+};
+
+
+/** A time window with a specified granularity. */
+export type StatsWindowEdgeServerInfosArgs = {
+  filter?: Maybe<EdgeServerInfosFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<EdgeServerInfosOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity. */
+export type StatsWindowErrorStatsArgs = {
+  filter?: Maybe<ErrorStatsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<ErrorStatsOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity. */
+export type StatsWindowFieldLatenciesArgs = {
+  filter?: Maybe<FieldLatenciesFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<FieldLatenciesOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity. */
+export type StatsWindowFieldStatsArgs = {
+  filter?: Maybe<FieldStatsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<FieldStatsOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity. */
+export type StatsWindowQueryStatsArgs = {
+  filter?: Maybe<QueryStatsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<QueryStatsOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity. */
+export type StatsWindowTracePathErrorsRefsArgs = {
+  filter?: Maybe<TracePathErrorsRefsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<TracePathErrorsRefsOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity. */
+export type StatsWindowTraceRefsArgs = {
+  filter?: Maybe<TraceRefsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<TraceRefsOrderBySpec>>;
+};
+
+/** Filter for data in EdgeServerInfos. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type EdgeServerInfosFilter = {
+  and?: Maybe<Array<EdgeServerInfosFilter>>;
+  /** Selects rows whose bootId dimension equals the given value if not null. To query for the null value, use {in: {bootId: [null]}} instead. */
+  bootId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose executableSchemaId dimension equals the given value if not null. To query for the null value, use {in: {executableSchemaId: [null]}} instead. */
+  executableSchemaId?: Maybe<Scalars['ID']>;
+  in?: Maybe<EdgeServerInfosFilterIn>;
+  /** Selects rows whose libraryVersion dimension equals the given value if not null. To query for the null value, use {in: {libraryVersion: [null]}} instead. */
+  libraryVersion?: Maybe<Scalars['String']>;
+  not?: Maybe<EdgeServerInfosFilter>;
+  or?: Maybe<Array<EdgeServerInfosFilter>>;
+  /** Selects rows whose platform dimension equals the given value if not null. To query for the null value, use {in: {platform: [null]}} instead. */
+  platform?: Maybe<Scalars['String']>;
+  /** Selects rows whose runtimeVersion dimension equals the given value if not null. To query for the null value, use {in: {runtimeVersion: [null]}} instead. */
+  runtimeVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serverId dimension equals the given value if not null. To query for the null value, use {in: {serverId: [null]}} instead. */
+  serverId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose userVersion dimension equals the given value if not null. To query for the null value, use {in: {userVersion: [null]}} instead. */
+  userVersion?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in EdgeServerInfos. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type EdgeServerInfosFilterIn = {
+  /** Selects rows whose bootId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  bootId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose executableSchemaId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  executableSchemaId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose libraryVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  libraryVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose platform dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  platform?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose runtimeVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  runtimeVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serverId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serverId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose userVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  userVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type EdgeServerInfosOrderBySpec = {
+  column: EdgeServerInfosColumn;
+  direction: Ordering;
+};
+
+/** Columns of EdgeServerInfos. */
+export enum EdgeServerInfosColumn {
+  BootId = 'BOOT_ID',
+  ExecutableSchemaId = 'EXECUTABLE_SCHEMA_ID',
+  LibraryVersion = 'LIBRARY_VERSION',
+  Platform = 'PLATFORM',
+  RuntimeVersion = 'RUNTIME_VERSION',
+  SchemaTag = 'SCHEMA_TAG',
+  ServerId = 'SERVER_ID',
+  ServiceId = 'SERVICE_ID',
+  Timestamp = 'TIMESTAMP',
+  UserVersion = 'USER_VERSION'
+}
+
+export type EdgeServerInfosRecord = {
+  __typename?: 'EdgeServerInfosRecord';
+  /** Dimensions of EdgeServerInfos that can be grouped by. */
+  groupBy: EdgeServerInfosDimensions;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type EdgeServerInfosDimensions = {
+  __typename?: 'EdgeServerInfosDimensions';
+  bootId?: Maybe<Scalars['ID']>;
+  executableSchemaId?: Maybe<Scalars['ID']>;
+  libraryVersion?: Maybe<Scalars['String']>;
+  platform?: Maybe<Scalars['String']>;
+  runtimeVersion?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serverId?: Maybe<Scalars['ID']>;
+  serviceId?: Maybe<Scalars['ID']>;
+  userVersion?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in ErrorStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type ErrorStatsFilter = {
+  /** Selects rows whose accountId dimension equals the given value if not null. To query for the null value, use {in: {accountId: [null]}} instead. */
+  accountId?: Maybe<Scalars['ID']>;
+  and?: Maybe<Array<ErrorStatsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  in?: Maybe<ErrorStatsFilterIn>;
+  not?: Maybe<ErrorStatsFilter>;
+  or?: Maybe<Array<ErrorStatsFilter>>;
+  /** Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead. */
+  path?: Maybe<Scalars['String']>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in ErrorStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type ErrorStatsFilterIn = {
+  /** Selects rows whose accountId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  accountId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  path?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type ErrorStatsOrderBySpec = {
+  column: ErrorStatsColumn;
+  direction: Ordering;
+};
+
+/** Columns of ErrorStats. */
+export enum ErrorStatsColumn {
+  AccountId = 'ACCOUNT_ID',
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  ErrorsCount = 'ERRORS_COUNT',
+  Path = 'PATH',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  RequestsWithErrorsCount = 'REQUESTS_WITH_ERRORS_COUNT',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  ServiceVersion = 'SERVICE_VERSION',
+  Timestamp = 'TIMESTAMP'
+}
+
+export type ErrorStatsRecord = {
+  __typename?: 'ErrorStatsRecord';
+  /** Dimensions of ErrorStats that can be grouped by. */
+  groupBy: ErrorStatsDimensions;
+  /** Metrics of ErrorStats that can be aggregated over. */
+  metrics: ErrorStatsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type ErrorStatsDimensions = {
+  __typename?: 'ErrorStatsDimensions';
+  accountId?: Maybe<Scalars['ID']>;
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  path?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+export type ErrorStatsMetrics = {
+  __typename?: 'ErrorStatsMetrics';
+  errorsCount: Scalars['Long'];
+  requestsWithErrorsCount: Scalars['Long'];
+};
+
+/** Filter for data in FieldLatencies. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type FieldLatenciesFilter = {
+  and?: Maybe<Array<FieldLatenciesFilter>>;
+  /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
+  field?: Maybe<Scalars['String']>;
+  in?: Maybe<FieldLatenciesFilterIn>;
+  not?: Maybe<FieldLatenciesFilter>;
+  or?: Maybe<Array<FieldLatenciesFilter>>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in FieldLatencies. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type FieldLatenciesFilterIn = {
+  /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+};
+
+export type FieldLatenciesOrderBySpec = {
+  column: FieldLatenciesColumn;
+  direction: Ordering;
+};
+
+/** Columns of FieldLatencies. */
+export enum FieldLatenciesColumn {
+  Field = 'FIELD',
+  FieldHistogram = 'FIELD_HISTOGRAM',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  Timestamp = 'TIMESTAMP'
+}
+
+export type FieldLatenciesRecord = {
+  __typename?: 'FieldLatenciesRecord';
+  /** Dimensions of FieldLatencies that can be grouped by. */
+  groupBy: FieldLatenciesDimensions;
+  /** Metrics of FieldLatencies that can be aggregated over. */
+  metrics: FieldLatenciesMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type FieldLatenciesDimensions = {
+  __typename?: 'FieldLatenciesDimensions';
+  field?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+export type FieldLatenciesMetrics = {
+  __typename?: 'FieldLatenciesMetrics';
+  fieldHistogram: DurationHistogram;
+};
+
+/** Filter for data in FieldStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type FieldStatsFilter = {
+  /** Selects rows whose accountId dimension equals the given value if not null. To query for the null value, use {in: {accountId: [null]}} instead. */
+  accountId?: Maybe<Scalars['ID']>;
+  and?: Maybe<Array<FieldStatsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
+  field?: Maybe<Scalars['String']>;
+  in?: Maybe<FieldStatsFilterIn>;
+  not?: Maybe<FieldStatsFilter>;
+  or?: Maybe<Array<FieldStatsFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in FieldStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type FieldStatsFilterIn = {
+  /** Selects rows whose accountId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  accountId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type FieldStatsOrderBySpec = {
+  column: FieldStatsColumn;
+  direction: Ordering;
+};
+
+/** Columns of FieldStats. */
+export enum FieldStatsColumn {
+  AccountId = 'ACCOUNT_ID',
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  ErrorsCount = 'ERRORS_COUNT',
+  Field = 'FIELD',
+  FieldHistogram = 'FIELD_HISTOGRAM',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  RequestCount = 'REQUEST_COUNT',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  ServiceVersion = 'SERVICE_VERSION',
+  Timestamp = 'TIMESTAMP'
+}
+
+export type FieldStatsRecord = {
+  __typename?: 'FieldStatsRecord';
+  /** Dimensions of FieldStats that can be grouped by. */
+  groupBy: FieldStatsDimensions;
+  /** Metrics of FieldStats that can be aggregated over. */
+  metrics: FieldStatsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type FieldStatsDimensions = {
+  __typename?: 'FieldStatsDimensions';
+  accountId?: Maybe<Scalars['ID']>;
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  field?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+export type FieldStatsMetrics = {
+  __typename?: 'FieldStatsMetrics';
+  errorsCount: Scalars['Long'];
+  fieldHistogram: DurationHistogram;
+  requestCount: Scalars['Long'];
+};
+
+/** Filter for data in QueryStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type QueryStatsFilter = {
+  /** Selects rows whose accountId dimension equals the given value if not null. To query for the null value, use {in: {accountId: [null]}} instead. */
+  accountId?: Maybe<Scalars['ID']>;
+  and?: Maybe<Array<QueryStatsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose fromEngineproxy dimension equals the given value if not null. To query for the null value, use {in: {fromEngineproxy: [null]}} instead. */
+  fromEngineproxy?: Maybe<Scalars['String']>;
+  in?: Maybe<QueryStatsFilterIn>;
+  not?: Maybe<QueryStatsFilter>;
+  or?: Maybe<Array<QueryStatsFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+/** Filter for data in QueryStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type QueryStatsFilterIn = {
+  /** Selects rows whose accountId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  accountId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose fromEngineproxy dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  fromEngineproxy?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type QueryStatsOrderBySpec = {
+  column: QueryStatsColumn;
+  direction: Ordering;
+};
+
+/** Columns of QueryStats. */
+export enum QueryStatsColumn {
+  AccountId = 'ACCOUNT_ID',
+  CacheTtlHistogram = 'CACHE_TTL_HISTOGRAM',
+  CachedHistogram = 'CACHED_HISTOGRAM',
+  CachedRequestsCount = 'CACHED_REQUESTS_COUNT',
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  ForbiddenOperationCount = 'FORBIDDEN_OPERATION_COUNT',
+  FromEngineproxy = 'FROM_ENGINEPROXY',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  RegisteredOperationCount = 'REGISTERED_OPERATION_COUNT',
+  RequestsWithErrorsCount = 'REQUESTS_WITH_ERRORS_COUNT',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  ServiceVersion = 'SERVICE_VERSION',
+  Timestamp = 'TIMESTAMP',
+  UncachedHistogram = 'UNCACHED_HISTOGRAM',
+  UncachedRequestsCount = 'UNCACHED_REQUESTS_COUNT'
+}
+
+export type QueryStatsRecord = {
+  __typename?: 'QueryStatsRecord';
+  /** Dimensions of QueryStats that can be grouped by. */
+  groupBy: QueryStatsDimensions;
+  /** Metrics of QueryStats that can be aggregated over. */
+  metrics: QueryStatsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type QueryStatsDimensions = {
+  __typename?: 'QueryStatsDimensions';
+  accountId?: Maybe<Scalars['ID']>;
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  fromEngineproxy?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  querySignature?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+  serviceVersion?: Maybe<Scalars['String']>;
+};
+
+export type QueryStatsMetrics = {
+  __typename?: 'QueryStatsMetrics';
+  cachedHistogram: DurationHistogram;
+  cachedRequestsCount: Scalars['Long'];
+  cacheTtlHistogram: DurationHistogram;
+  forbiddenOperationCount: Scalars['Long'];
+  registeredOperationCount: Scalars['Long'];
+  requestsWithErrorsCount: Scalars['Long'];
+  totalLatencyHistogram: DurationHistogram;
+  totalRequestCount: Scalars['Long'];
+  uncachedHistogram: DurationHistogram;
+  uncachedRequestsCount: Scalars['Long'];
+};
+
+/** Filter for data in TracePathErrorsRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type TracePathErrorsRefsFilter = {
+  and?: Maybe<Array<TracePathErrorsRefsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
+  durationBucket?: Maybe<Scalars['Int']>;
+  /** Selects rows whose errorMessage dimension equals the given value if not null. To query for the null value, use {in: {errorMessage: [null]}} instead. */
+  errorMessage?: Maybe<Scalars['String']>;
+  in?: Maybe<TracePathErrorsRefsFilterIn>;
+  not?: Maybe<TracePathErrorsRefsFilter>;
+  or?: Maybe<Array<TracePathErrorsRefsFilter>>;
+  /** Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead. */
+  path?: Maybe<Scalars['String']>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
+  serviceVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose traceHttpStatusCode dimension equals the given value if not null. To query for the null value, use {in: {traceHttpStatusCode: [null]}} instead. */
+  traceHttpStatusCode?: Maybe<Scalars['Int']>;
+  /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
+  traceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in TracePathErrorsRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type TracePathErrorsRefsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  durationBucket?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  /** Selects rows whose errorMessage dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  errorMessage?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  path?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose traceHttpStatusCode dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  traceHttpStatusCode?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  traceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+};
+
+export type TracePathErrorsRefsOrderBySpec = {
+  column: TracePathErrorsRefsColumn;
+  direction: Ordering;
+};
+
+/** Columns of TracePathErrorsRefs. */
+export enum TracePathErrorsRefsColumn {
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  DurationBucket = 'DURATION_BUCKET',
+  ErrorMessage = 'ERROR_MESSAGE',
+  ErrorsCountInPath = 'ERRORS_COUNT_IN_PATH',
+  ErrorsCountInTrace = 'ERRORS_COUNT_IN_TRACE',
+  Path = 'PATH',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  ServiceVersion = 'SERVICE_VERSION',
+  Timestamp = 'TIMESTAMP',
+  TraceHttpStatusCode = 'TRACE_HTTP_STATUS_CODE',
+  TraceId = 'TRACE_ID',
+  TraceSizeBytes = 'TRACE_SIZE_BYTES',
+  TraceStartsAt = 'TRACE_STARTS_AT'
+}
+
+export type TracePathErrorsRefsRecord = {
+  __typename?: 'TracePathErrorsRefsRecord';
+  /** Dimensions of TracePathErrorsRefs that can be grouped by. */
+  groupBy: TracePathErrorsRefsDimensions;
+  /** Metrics of TracePathErrorsRefs that can be aggregated over. */
+  metrics: TracePathErrorsRefsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type TracePathErrorsRefsDimensions = {
+  __typename?: 'TracePathErrorsRefsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  durationBucket?: Maybe<Scalars['Int']>;
+  errorMessage?: Maybe<Scalars['String']>;
+  /** If metrics were collected from a federated service, this field will be prefixed with `service:<SERVICE_NAME>.` */
+  path?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+  serviceVersion?: Maybe<Scalars['String']>;
+  traceHttpStatusCode?: Maybe<Scalars['Int']>;
+  traceId?: Maybe<Scalars['ID']>;
+  traceStartsAt?: Maybe<Scalars['Timestamp']>;
+};
+
+export type TracePathErrorsRefsMetrics = {
+  __typename?: 'TracePathErrorsRefsMetrics';
+  errorsCountInPath: Scalars['Long'];
+  errorsCountInTrace: Scalars['Long'];
+  traceSizeBytes: Scalars['Long'];
+};
+
+/** Filter for data in TraceRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type TraceRefsFilter = {
+  and?: Maybe<Array<TraceRefsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
+  durationBucket?: Maybe<Scalars['Int']>;
+  in?: Maybe<TraceRefsFilterIn>;
+  not?: Maybe<TraceRefsFilter>;
+  or?: Maybe<Array<TraceRefsFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
+  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
+  serviceVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
+  traceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in TraceRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type TraceRefsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  durationBucket?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  traceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+};
+
+export type TraceRefsOrderBySpec = {
+  column: TraceRefsColumn;
+  direction: Ordering;
+};
+
+/** Columns of TraceRefs. */
+export enum TraceRefsColumn {
+  ClientName = 'CLIENT_NAME',
+  ClientReferenceId = 'CLIENT_REFERENCE_ID',
+  ClientVersion = 'CLIENT_VERSION',
+  DurationBucket = 'DURATION_BUCKET',
+  DurationNs = 'DURATION_NS',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  ServiceVersion = 'SERVICE_VERSION',
+  Timestamp = 'TIMESTAMP',
+  TraceId = 'TRACE_ID',
+  TraceSizeBytes = 'TRACE_SIZE_BYTES'
+}
+
+export type TraceRefsRecord = {
+  __typename?: 'TraceRefsRecord';
+  /** Dimensions of TraceRefs that can be grouped by. */
+  groupBy: TraceRefsDimensions;
+  /** Metrics of TraceRefs that can be aggregated over. */
+  metrics: TraceRefsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type TraceRefsDimensions = {
+  __typename?: 'TraceRefsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  durationBucket?: Maybe<Scalars['Int']>;
+  queryId?: Maybe<Scalars['ID']>;
+  queryName?: Maybe<Scalars['String']>;
+  querySignature?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+  serviceVersion?: Maybe<Scalars['String']>;
+  traceId?: Maybe<Scalars['ID']>;
+};
+
+export type TraceRefsMetrics = {
+  __typename?: 'TraceRefsMetrics';
+  durationNs: Scalars['Long'];
+  traceSizeBytes: Scalars['Long'];
+};
+
+export type UserSettings = {
+  __typename?: 'UserSettings';
+  appNavCollapsed: Scalars['Boolean'];
+  autoManageVariables: Scalars['Boolean'];
+  id: Scalars['String'];
+  mockingResponses: Scalars['Boolean'];
+  preflightScriptEnabled: Scalars['Boolean'];
+  responseHints: ResponseHints;
+  tableMode: Scalars['Boolean'];
+  themeName: ThemeName;
+};
+
+export enum ResponseHints {
+  None = 'NONE',
+  SampleResponses = 'SAMPLE_RESPONSES',
+  Subgraphs = 'SUBGRAPHS',
+  Timings = 'TIMINGS',
+  TraceTimings = 'TRACE_TIMINGS'
+}
+
+export enum ThemeName {
+  Dark = 'DARK',
+  Light = 'LIGHT'
+}
+
+export type GraphVariantLookup = GraphVariant | InvalidRefFormat;
+
+export type InvalidRefFormat = Error & {
+  __typename?: 'InvalidRefFormat';
+  message: Scalars['String'];
+};
+
+export type Error = {
+  message: Scalars['String'];
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  account?: Maybe<AccountMutation>;
+  /**
+   * Finalize a password reset with a token included in the E-mail link,
+   * returns the corresponding login email when successful
+   */
+  finalizePasswordReset?: Maybe<Scalars['String']>;
+  /** Join an account with a token */
+  joinAccount?: Maybe<Account>;
+  me?: Maybe<IdentityMutation>;
+  newAccount?: Maybe<Account>;
+  newService?: Maybe<Service>;
+  /** Refresh all plans from third-party billing service */
+  plansRefreshBilling?: Maybe<Scalars['Void']>;
+  /** Report a running GraphQL server's schema. */
+  reportSchema?: Maybe<ReportSchemaResult>;
+  /** Ask for a user's password to be reset by E-mail */
+  resetPassword?: Maybe<Scalars['Void']>;
+  resolveAllInternalCronExecutions?: Maybe<Scalars['Void']>;
+  resolveInternalCronExecution?: Maybe<CronExecution>;
+  service?: Maybe<ServiceMutation>;
+  /** Set the subscriptions for a given email */
+  setSubscriptions?: Maybe<EmailPreferences>;
+  /** Set the studio settings for the current user */
+  setUserSettings?: Maybe<UserSettings>;
+  signUp?: Maybe<User>;
+  /** This is called by the form shown to users after they delete their user or organization account. */
+  submitPostDeletionFeedback?: Maybe<Scalars['Void']>;
+  /** Mutation for basic engagement tracking in studio */
+  track?: Maybe<Scalars['Void']>;
+  /** Unsubscribe a given email from all emails */
+  unsubscribeFromAll?: Maybe<EmailPreferences>;
+  user?: Maybe<UserMutation>;
+};
+
+
+export type MutationAccountArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type MutationFinalizePasswordResetArgs = {
+  newPassword: Scalars['String'];
+  resetToken: Scalars['String'];
+};
+
+
+export type MutationJoinAccountArgs = {
+  accountId: Scalars['ID'];
+  joinToken: Scalars['String'];
+};
+
+
+export type MutationNewAccountArgs = {
+  companyUrl?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+};
+
+
+export type MutationNewServiceArgs = {
+  accountId: Scalars['ID'];
+  description?: Maybe<Scalars['String']>;
+  hiddenFromUninvitedNonAdminAccountMembers?: Scalars['Boolean'];
+  id: Scalars['ID'];
+  isDev?: Scalars['Boolean'];
+  name?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+};
+
+
+export type MutationReportSchemaArgs = {
+  coreSchema?: Maybe<Scalars['String']>;
+  report: SchemaReport;
+};
+
+
+export type MutationResetPasswordArgs = {
+  email: Scalars['String'];
+};
+
+
+export type MutationResolveAllInternalCronExecutionsArgs = {
+  group?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+};
+
+
+export type MutationResolveInternalCronExecutionArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type MutationServiceArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type MutationSetSubscriptionsArgs = {
+  email: Scalars['String'];
+  subscriptions: Array<EmailCategory>;
+  token: Scalars['String'];
+};
+
+
+export type MutationSetUserSettingsArgs = {
+  newSettings?: Maybe<UserSettingsInput>;
+};
+
+
+export type MutationSignUpArgs = {
+  email: Scalars['String'];
+  fullName: Scalars['String'];
+  password: Scalars['String'];
+  referrer?: Maybe<Scalars['String']>;
+  trackingGoogleClientId?: Maybe<Scalars['String']>;
+  trackingMarketoClientId?: Maybe<Scalars['String']>;
+  userSegment?: Maybe<UserSegment>;
+  utmCampaign?: Maybe<Scalars['String']>;
+  utmMedium?: Maybe<Scalars['String']>;
+  utmSource?: Maybe<Scalars['String']>;
+};
+
+
+export type MutationSubmitPostDeletionFeedbackArgs = {
+  feedback: Scalars['String'];
+  targetIdentifier: Scalars['ID'];
+  targetType: DeletionTargetType;
+};
+
+
+export type MutationTrackArgs = {
+  event: EventEnum;
+  graphID: Scalars['String'];
+  graphVariant?: Scalars['String'];
+};
+
+
+export type MutationUnsubscribeFromAllArgs = {
+  email: Scalars['String'];
+  token: Scalars['String'];
+};
+
+
+export type MutationUserArgs = {
+  id: Scalars['ID'];
+};
+
+export type AccountMutation = {
+  __typename?: 'AccountMutation';
+  auditExport?: Maybe<AuditLogExportMutation>;
+  /** Cancel a pending change from an annual team subscription to a monthly team subscription when the current period expires. */
+  cancelConvertAnnualTeamSubscriptionToMonthlyAtNextPeriod?: Maybe<Account>;
+  /** Cancel account subscriptions, subscriptions will remain active until the end of the paid period */
+  cancelSubscriptions?: Maybe<Account>;
+  /** Changes an annual team subscription to a monthly team subscription when the current period expires. */
+  convertAnnualTeamSubscriptionToMonthlyAtNextPeriod?: Maybe<Account>;
+  /** Changes a monthly team subscription to an annual team subscription. */
+  convertMonthlyTeamSubscriptionToAnnual?: Maybe<Account>;
+  createStaticInvitation?: Maybe<OrganizationInviteLink>;
+  /** Delete the account's avatar. Requires Account.canUpdateAvatar to be true. */
+  deleteAvatar?: Maybe<AvatarDeleteError>;
+  /** Acknowledge that a trial has expired and return to community */
+  dismissExpiredTrial?: Maybe<Account>;
+  /** Apollo admins only: extend an ongoing trial */
+  extendTrial?: Maybe<Account>;
+  /** Hard delete an account and all associated services */
+  hardDelete?: Maybe<Scalars['Void']>;
+  /** Send an invitation to join the account by E-mail */
+  invite?: Maybe<AccountInvitation>;
+  /** Reactivate a canceled current subscription */
+  reactivateCurrentSubscription?: Maybe<Account>;
+  /** Refresh billing information from third-party billing service */
+  refreshBilling?: Maybe<Scalars['Void']>;
+  /** Delete an invitation */
+  removeInvitation?: Maybe<Scalars['Void']>;
+  /** Remove a member of the account */
+  removeMember?: Maybe<Account>;
+  requestAuditExport?: Maybe<Account>;
+  /** Send a new E-mail for an existing invitation */
+  resendInvitation?: Maybe<AccountInvitation>;
+  revokeStaticInvitation?: Maybe<OrganizationInviteLink>;
+  /** Apollo admins only: set the billing plan to an arbitrary plan */
+  setPlan?: Maybe<Scalars['Void']>;
+  /** Start a new team subscription with the given billing period */
+  startTeamSubscription?: Maybe<Account>;
+  /** Start a team trial */
+  startTrial?: Maybe<Account>;
+  /** This is called by the form shown to users after they cancel their team subscription. */
+  submitTeamCancellationFeedback?: Maybe<Scalars['Void']>;
+  /** Apollo admins only: terminate any ongoing subscriptions in the account, without refunds */
+  terminateSubscriptions?: Maybe<Account>;
+  /** Update the billing address for a Recurly token */
+  updateBillingAddress?: Maybe<Account>;
+  /** Update the billing information from a Recurly token */
+  updateBillingInfo?: Maybe<Scalars['Void']>;
+  updateCompanyUrl?: Maybe<Account>;
+  /** Set the E-mail address of the account, used notably for billing */
+  updateEmail?: Maybe<Scalars['Void']>;
+  /** Update the account ID */
+  updateID?: Maybe<Account>;
+  /** Update the company name */
+  updateName?: Maybe<Scalars['Void']>;
+  /** Apollo admins only: enable or disable an account for PingOne SSO login */
+  updatePingOneSSOIDPID?: Maybe<Account>;
+  /** Updates the role assigned to new SSO users. */
+  updateSSODefaultRole?: Maybe<OrganizationSso>;
+  /** A (currently) internal to Apollo mutation to update a user's role within an organization */
+  updateUserPermission?: Maybe<User>;
+};
+
+
+export type AccountMutationAuditExportArgs = {
+  id: Scalars['String'];
+};
+
+
+export type AccountMutationCreateStaticInvitationArgs = {
+  role: UserPermission;
+};
+
+
+export type AccountMutationExtendTrialArgs = {
+  to: Scalars['Timestamp'];
+};
+
+
+export type AccountMutationInviteArgs = {
+  email: Scalars['String'];
+  role?: Maybe<UserPermission>;
+};
+
+
+export type AccountMutationRemoveInvitationArgs = {
+  id?: Maybe<Scalars['ID']>;
+};
+
+
+export type AccountMutationRemoveMemberArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type AccountMutationRequestAuditExportArgs = {
+  actors?: Maybe<Array<ActorInput>>;
+  from: Scalars['Timestamp'];
+  graphIds?: Maybe<Array<Scalars['String']>>;
+  to: Scalars['Timestamp'];
+};
+
+
+export type AccountMutationResendInvitationArgs = {
+  id?: Maybe<Scalars['ID']>;
+};
+
+
+export type AccountMutationRevokeStaticInvitationArgs = {
+  token: Scalars['String'];
+};
+
+
+export type AccountMutationSetPlanArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type AccountMutationStartTeamSubscriptionArgs = {
+  billingPeriod: BillingPeriod;
+};
+
+
+export type AccountMutationSubmitTeamCancellationFeedbackArgs = {
+  feedback: Scalars['String'];
+};
+
+
+export type AccountMutationUpdateBillingAddressArgs = {
+  billingAddress: BillingAddressInput;
+};
+
+
+export type AccountMutationUpdateBillingInfoArgs = {
+  token: Scalars['String'];
+};
+
+
+export type AccountMutationUpdateCompanyUrlArgs = {
+  companyUrl?: Maybe<Scalars['String']>;
+};
+
+
+export type AccountMutationUpdateEmailArgs = {
+  email: Scalars['String'];
+};
+
+
+export type AccountMutationUpdateIdArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type AccountMutationUpdateNameArgs = {
+  name: Scalars['String'];
+};
+
+
+export type AccountMutationUpdatePingOneSsoidpidArgs = {
+  idpid?: Maybe<Scalars['String']>;
+};
+
+
+export type AccountMutationUpdateSsoDefaultRoleArgs = {
+  role: UserPermission;
+};
+
+
+export type AccountMutationUpdateUserPermissionArgs = {
+  permission: UserPermission;
+  userID: Scalars['ID'];
+};
+
+export type AuditLogExportMutation = {
+  __typename?: 'AuditLogExportMutation';
+  cancel?: Maybe<Account>;
+  delete?: Maybe<Account>;
+};
+
+export type AvatarDeleteError = {
+  __typename?: 'AvatarDeleteError';
+  clientMessage: Scalars['String'];
+  code: AvatarDeleteErrorCode;
+  serverMessage: Scalars['String'];
+};
+
+export enum AvatarDeleteErrorCode {
+  SsoUsersCannotDeleteSelfAvatar = 'SSO_USERS_CANNOT_DELETE_SELF_AVATAR'
+}
+
+export type ActorInput = {
+  actorId: Scalars['ID'];
+  type: ActorType;
+};
+
+/** Billing address inpnut */
+export type BillingAddressInput = {
+  address1: Scalars['String'];
+  address2?: Maybe<Scalars['String']>;
+  city: Scalars['String'];
+  country: Scalars['String'];
+  state: Scalars['String'];
+  zip: Scalars['String'];
+};
+
+export type IdentityMutation = ServiceMutation | UserMutation;
+
+export type ServiceMutation = {
+  __typename?: 'ServiceMutation';
+  /**
+   * Compose an implementing service's partial schema, diff the composed schema, validate traffic against that schema,
+   * and store the result so the details can be viewed by users in the UI.
+   * This mutation will not mark the schema as "published".
+   */
+  checkPartialSchema: CheckPartialSchemaResult;
+  /**
+   * Checks a proposed schema against the schema that has been published to
+   * a particular tag, using metrics that have been published to the base tag.
+   * Callers can set the historicParameters directly, which will be used if
+   * provided. If useMaximumRetention is provided, but historicParameters is not,
+   * then validation will use the maximum retention the graph has access to.
+   * If neither historicParameters nor useMaximumRetention is provided, the
+   * default time range of one week (7 days) will be used.
+   */
+  checkSchema: CheckSchemaResult;
+  /** Make changes to a check workflow. */
+  checkWorkflow?: Maybe<CheckWorkflowMutation>;
+  createCompositionStatusSubscription: SchemaPublishSubscription;
+  createSchemaPublishSubscription: SchemaPublishSubscription;
+  /** Soft delete a graph. Data associated with the graph is not permanently deleted; Apollo support can undo. */
+  delete?: Maybe<Scalars['Void']>;
+  /** Delete the service's avatar. Requires Service.roles.canUpdateAvatar to be true. */
+  deleteAvatar?: Maybe<AvatarDeleteError>;
+  /** Delete an existing channel */
+  deleteChannel: Scalars['Boolean'];
+  /** Delete an existing query trigger */
+  deleteQueryTrigger: Scalars['Boolean'];
+  /** Deletes this service's current subscriptions specific to the ID, returns true if it existed */
+  deleteRegistrySubscription: Scalars['Boolean'];
+  /**
+   * Deletes this service's current registry subscription(s) specific to its graph variant,
+   * returns a list of subscription IDs that were deleted.
+   */
+  deleteRegistrySubscriptions: Array<Scalars['ID']>;
+  deleteScheduledSummary: Scalars['Boolean'];
+  deleteSchemaTag: DeleteSchemaTagResult;
+  /** Given a UTC timestamp, delete all traces associated with this Service, on that corresponding day. If a timestamp to is provided, deletes all days inclusive. */
+  deleteTraces?: Maybe<Scalars['Void']>;
+  disableDatadogForwardingLegacyMetricNames?: Maybe<Service>;
+  /** Hard delete a graph and all data associated with it. Its ID cannot be reused. */
+  hardDelete?: Maybe<Scalars['Void']>;
+  /** @deprecated Use service.id */
+  id: Scalars['ID'];
+  /**
+   * Ignore an operation in future checks;
+   * changes affecting it will be tracked,
+   * but won't affect the outcome of the check.
+   * Returns true if the operation is newly ignored,
+   * false if it already was.
+   */
+  ignoreOperationsInChecks?: Maybe<IgnoreOperationsInChecksResult>;
+  /**
+   * Mark the changeset that affects an operation in a given check instance as safe.
+   * Note that only operations marked as behavior changes are allowed to be marked as safe.
+   */
+  markChangesForOperationAsSafe: MarkChangesForOperationAsSafeResult;
+  newKey: GraphApiKey;
+  /** Adds an override to the given users permission for this graph */
+  overrideUserPermission?: Maybe<Service>;
+  /** Returns a preview of the Core and API schema contracts derived from a source variant and a set of filter configurations */
+  previewContractVariant: ContractVariantPreviewResult;
+  /** Promote the schema with the given SHA-256 hash to active for the given variant/tag. */
+  promoteSchema: PromoteSchemaResponseOrError;
+  registerOperationsWithResponse?: Maybe<RegisterOperationsMutationResponse>;
+  removeImplementingServiceAndTriggerComposition: CompositionAndRemoveResult;
+  removeKey?: Maybe<Scalars['Void']>;
+  renameKey?: Maybe<GraphApiKey>;
+  /** @deprecated use Mutation.reportSchema instead */
+  reportServerInfo?: Maybe<ReportServerInfoResult>;
+  service: Service;
+  /**
+   * Store a given schema document. This schema will be attached to the graph but
+   * not be associated with any variant. On success, returns the schema hash.
+   */
+  storeSchemaDocument: StoreSchemaResponseOrError;
+  /** Test Slack notification channel */
+  testSlackChannel?: Maybe<Scalars['Void']>;
+  testSubscriptionForChannel: Scalars['String'];
+  transfer?: Maybe<Service>;
+  triggerRepublish?: Maybe<Scalars['Void']>;
+  undelete?: Maybe<Service>;
+  /**
+   * Revert the effects of ignoreOperation.
+   * Returns true if the operation is no longer ignored,
+   * false if it wasn't.
+   */
+  unignoreOperationsInChecks?: Maybe<UnignoreOperationsInChecksResult>;
+  /** Unmark changes for an operation as safe. */
+  unmarkChangesForOperationAsSafe: MarkChangesForOperationAsSafeResult;
+  /** Update schema check configuration for a graph. */
+  updateCheckConfiguration: CheckConfiguration;
+  updateDatadogMetricsConfig?: Maybe<DatadogMetricsConfig>;
+  updateDescription?: Maybe<Service>;
+  /** Update hiddenFromUninvitedNonAdminAccountMembers */
+  updateHiddenFromUninvitedNonAdminAccountMembers?: Maybe<Service>;
+  updateReadme?: Maybe<Service>;
+  updateTitle?: Maybe<Service>;
+  uploadSchema?: Maybe<UploadSchemaMutationResponse>;
+  upsertChannel?: Maybe<Channel>;
+  /** Creates a contract schema from a source variant and a set of filter configurations */
+  upsertContractVariant: ContractVariantUpsertResult;
+  upsertImplementingServiceAndTriggerComposition?: Maybe<CompositionAndUpsertResult>;
+  /** Create/update PagerDuty notification channel */
+  upsertPagerDutyChannel?: Maybe<PagerDutyChannel>;
+  upsertQueryTrigger?: Maybe<QueryTrigger>;
+  /** Create or update a subscription for a service. */
+  upsertRegistrySubscription: RegistrySubscription;
+  upsertScheduledSummary?: Maybe<ScheduledSummary>;
+  /** Create/update Slack notification channel */
+  upsertSlackChannel?: Maybe<SlackChannel>;
+  upsertWebhookChannel?: Maybe<WebhookChannel>;
+  validateOperations: ValidateOperationsResult;
+  /**
+   * This mutation will not result in any changes to the implementing service
+   * Run composition with the Implementing Service's partial schema replaced with the one provided
+   * in the mutation's input. Store the composed schema, return the hash of the composed schema,
+   * and any warnings and errors pertaining to composition.
+   * This mutation will not run validation against operations.
+   */
+  validatePartialSchemaOfImplementingServiceAgainstGraph: CompositionValidationResult;
+  /** Make changes to a graph variant. */
+  variant?: Maybe<GraphVariantMutation>;
+};
+
+
+export type ServiceMutationCheckPartialSchemaArgs = {
+  frontend?: Maybe<Scalars['String']>;
+  gitContext?: Maybe<GitContextInput>;
+  graphVariant: Scalars['String'];
+  historicParameters?: Maybe<HistoricQueryParameters>;
+  implementingServiceName: Scalars['String'];
+  partialSchema: PartialSchemaInput;
+  useMaximumRetention?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type ServiceMutationCheckSchemaArgs = {
+  baseSchemaTag?: Maybe<Scalars['String']>;
+  frontend?: Maybe<Scalars['String']>;
+  gitContext?: Maybe<GitContextInput>;
+  historicParameters?: Maybe<HistoricQueryParameters>;
+  proposedSchema?: Maybe<IntrospectionSchemaInput>;
+  proposedSchemaDocument?: Maybe<Scalars['String']>;
+  proposedSchemaHash?: Maybe<Scalars['String']>;
+  useMaximumRetention?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type ServiceMutationCheckWorkflowArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type ServiceMutationCreateCompositionStatusSubscriptionArgs = {
+  channelID: Scalars['ID'];
+  variant: Scalars['String'];
+};
+
+
+export type ServiceMutationCreateSchemaPublishSubscriptionArgs = {
+  channelID: Scalars['ID'];
+  variant: Scalars['String'];
+};
+
+
+export type ServiceMutationDeleteChannelArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type ServiceMutationDeleteQueryTriggerArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type ServiceMutationDeleteRegistrySubscriptionArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type ServiceMutationDeleteRegistrySubscriptionsArgs = {
+  variant: Scalars['String'];
+};
+
+
+export type ServiceMutationDeleteScheduledSummaryArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type ServiceMutationDeleteSchemaTagArgs = {
+  tag: Scalars['String'];
+};
+
+
+export type ServiceMutationDeleteTracesArgs = {
+  from: Scalars['Timestamp'];
+  to?: Maybe<Scalars['Timestamp']>;
+};
+
+
+export type ServiceMutationIgnoreOperationsInChecksArgs = {
+  ids: Array<Scalars['ID']>;
+};
+
+
+export type ServiceMutationMarkChangesForOperationAsSafeArgs = {
+  checkID: Scalars['ID'];
+  operationID: Scalars['ID'];
+};
+
+
+export type ServiceMutationNewKeyArgs = {
+  keyName?: Maybe<Scalars['String']>;
+  role?: UserPermission;
+};
+
+
+export type ServiceMutationOverrideUserPermissionArgs = {
+  permission?: Maybe<UserPermission>;
+  userID: Scalars['ID'];
+};
+
+
+export type ServiceMutationPreviewContractVariantArgs = {
+  filterConfig: FilterConfigInput;
+  sourceVariant: Scalars['String'];
+};
+
+
+export type ServiceMutationPromoteSchemaArgs = {
+  graphVariant: Scalars['String'];
+  historicParameters?: Maybe<HistoricQueryParameters>;
+  overrideComposedSchema?: Scalars['Boolean'];
+  sha256: Scalars['SHA256'];
+};
+
+
+export type ServiceMutationRegisterOperationsWithResponseArgs = {
+  clientIdentity?: Maybe<RegisteredClientIdentityInput>;
+  gitContext?: Maybe<GitContextInput>;
+  graphVariant?: Scalars['String'];
+  manifestVersion?: Maybe<Scalars['Int']>;
+  operations: Array<RegisteredOperationInput>;
+};
+
+
+export type ServiceMutationRemoveImplementingServiceAndTriggerCompositionArgs = {
+  dryRun?: Scalars['Boolean'];
+  graphVariant: Scalars['String'];
+  name: Scalars['String'];
+};
+
+
+export type ServiceMutationRemoveKeyArgs = {
+  id?: Maybe<Scalars['ID']>;
+};
+
+
+export type ServiceMutationRenameKeyArgs = {
+  id: Scalars['ID'];
+  newKeyName?: Maybe<Scalars['String']>;
+};
+
+
+export type ServiceMutationReportServerInfoArgs = {
+  executableSchema?: Maybe<Scalars['String']>;
+  info: EdgeServerInfo;
+};
+
+
+export type ServiceMutationStoreSchemaDocumentArgs = {
+  schemaDocument: Scalars['String'];
+};
+
+
+export type ServiceMutationTestSlackChannelArgs = {
+  id: Scalars['ID'];
+  notification: SlackNotificationInput;
+};
+
+
+export type ServiceMutationTestSubscriptionForChannelArgs = {
+  channelID: Scalars['ID'];
+  subscriptionID: Scalars['ID'];
+};
+
+
+export type ServiceMutationTransferArgs = {
+  to: Scalars['String'];
+};
+
+
+export type ServiceMutationTriggerRepublishArgs = {
+  graphVariant: Scalars['String'];
+};
+
+
+export type ServiceMutationUnignoreOperationsInChecksArgs = {
+  ids: Array<Scalars['ID']>;
+};
+
+
+export type ServiceMutationUnmarkChangesForOperationAsSafeArgs = {
+  checkID: Scalars['ID'];
+  operationID: Scalars['ID'];
+};
+
+
+export type ServiceMutationUpdateCheckConfigurationArgs = {
+  excludedClients?: Maybe<Array<ClientFilterInput>>;
+  excludedOperations?: Maybe<Array<ExcludedOperationInput>>;
+  includeBaseVariant?: Maybe<Scalars['Boolean']>;
+  includedVariants?: Maybe<Array<Scalars['String']>>;
+  operationCountThreshold?: Maybe<Scalars['Int']>;
+  operationCountThresholdPercentage?: Maybe<Scalars['Float']>;
+  timeRangeSeconds?: Maybe<Scalars['Long']>;
+};
+
+
+export type ServiceMutationUpdateDatadogMetricsConfigArgs = {
+  apiKey?: Maybe<Scalars['String']>;
+  apiRegion?: Maybe<DatadogApiRegion>;
+  enabled?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type ServiceMutationUpdateDescriptionArgs = {
+  description: Scalars['String'];
+};
+
+
+export type ServiceMutationUpdateHiddenFromUninvitedNonAdminAccountMembersArgs = {
+  hiddenFromUninvitedNonAdminAccountMembers: Scalars['Boolean'];
+};
+
+
+export type ServiceMutationUpdateReadmeArgs = {
+  readme: Scalars['String'];
+};
+
+
+export type ServiceMutationUpdateTitleArgs = {
+  title: Scalars['String'];
+};
+
+
+export type ServiceMutationUploadSchemaArgs = {
+  errorOnBadRequest?: Scalars['Boolean'];
+  gitContext?: Maybe<GitContextInput>;
+  historicParameters?: Maybe<HistoricQueryParameters>;
+  overrideComposedSchema?: Scalars['Boolean'];
+  schema?: Maybe<IntrospectionSchemaInput>;
+  schemaDocument?: Maybe<Scalars['String']>;
+  tag: Scalars['String'];
+};
+
+
+export type ServiceMutationUpsertChannelArgs = {
+  id?: Maybe<Scalars['ID']>;
+  pagerDutyChannel?: Maybe<PagerDutyChannelInput>;
+  slackChannel?: Maybe<SlackChannelInput>;
+  webhookChannel?: Maybe<WebhookChannelInput>;
+};
+
+
+export type ServiceMutationUpsertContractVariantArgs = {
+  contractVariantName: Scalars['String'];
+  filterConfig: FilterConfigInput;
+  sourceVariant: Scalars['String'];
+};
+
+
+export type ServiceMutationUpsertImplementingServiceAndTriggerCompositionArgs = {
+  activePartialSchema: PartialSchemaInput;
+  gitContext?: Maybe<GitContextInput>;
+  graphVariant: Scalars['String'];
+  name: Scalars['String'];
+  revision: Scalars['String'];
+  url?: Maybe<Scalars['String']>;
+};
+
+
+export type ServiceMutationUpsertPagerDutyChannelArgs = {
+  channel: PagerDutyChannelInput;
+  id?: Maybe<Scalars['ID']>;
+};
+
+
+export type ServiceMutationUpsertQueryTriggerArgs = {
+  id?: Maybe<Scalars['ID']>;
+  trigger: QueryTriggerInput;
+};
+
+
+export type ServiceMutationUpsertRegistrySubscriptionArgs = {
+  channelID?: Maybe<Scalars['ID']>;
+  id?: Maybe<Scalars['ID']>;
+  options?: Maybe<SubscriptionOptionsInput>;
+  variant?: Maybe<Scalars['String']>;
+};
+
+
+export type ServiceMutationUpsertScheduledSummaryArgs = {
+  channelID?: Maybe<Scalars['ID']>;
+  enabled?: Maybe<Scalars['Boolean']>;
+  id?: Maybe<Scalars['ID']>;
+  tag?: Maybe<Scalars['String']>;
+  timezone?: Maybe<Scalars['String']>;
+  variant?: Maybe<Scalars['String']>;
+};
+
+
+export type ServiceMutationUpsertSlackChannelArgs = {
+  channel: SlackChannelInput;
+  id?: Maybe<Scalars['ID']>;
+};
+
+
+export type ServiceMutationUpsertWebhookChannelArgs = {
+  id?: Maybe<Scalars['ID']>;
+  name?: Maybe<Scalars['String']>;
+  secretToken?: Maybe<Scalars['String']>;
+  url: Scalars['String'];
+};
+
+
+export type ServiceMutationValidateOperationsArgs = {
+  gitContext?: Maybe<GitContextInput>;
+  operations: Array<OperationDocumentInput>;
+  tag?: Maybe<Scalars['String']>;
+};
+
+
+export type ServiceMutationValidatePartialSchemaOfImplementingServiceAgainstGraphArgs = {
+  graphVariant: Scalars['String'];
+  implementingServiceName: Scalars['String'];
+  partialSchema: PartialSchemaInput;
+};
+
+
+export type ServiceMutationVariantArgs = {
+  name: Scalars['String'];
+};
+
+/** This is stored with a schema when it is uploaded */
+export type GitContextInput = {
+  branch?: Maybe<Scalars['String']>;
+  commit?: Maybe<Scalars['ID']>;
+  committer?: Maybe<Scalars['String']>;
+  message?: Maybe<Scalars['String']>;
+  remoteUrl?: Maybe<Scalars['String']>;
+};
+
+export type HistoricQueryParameters = {
+  /** A list of clients to filter out during validation. */
+  excludedClients?: Maybe<Array<ClientInfoFilter>>;
+  from?: Maybe<Scalars['Timestamp']>;
+  /** A list of operation IDs to filter out during validation. */
+  ignoredOperations?: Maybe<Array<Scalars['ID']>>;
+  /**
+   * A list of variants to include in the validation. If no variants are provided
+   * then this defaults to the "current" variant along with the base variant. The
+   * base variant indicates the schema that generates diff and marks the metrics that
+   * are checked for broken queries. We union this base variant with the untagged values('',
+   * same as null inside of `in`, and 'current') in this metrics fetch. This strategy
+   * supports users who have not tagged their metrics or schema.
+   */
+  includedVariants?: Maybe<Array<Scalars['String']>>;
+  /** Minimum number of requests within the window for a query to be considered. */
+  queryCountThreshold?: Maybe<Scalars['Int']>;
+  /**
+   * Number of requests within the window for a query to be considered, relative to
+   * total request count. Expected values are between 0 and 0.05 (minimum 5% of total
+   * request volume)
+   */
+  queryCountThresholdPercentage?: Maybe<Scalars['Float']>;
+  to?: Maybe<Scalars['Timestamp']>;
+};
+
+/** Filter options to exclude by client reference ID, client name, and client version. */
+export type ClientInfoFilter = {
+  name?: Maybe<Scalars['String']>;
+  referenceID?: Maybe<Scalars['ID']>;
+  version?: Maybe<Scalars['String']>;
+};
+
+/**
+ * Input for registering a partial schema to an implementing service.
+ * One of the fields must be specified (validated server-side).
+ *
+ * If a new partialSchemaSDL is passed in, this operation will store it before
+ * creating the association.
+ *
+ * If both the sdl and hash are specified, an error will be thrown if the provided
+ * hash doesn't match our hash of the sdl contents. If the sdl field is specified,
+ * the hash does not need to be and will be computed server-side.
+ */
+export type PartialSchemaInput = {
+  /**
+   * Hash of the partial schema to associate; error is thrown if only the hash is
+   * specified and the hash has not been seen before
+   */
+  hash?: Maybe<Scalars['String']>;
+  /**
+   * Contents of the partial schema in SDL syntax, but may reference types
+   * that aren't defined in this document
+   */
+  sdl?: Maybe<Scalars['String']>;
+};
+
+export type CheckPartialSchemaResult = {
+  __typename?: 'CheckPartialSchemaResult';
+  /** Result of traffic validation. This will be null if composition validation was unsuccessful. */
+  checkSchemaResult?: Maybe<CheckSchemaResult>;
+  /** Result of composition validation run before the schema check. */
+  compositionValidationResult: CompositionValidationResult;
+  /** Workflow associated with the composition validation. */
+  workflow?: Maybe<CheckWorkflow>;
+};
+
+export type CheckSchemaResult = {
+  __typename?: 'CheckSchemaResult';
+  /** Schema diff and affected operations generated by the schema check */
+  diffToPrevious: SchemaDiff;
+  /** ID of the operations check that was created */
+  operationsCheckID: Scalars['ID'];
+  /** Generated url to view schema diff in Engine */
+  targetUrl?: Maybe<Scalars['String']>;
+  /** Workflow associated with this check result */
+  workflow?: Maybe<CheckWorkflow>;
+};
+
+/** Metadata about the result of compositions validation run in the cloud */
+export type CompositionValidationResult = CompositionResult & {
+  __typename?: 'CompositionValidationResult';
+  /** Describes whether composition succeeded. */
+  compositionSuccess: Scalars['Boolean'];
+  /**
+   * Akin to a composition config, represents the partial schemas and implementing services that were used
+   * in running composition. Will be null if any errors are encountered. Also may contain a schema hash if
+   * one could be computed, which can be used for schema validation.
+   */
+  compositionValidationDetails?: Maybe<CompositionValidationDetails>;
+  /**
+   * Supergraph SDL generated by composition (this is not the CSDL, that is a deprecated format).
+   * @deprecated Use supergraphSdl instead
+   */
+  csdl?: Maybe<Scalars['GraphQLDocument']>;
+  /**
+   * List of errors during composition. Errors mean that Apollo was unable to compose the
+   * graph's implementing services into a GraphQL schema. This partial schema should not be
+   * published to the implementing service if there were any errors encountered
+   */
+  errors: Array<SchemaCompositionError>;
+  /** ID that points to the results of this composition. */
+  graphCompositionID: Scalars['ID'];
+  /** The implementing service that was responsible for triggering the validation */
+  proposedImplementingService: FederatedImplementingServicePartialSchema;
+  /** List of subgraphs that are included in this composition. */
+  subgraphConfigs: Array<SubgraphConfig>;
+  /** Supergraph SDL generated by composition. */
+  supergraphSdl?: Maybe<Scalars['GraphQLDocument']>;
+  /** If created as part of a check workflow, the associated workflow task. */
+  workflowTask?: Maybe<CompositionCheckTask>;
+};
+
+/** The composition config exposed to the gateway */
+export type CompositionValidationDetails = {
+  __typename?: 'CompositionValidationDetails';
+  /** List of implementing service partial schemas that comprised the graph composed during validation */
+  implementingServices: Array<FederatedImplementingServicePartialSchema>;
+  /** Hash of the composed schema */
+  schemaHash?: Maybe<Scalars['String']>;
+};
+
+/** A minimal representation of a federated implementing service, using only a name and partial schema SDL */
+export type FederatedImplementingServicePartialSchema = {
+  __typename?: 'FederatedImplementingServicePartialSchema';
+  /** The name of the implementing service */
+  name: Scalars['String'];
+  /** The partial schema of the implementing service */
+  sdl: Scalars['String'];
+};
+
+export type CompositionCheckTask = CheckWorkflowTask & {
+  __typename?: 'CompositionCheckTask';
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  createdAt: Scalars['Timestamp'];
+  id: Scalars['ID'];
+  /** The result of the composition. */
+  result?: Maybe<CompositionResult>;
+  status: CheckWorkflowTaskStatus;
+  workflow: CheckWorkflow;
+};
+
+/** __Schema introspection type */
+export type IntrospectionSchemaInput = {
+  description?: Maybe<Scalars['String']>;
+  directives: Array<IntrospectionDirectiveInput>;
+  mutationType?: Maybe<IntrospectionTypeRefInput>;
+  queryType: IntrospectionTypeRefInput;
+  subscriptionType?: Maybe<IntrospectionTypeRefInput>;
+  types?: Maybe<Array<IntrospectionTypeInput>>;
+};
+
+export type IntrospectionDirectiveInput = {
+  args: Array<IntrospectionInputValueInput>;
+  description?: Maybe<Scalars['String']>;
+  isRepeatable?: Maybe<Scalars['Boolean']>;
+  locations: Array<IntrospectionDirectiveLocation>;
+  name: Scalars['String'];
+};
+
+/** __Value introspection type */
+export type IntrospectionInputValueInput = {
+  defaultValue?: Maybe<Scalars['String']>;
+  deprecationReason?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  isDeprecated?: Maybe<Scalars['Boolean']>;
+  name: Scalars['String'];
+  type: IntrospectionTypeInput;
+};
+
+/** __Type introspection type */
+export type IntrospectionTypeInput = {
+  description?: Maybe<Scalars['String']>;
+  enumValues?: Maybe<Array<IntrospectionEnumValueInput>>;
+  fields?: Maybe<Array<IntrospectionFieldInput>>;
+  inputFields?: Maybe<Array<IntrospectionInputValueInput>>;
+  interfaces?: Maybe<Array<IntrospectionTypeInput>>;
+  kind: IntrospectionTypeKind;
+  name?: Maybe<Scalars['String']>;
+  ofType?: Maybe<IntrospectionTypeInput>;
+  possibleTypes?: Maybe<Array<IntrospectionTypeInput>>;
+  specifiedByUrl?: Maybe<Scalars['String']>;
+};
+
+/** __EnumValue introspection type */
+export type IntrospectionEnumValueInput = {
+  deprecationReason?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  isDeprecated: Scalars['Boolean'];
+  name: Scalars['String'];
+};
+
+/** __Field introspection type */
+export type IntrospectionFieldInput = {
+  args: Array<IntrospectionInputValueInput>;
+  deprecationReason?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  isDeprecated: Scalars['Boolean'];
+  name: Scalars['String'];
+  type: IntrospectionTypeInput;
+};
+
+/** Shallow __Type introspection type */
+export type IntrospectionTypeRefInput = {
+  kind?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
+};
+
+export type CheckWorkflowMutation = {
+  __typename?: 'CheckWorkflowMutation';
+  /** Re-run a check workflow using the current configuration. A new workflow is created and returned. */
+  rerun?: Maybe<CheckWorkflowRerunResult>;
+};
+
+export type CheckWorkflowRerunResult = {
+  __typename?: 'CheckWorkflowRerunResult';
+  /** Check workflow created by re-running. */
+  result?: Maybe<CheckWorkflow>;
+  /** Check workflow that was rerun. */
+  source?: Maybe<CheckWorkflow>;
+};
+
+export type SchemaPublishSubscription = ChannelSubscription & {
+  __typename?: 'SchemaPublishSubscription';
+  channels: Array<Channel>;
+  createdAt: Scalars['Timestamp'];
+  enabled: Scalars['Boolean'];
+  id: Scalars['ID'];
+  lastUpdatedAt: Scalars['Timestamp'];
+  variant?: Maybe<Scalars['String']>;
+};
+
+export type DeleteSchemaTagResult = {
+  __typename?: 'DeleteSchemaTagResult';
+  deleted: Scalars['Boolean'];
+  deletedSubscriptionIDs: Array<Scalars['ID']>;
+};
+
+export type IgnoreOperationsInChecksResult = {
+  __typename?: 'IgnoreOperationsInChecksResult';
+  graph: Service;
+};
+
+export type MarkChangesForOperationAsSafeResult = {
+  __typename?: 'MarkChangesForOperationAsSafeResult';
+  /**
+   * Nice to have for the frontend since the Apollo cache is already watching for AffectedQuery to update.
+   * This might return null if no behavior changes were found for the affected operation ID.
+   * This is a weird situation that should never happen.
+   */
+  affectedOperation?: Maybe<AffectedQuery>;
+  message: Scalars['String'];
+  success: Scalars['Boolean'];
+};
+
+export type FilterConfigInput = {
+  exclude: Array<Scalars['String']>;
+  include: Array<Scalars['String']>;
+};
+
+export type ContractVariantPreviewResult = ContractVariantPreviewErrors | ContractVariantPreviewSuccess;
+
+export type ContractVariantPreviewErrors = {
+  __typename?: 'ContractVariantPreviewErrors';
+  errorMessages: Array<Scalars['String']>;
+  failedStep: ContractVariantFailedStep;
+};
+
+export enum ContractVariantFailedStep {
+  EmptyObjectAndInterfaceMasking = 'EMPTY_OBJECT_AND_INTERFACE_MASKING',
+  EmptyUnionMasking = 'EMPTY_UNION_MASKING',
+  InputValidation = 'INPUT_VALIDATION',
+  Parsing = 'PARSING',
+  ParsingTagDirectives = 'PARSING_TAG_DIRECTIVES',
+  PartialInterfaceMasking = 'PARTIAL_INTERFACE_MASKING',
+  SchemaRetrieval = 'SCHEMA_RETRIEVAL',
+  TagMatching = 'TAG_MATCHING',
+  ToApiSchema = 'TO_API_SCHEMA',
+  ToFilterSchema = 'TO_FILTER_SCHEMA',
+  Unknown = 'UNKNOWN'
+}
+
+export type ContractVariantPreviewSuccess = {
+  __typename?: 'ContractVariantPreviewSuccess';
+  allTags: Array<Scalars['String']>;
+  baseApiSchema: Scalars['String'];
+  baseCoreSchema: Scalars['String'];
+  contractApiSchema: Scalars['String'];
+  contractCoreSchema: Scalars['String'];
+};
+
+export type PromoteSchemaResponseOrError = PromoteSchemaError | PromoteSchemaResponse;
+
+export type PromoteSchemaError = {
+  __typename?: 'PromoteSchemaError';
+  code: PromoteSchemaErrorCode;
+  message: Scalars['String'];
+};
+
+export enum PromoteSchemaErrorCode {
+  CannotPromoteSchemaForFederatedGraph = 'CANNOT_PROMOTE_SCHEMA_FOR_FEDERATED_GRAPH'
+}
+
+export type PromoteSchemaResponse = {
+  __typename?: 'PromoteSchemaResponse';
+  code: PromoteSchemaResponseCode;
+  tag: SchemaTag;
+};
+
+export enum PromoteSchemaResponseCode {
+  NoChangesDetected = 'NO_CHANGES_DETECTED',
+  PromotionSuccess = 'PROMOTION_SUCCESS'
+}
+
+export type RegisteredClientIdentityInput = {
+  identifier: Scalars['String'];
+  name: Scalars['String'];
+  version?: Maybe<Scalars['String']>;
+};
+
+export type RegisteredOperationInput = {
+  document?: Maybe<Scalars['String']>;
+  metadata?: Maybe<RegisteredOperationMetadataInput>;
+  signature: Scalars['ID'];
+};
+
+export type RegisteredOperationMetadataInput = {
+  /** This will be used to link existing records in Engine to a new ID. */
+  engineSignature?: Maybe<Scalars['String']>;
+};
+
+export type RegisterOperationsMutationResponse = {
+  __typename?: 'RegisterOperationsMutationResponse';
+  invalidOperations?: Maybe<Array<InvalidOperation>>;
+  newOperations?: Maybe<Array<RegisteredOperation>>;
+  registrationSuccess: Scalars['Boolean'];
+};
+
+export type InvalidOperation = {
+  __typename?: 'InvalidOperation';
+  errors?: Maybe<Array<OperationValidationError>>;
+  signature: Scalars['ID'];
+};
+
+export type OperationValidationError = {
+  __typename?: 'OperationValidationError';
+  message: Scalars['String'];
+};
+
+export type RegisteredOperation = {
+  __typename?: 'RegisteredOperation';
+  signature: Scalars['ID'];
+};
+
+/** Metadata about the result of composition run in the cloud, combined with removing an implementing service */
+export type CompositionAndRemoveResult = {
+  __typename?: 'CompositionAndRemoveResult';
+  /** The produced composition config. Will be null if there are any errors */
+  compositionConfig?: Maybe<CompositionConfig>;
+  /** Whether the removed implementing service existed. */
+  didExist: Scalars['Boolean'];
+  /**
+   * List of errors during composition. Errors mean that Apollo was unable to compose the
+   * graph's implementing services into a GraphQL schema. This partial schema should not be
+   * published to the implementing service if there were any errors encountered.
+   */
+  errors: Array<Maybe<SchemaCompositionError>>;
+  /** ID that points to the results of composition. */
+  graphCompositionID: Scalars['String'];
+  /** List of subgraphs that are included in this composition. */
+  subgraphConfigs: Array<SubgraphConfig>;
+  /** Whether the gateway link was updated, or would have been for dry runs. */
+  updatedGateway: Scalars['Boolean'];
+};
+
+export type EdgeServerInfo = {
+  /** A randomly generated UUID, immutable for the lifetime of the edge server runtime. */
+  bootId: Scalars['String'];
+  /** A unique identifier for the executable GraphQL served by the edge server. length must be <= 64 characters. */
+  executableSchemaId: Scalars['String'];
+  /** The graph variant, defaults to 'current' */
+  graphVariant?: Scalars['String'];
+  /** The version of the edge server reporting agent, e.g. apollo-server-2.8, graphql-java-3.1, etc. length must be <= 256 characters. */
+  libraryVersion?: Maybe<Scalars['String']>;
+  /** The infra environment in which this edge server is running, e.g. localhost, Kubernetes, AWS Lambda, Google CloudRun, AWS ECS, etc. length must be <= 256 characters. */
+  platform?: Maybe<Scalars['String']>;
+  /** The runtime in which the edge server is running, e.g. node 12.03, zulu8.46.0.19-ca-jdk8.0.252-macosx_x64, etc. length must be <= 256 characters. */
+  runtimeVersion?: Maybe<Scalars['String']>;
+  /** If available, an identifier for the edge server instance, such that when restarting this instance it will have the same serverId, with a different bootId. For example, in Kubernetes this might be the pod name. Length must be <= 256 characters. */
+  serverId?: Maybe<Scalars['String']>;
+  /** An identifier used to distinguish the version (from the user's perspective) of the edge server's code itself. For instance, the git sha of the server's repository or the docker sha of the associated image this server runs with. Length must be <= 256 characters. */
+  userVersion?: Maybe<Scalars['String']>;
+};
+
+export type ReportServerInfoResult = {
+  inSeconds: Scalars['Int'];
+  withExecutableSchema: Scalars['Boolean'];
+};
+
+export type StoreSchemaResponseOrError = StoreSchemaError | StoreSchemaResponse;
+
+export type StoreSchemaError = {
+  __typename?: 'StoreSchemaError';
+  code: StoreSchemaErrorCode;
+  message: Scalars['String'];
+};
+
+export enum StoreSchemaErrorCode {
+  SchemaIsNotParsable = 'SCHEMA_IS_NOT_PARSABLE',
+  SchemaIsNotValid = 'SCHEMA_IS_NOT_VALID'
+}
+
+export type StoreSchemaResponse = {
+  __typename?: 'StoreSchemaResponse';
+  sha256: Scalars['SHA256'];
+};
+
+/** Slack notification message */
+export type SlackNotificationInput = {
+  color?: Maybe<Scalars['String']>;
+  fallback: Scalars['String'];
+  fields?: Maybe<Array<SlackNotificationField>>;
+  iconUrl?: Maybe<Scalars['String']>;
+  text?: Maybe<Scalars['String']>;
+  timestamp?: Maybe<Scalars['Timestamp']>;
+  title?: Maybe<Scalars['String']>;
+  titleLink?: Maybe<Scalars['String']>;
+  username?: Maybe<Scalars['String']>;
+};
+
+export type SlackNotificationField = {
+  key: Scalars['String'];
+  value: Scalars['String'];
+};
+
+export type UnignoreOperationsInChecksResult = {
+  __typename?: 'UnignoreOperationsInChecksResult';
+  graph: Service;
+};
+
+/**
+ * Options to filter by client reference ID, client name, and client version.
+ * If passing client version, make sure to either provide a client reference ID or client name.
+ */
+export type ClientFilterInput = {
+  /** name of the client set by the user and reported alongside metrics */
+  name?: Maybe<Scalars['String']>;
+  /** ID, often the name, of the client set by the user and reported alongside metrics */
+  referenceID?: Maybe<Scalars['ID']>;
+  /** version of the client set by the user and reported alongside metrics */
+  version?: Maybe<Scalars['String']>;
+};
+
+/** Option to filter by operation ID. */
+export type ExcludedOperationInput = {
+  /** Operation ID to exclude from schema check. */
+  ID: Scalars['ID'];
+};
+
+export type UploadSchemaMutationResponse = {
+  __typename?: 'UploadSchemaMutationResponse';
+  code: Scalars['String'];
+  message: Scalars['String'];
+  success: Scalars['Boolean'];
+  tag?: Maybe<SchemaTag>;
+};
+
+/** PagerDuty notification channel parameters */
+export type PagerDutyChannelInput = {
+  name?: Maybe<Scalars['String']>;
+  routingKey: Scalars['String'];
+};
+
+/** Slack notification channel parameters */
+export type SlackChannelInput = {
+  name?: Maybe<Scalars['String']>;
+  url: Scalars['String'];
+};
+
+/** PagerDuty notification channel parameters */
+export type WebhookChannelInput = {
+  name?: Maybe<Scalars['String']>;
+  secretToken?: Maybe<Scalars['String']>;
+  url: Scalars['String'];
+};
+
+export type ContractVariantUpsertResult = ContractVariantUpsertErrors | ContractVariantUpsertSuccess;
+
+export type ContractVariantUpsertErrors = {
+  __typename?: 'ContractVariantUpsertErrors';
+  errorMessages: Array<Scalars['String']>;
+};
+
+export type ContractVariantUpsertSuccess = {
+  __typename?: 'ContractVariantUpsertSuccess';
+  contractVariant: GraphVariant;
+};
+
+/** Metadata about the result of composition run in the cloud, combined with implementing service upsert */
+export type CompositionAndUpsertResult = {
+  __typename?: 'CompositionAndUpsertResult';
+  /** The produced composition config. Will be null if there are any errors */
+  compositionConfig?: Maybe<CompositionConfig>;
+  /**
+   * List of errors during composition. Errors mean that Apollo was unable to compose the
+   * graph's implementing services into a GraphQL schema. This partial schema should not be
+   * published to the implementing service if there were any errors encountered
+   */
+  errors: Array<Maybe<SchemaCompositionError>>;
+  /** ID that points to the results of composition. */
+  graphCompositionID: Scalars['String'];
+  /** List of subgraphs that are included in this composition. */
+  subgraphConfigs: Array<SubgraphConfig>;
+  /** Whether the gateway link was updated. */
+  updatedGateway: Scalars['Boolean'];
+  /** Whether an implementingService was created as part of this mutation */
+  wasCreated: Scalars['Boolean'];
+  /** Whether an implementingService was updated as part of this mutation */
+  wasUpdated: Scalars['Boolean'];
+};
+
+/** PagerDuty notification channel */
+export type PagerDutyChannel = Channel & {
+  __typename?: 'PagerDutyChannel';
+  id: Scalars['ID'];
+  name: Scalars['String'];
+  routingKey: Scalars['String'];
+  subscriptions: Array<ChannelSubscription>;
+};
+
+/** Query trigger */
+export type QueryTriggerInput = {
+  channelIds?: Maybe<Array<Scalars['String']>>;
+  comparisonOperator: ComparisonOperator;
+  enabled?: Maybe<Scalars['Boolean']>;
+  excludedOperationNames?: Maybe<Array<Scalars['String']>>;
+  metric: QueryTriggerMetric;
+  operationNames?: Maybe<Array<Scalars['String']>>;
+  percentile?: Maybe<Scalars['Float']>;
+  scope?: Maybe<QueryTriggerScope>;
+  threshold: Scalars['Float'];
+  variant?: Maybe<Scalars['String']>;
+  window: QueryTriggerWindow;
+};
+
+export type SubscriptionOptionsInput = {
+  /** Enables notifications for schema updates */
+  schemaUpdates: Scalars['Boolean'];
+};
+
+export type RegistrySubscription = ChannelSubscription & {
+  __typename?: 'RegistrySubscription';
+  channel?: Maybe<Channel>;
+  /** @deprecated Use channels list instead */
+  channels: Array<Channel>;
+  createdAt: Scalars['Timestamp'];
+  enabled: Scalars['Boolean'];
+  id: Scalars['ID'];
+  lastUpdatedAt: Scalars['Timestamp'];
+  options: SubscriptionOptions;
+  variant?: Maybe<Scalars['String']>;
+};
+
+export type SubscriptionOptions = {
+  __typename?: 'SubscriptionOptions';
+  /** Enables notifications for schema updates */
+  schemaUpdates: Scalars['Boolean'];
+};
+
+/** Slack notification channel */
+export type SlackChannel = Channel & {
+  __typename?: 'SlackChannel';
+  id: Scalars['ID'];
+  name: Scalars['String'];
+  subscriptions: Array<ChannelSubscription>;
+  url: Scalars['String'];
+};
+
+/** Webhook notification channel */
+export type WebhookChannel = Channel & {
+  __typename?: 'WebhookChannel';
+  id: Scalars['ID'];
+  name: Scalars['String'];
+  secretToken?: Maybe<Scalars['String']>;
+  subscriptions: Array<ChannelSubscription>;
+  url: Scalars['String'];
+};
+
+export type OperationDocumentInput = {
+  /** Operation document body */
+  body: Scalars['String'];
+  /** Operation name */
+  name?: Maybe<Scalars['String']>;
+};
+
+export type ValidateOperationsResult = {
+  __typename?: 'ValidateOperationsResult';
+  validationResults: Array<ValidationResult>;
+};
+
+/**
+ * Represents a single validation error, with information relating to the error
+ * and its respective operation
+ */
+export type ValidationResult = {
+  __typename?: 'ValidationResult';
+  /** The validation result's error code */
+  code: ValidationErrorCode;
+  /** Description of the validation error */
+  description: Scalars['String'];
+  /** The operation related to this validation result */
+  operation: OperationDocument;
+  /** The type of validation error thrown - warning, failure, or invalid. */
+  type: ValidationErrorType;
+};
+
+export enum ValidationErrorCode {
+  DeprecatedField = 'DEPRECATED_FIELD',
+  InvalidOperation = 'INVALID_OPERATION',
+  NonParseableDocument = 'NON_PARSEABLE_DOCUMENT'
+}
+
+export type OperationDocument = {
+  __typename?: 'OperationDocument';
+  /** Operation document body */
+  body: Scalars['String'];
+  /** Operation name */
+  name?: Maybe<Scalars['String']>;
+};
+
+export enum ValidationErrorType {
+  Failure = 'FAILURE',
+  Invalid = 'INVALID',
+  Warning = 'WARNING'
+}
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutation = {
+  __typename?: 'GraphVariantMutation';
+  addLinkToVariant: GraphVariant;
+  enableTagAndInaccessible?: Maybe<GraphVariant>;
+  /** Graph ID of the variant */
+  graphId: Scalars['String'];
+  /** Global identifier for the graph variant, in the form `graph@variant`. */
+  id: Scalars['ID'];
+  /** Name of the variant, like `variant`. */
+  name: Scalars['String'];
+  relaunch: RelaunchResult;
+  removeLinkFromVariant: GraphVariant;
+  setIsFavoriteOfCurrentUser: GraphVariant;
+  updateDefaultHeaders?: Maybe<GraphVariant>;
+  updateIsProtected?: Maybe<GraphVariant>;
+  updatePreflightScript?: Maybe<GraphVariant>;
+  updateSendCookies?: Maybe<GraphVariant>;
+  updateSubscriptionURL?: Maybe<GraphVariant>;
+  updateURL?: Maybe<GraphVariant>;
+  updateVariantIsPublic?: Maybe<GraphVariant>;
+  updateVariantReadme?: Maybe<GraphVariant>;
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationAddLinkToVariantArgs = {
+  title?: Maybe<Scalars['String']>;
+  type: LinkInfoType;
+  url: Scalars['String'];
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationEnableTagAndInaccessibleArgs = {
+  enabled: Scalars['Boolean'];
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationRemoveLinkFromVariantArgs = {
+  linkInfoId: Scalars['ID'];
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationSetIsFavoriteOfCurrentUserArgs = {
+  favorite: Scalars['Boolean'];
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationUpdateDefaultHeadersArgs = {
+  defaultHeaders?: Maybe<Scalars['String']>;
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationUpdateIsProtectedArgs = {
+  isProtected: Scalars['Boolean'];
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationUpdatePreflightScriptArgs = {
+  preflightScript?: Maybe<Scalars['String']>;
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationUpdateSendCookiesArgs = {
+  sendCookies: Scalars['Boolean'];
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationUpdateSubscriptionUrlArgs = {
+  subscriptionUrl?: Maybe<Scalars['String']>;
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationUpdateUrlArgs = {
+  url?: Maybe<Scalars['String']>;
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationUpdateVariantIsPublicArgs = {
+  isPublic: Scalars['Boolean'];
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationUpdateVariantReadmeArgs = {
+  readme: Scalars['String'];
+};
+
+export type RelaunchResult = RelaunchComplete | RelaunchError;
+
+export type RelaunchComplete = {
+  __typename?: 'RelaunchComplete';
+  latestLaunch: Launch;
+  updated: Scalars['Boolean'];
+};
+
+export type RelaunchError = {
+  __typename?: 'RelaunchError';
+  message: Scalars['String'];
+};
+
+export type UserMutation = {
+  __typename?: 'UserMutation';
+  acceptPrivacyPolicy?: Maybe<Scalars['Void']>;
+  /** Change the user's password */
+  changePassword?: Maybe<Scalars['Void']>;
+  createOdysseyCourses?: Maybe<Array<OdysseyCourse>>;
+  createOdysseyTasks?: Maybe<Array<OdysseyTask>>;
+  /** Delete the user's avatar. Requires User.canUpdateAvatar to be true. */
+  deleteAvatar?: Maybe<AvatarDeleteError>;
+  /** Hard deletes the associated user. Throws an error otherwise with reason included. */
+  hardDelete?: Maybe<Scalars['Void']>;
+  /** Create a new API key for this user. Must take in a name for this key. */
+  newKey: UserApiKey;
+  /**
+   * Create a new API key for this user if there are no current API keys.
+   * If an API key already exists, this will return one at random and not create a new one.
+   */
+  provisionKey?: Maybe<ApiKeyProvision>;
+  /** Refresh information about the user from its upstream service (eg list of organizations from GitHub) */
+  refresh?: Maybe<User>;
+  /** Removes the given key from this user. Can be used to remove either a web cookie or a user API key. */
+  removeKey?: Maybe<Scalars['Void']>;
+  /** Renames the given key to the new key name. */
+  renameKey?: Maybe<UserApiKey>;
+  resendVerificationEmail?: Maybe<Scalars['Void']>;
+  setOdysseyCourse?: Maybe<OdysseyCourse>;
+  setOdysseyTask?: Maybe<OdysseyTask>;
+  /** Submit a zendesk ticket for this user */
+  submitZendeskTicket?: Maybe<ZendeskTicket>;
+  /** Update information about a user; all arguments are optional */
+  update?: Maybe<User>;
+  /** Updates this users' preference concerning opting into beta features. */
+  updateBetaFeaturesOn?: Maybe<User>;
+  /** Update the status of a feature for this. For example, if you want to hide an introductory popup. */
+  updateFeatureIntros?: Maybe<User>;
+  /**
+   * Update user to have the given internal mdg admin role.
+   * It is necessary to be an MDG_INTERNAL_SUPER_ADMIN to perform update.
+   * Additionally, upserting a null value explicitly revokes this user's
+   * admin status.
+   */
+  updateRole?: Maybe<User>;
+  user: User;
+  verifyEmail?: Maybe<User>;
+};
+
+
+export type UserMutationChangePasswordArgs = {
+  newPassword: Scalars['String'];
+  previousPassword: Scalars['String'];
+};
+
+
+export type UserMutationCreateOdysseyCoursesArgs = {
+  courses: Array<OdysseyCourseInput>;
+};
+
+
+export type UserMutationCreateOdysseyTasksArgs = {
+  tasks: Array<OdysseyTaskInput>;
+};
+
+
+export type UserMutationNewKeyArgs = {
+  keyName: Scalars['String'];
+};
+
+
+export type UserMutationProvisionKeyArgs = {
+  keyName?: Scalars['String'];
+};
+
+
+export type UserMutationRemoveKeyArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type UserMutationRenameKeyArgs = {
+  id: Scalars['ID'];
+  newKeyName?: Maybe<Scalars['String']>;
+};
+
+
+export type UserMutationSetOdysseyCourseArgs = {
+  course: OdysseyCourseInput;
+};
+
+
+export type UserMutationSetOdysseyTaskArgs = {
+  task: OdysseyTaskInput;
+};
+
+
+export type UserMutationSubmitZendeskTicketArgs = {
+  collaborators?: Maybe<Array<Scalars['String']>>;
+  email: Scalars['String'];
+  ticket: ZendeskTicketInput;
+};
+
+
+export type UserMutationUpdateArgs = {
+  email?: Maybe<Scalars['String']>;
+  fullName?: Maybe<Scalars['String']>;
+  referrer?: Maybe<Scalars['String']>;
+  trackingGoogleClientId?: Maybe<Scalars['String']>;
+  trackingMarketoClientId?: Maybe<Scalars['String']>;
+  userSegment?: Maybe<UserSegment>;
+  utmCampaign?: Maybe<Scalars['String']>;
+  utmMedium?: Maybe<Scalars['String']>;
+  utmSource?: Maybe<Scalars['String']>;
+};
+
+
+export type UserMutationUpdateBetaFeaturesOnArgs = {
+  betaFeaturesOn: Scalars['Boolean'];
+};
+
+
+export type UserMutationUpdateFeatureIntrosArgs = {
+  newFeatureIntros?: Maybe<FeatureIntrosInput>;
+};
+
+
+export type UserMutationUpdateRoleArgs = {
+  newRole?: Maybe<InternalMdgAdminRole>;
+};
+
+
+export type UserMutationVerifyEmailArgs = {
+  token: Scalars['String'];
+};
+
+export type OdysseyCourseInput = {
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  courseId: Scalars['String'];
+};
+
+export type OdysseyTaskInput = {
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  taskId: Scalars['String'];
+  value?: Maybe<Scalars['String']>;
+};
+
+export type ApiKeyProvision = {
+  __typename?: 'ApiKeyProvision';
+  apiKey: ApiKey;
+  created: Scalars['Boolean'];
+};
+
+/** Zendesk ticket input */
+export type ZendeskTicketInput = {
+  description: Scalars['String'];
+  graphId?: Maybe<Scalars['String']>;
+  organizationId?: Maybe<Scalars['String']>;
+  priority: TicketPriority;
+  subject: Scalars['String'];
+};
+
+export enum UserSegment {
+  JoinMyTeam = 'JOIN_MY_TEAM',
+  LocalDevelopment = 'LOCAL_DEVELOPMENT',
+  NotSpecified = 'NOT_SPECIFIED',
+  ProductionGraphs = 'PRODUCTION_GRAPHS',
+  Sandbox = 'SANDBOX',
+  TryTeam = 'TRY_TEAM'
+}
+
+/** Feature Intros Input Type */
+export type FeatureIntrosInput = {
+  devGraph?: Maybe<Scalars['Boolean']>;
+  federatedGraph?: Maybe<Scalars['Boolean']>;
+  freeConsumerSeats?: Maybe<Scalars['Boolean']>;
+};
+
+export type SchemaReport = {
+  /** A randomly generated UUID, immutable for the lifetime of the edge server runtime. */
+  bootId: Scalars['String'];
+  /** The hex SHA256 hash of the schema being reported. Note that for a GraphQL server with a core schema, this should be the core schema, not the API schema. */
+  coreSchemaHash: Scalars['String'];
+  /** The graph ref (eg, 'id@variant') */
+  graphRef: Scalars['String'];
+  /** The version of the edge server reporting agent, e.g. apollo-server-2.8, graphql-java-3.1, etc. length must be <= 256 characters. */
+  libraryVersion?: Maybe<Scalars['String']>;
+  /** The infra environment in which this edge server is running, e.g. localhost, Kubernetes, AWS Lambda, Google CloudRun, AWS ECS, etc. length must be <= 256 characters. */
+  platform?: Maybe<Scalars['String']>;
+  /** The runtime in which the edge server is running, e.g. node 12.03, zulu8.46.0.19-ca-jdk8.0.252-macosx_x64, etc. length must be <= 256 characters. */
+  runtimeVersion?: Maybe<Scalars['String']>;
+  /** If available, an identifier for the edge server instance, such that when restarting this instance it will have the same serverId, with a different bootId. For example, in Kubernetes this might be the pod name. Length must be <= 256 characters. */
+  serverId?: Maybe<Scalars['String']>;
+  /** An identifier used to distinguish the version (from the user's perspective) of the edge server's code itself. For instance, the git sha of the server's repository or the docker sha of the associated image this server runs with. Length must be <= 256 characters. */
+  userVersion?: Maybe<Scalars['String']>;
+};
+
+export type ReportSchemaResult = {
+  inSeconds: Scalars['Int'];
+  withCoreSchema: Scalars['Boolean'];
+};
+
+/** Explorer user settings input */
+export type UserSettingsInput = {
+  appNavCollapsed?: Maybe<Scalars['Boolean']>;
+  autoManageVariables?: Maybe<Scalars['Boolean']>;
+  mockingResponses?: Maybe<Scalars['Boolean']>;
+  preflightScriptEnabled?: Maybe<Scalars['Boolean']>;
+  responseHints?: Maybe<ResponseHints>;
+  tableMode?: Maybe<Scalars['Boolean']>;
+  themeName?: Maybe<ThemeName>;
+};
+
+export enum DeletionTargetType {
+  Account = 'ACCOUNT',
+  User = 'USER'
+}
+
+/**  Input parameters for run explorer operation event. */
+export enum EventEnum {
+  ClickCheckList = 'CLICK_CHECK_LIST',
+  ClickGoToGraphSettings = 'CLICK_GO_TO_GRAPH_SETTINGS',
+  RunExplorerOperation = 'RUN_EXPLORER_OPERATION'
+}
+
+export type CompositionStatusSubscription = ChannelSubscription & {
+  __typename?: 'CompositionStatusSubscription';
+  channels: Array<Channel>;
+  createdAt: Scalars['Timestamp'];
+  enabled: Scalars['Boolean'];
+  id: Scalars['ID'];
+  lastUpdatedAt: Scalars['Timestamp'];
+  variant?: Maybe<Scalars['String']>;
+};
+
+export type InternalIdentity = Identity & {
+  __typename?: 'InternalIdentity';
+  accounts: Array<Account>;
+  asActor: Actor;
+  email?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  name: Scalars['String'];
+};
+
+/** query documents to validate against */
+export type QueryDocumentInput = {
+  document?: Maybe<Scalars['String']>;
+};
+
+export type RegistryApiKey = {
+  __typename?: 'RegistryApiKey';
+  keyName?: Maybe<Scalars['String']>;
+  token: Scalars['String'];
+};
+
+export type ReportSchemaError = ReportSchemaResult & {
+  __typename?: 'ReportSchemaError';
+  code: ReportSchemaErrorCode;
+  inSeconds: Scalars['Int'];
+  message: Scalars['String'];
+  withCoreSchema: Scalars['Boolean'];
+};
+
+export enum ReportSchemaErrorCode {
+  BootIdIsNotValidUuid = 'BOOT_ID_IS_NOT_VALID_UUID',
+  BootIdIsRequired = 'BOOT_ID_IS_REQUIRED',
+  CoreSchemaHashIsNotSchemaSha256 = 'CORE_SCHEMA_HASH_IS_NOT_SCHEMA_SHA256',
+  CoreSchemaHashIsRequired = 'CORE_SCHEMA_HASH_IS_REQUIRED',
+  CoreSchemaHashIsTooLong = 'CORE_SCHEMA_HASH_IS_TOO_LONG',
+  ExecutableSchemaIdIsNotSchemaSha256 = 'EXECUTABLE_SCHEMA_ID_IS_NOT_SCHEMA_SHA256',
+  ExecutableSchemaIdIsRequired = 'EXECUTABLE_SCHEMA_ID_IS_REQUIRED',
+  ExecutableSchemaIdIsTooLong = 'EXECUTABLE_SCHEMA_ID_IS_TOO_LONG',
+  GraphRefInvalidFormat = 'GRAPH_REF_INVALID_FORMAT',
+  GraphRefIsRequired = 'GRAPH_REF_IS_REQUIRED',
+  GraphVariantDoesNotMatchRegex = 'GRAPH_VARIANT_DOES_NOT_MATCH_REGEX',
+  GraphVariantIsRequired = 'GRAPH_VARIANT_IS_REQUIRED',
+  LibraryVersionIsTooLong = 'LIBRARY_VERSION_IS_TOO_LONG',
+  PlatformIsTooLong = 'PLATFORM_IS_TOO_LONG',
+  RuntimeVersionIsTooLong = 'RUNTIME_VERSION_IS_TOO_LONG',
+  SchemaIsNotParsable = 'SCHEMA_IS_NOT_PARSABLE',
+  SchemaIsNotValid = 'SCHEMA_IS_NOT_VALID',
+  ServerIdIsTooLong = 'SERVER_ID_IS_TOO_LONG',
+  UserVersionIsTooLong = 'USER_VERSION_IS_TOO_LONG'
+}
+
+export type ReportSchemaResponse = ReportSchemaResult & {
+  __typename?: 'ReportSchemaResponse';
+  inSeconds: Scalars['Int'];
+  withCoreSchema: Scalars['Boolean'];
+};
+
+export type ReportServerInfoError = ReportServerInfoResult & {
+  __typename?: 'ReportServerInfoError';
+  code: ReportSchemaErrorCode;
+  inSeconds: Scalars['Int'];
+  message: Scalars['String'];
+  withExecutableSchema: Scalars['Boolean'];
+};
+
+export type ReportServerInfoResponse = ReportServerInfoResult & {
+  __typename?: 'ReportServerInfoResponse';
+  inSeconds: Scalars['Int'];
+  withExecutableSchema: Scalars['Boolean'];
+};
+
+export type StringToStringInput = {
+  key: Scalars['String'];
+  value: Scalars['String'];
+};
+
+export type Uri = {
+  __typename?: 'URI';
+  /** A GCS URI */
+  gcs: Scalars['String'];
+};
+
+export type SchemaTagsAndFieldStatsQueryVariables = Exact<{
+  id: Scalars['ID'];
+}>;
+
+
+export type SchemaTagsAndFieldStatsQuery = { __typename?: 'Query', service?: Maybe<{ __typename?: 'Service', schemaTags?: Maybe<Array<{ __typename?: 'SchemaTag', tag: string }>>, stats: { __typename?: 'ServiceStatsWindow', fieldStats: Array<{ __typename?: 'ServiceFieldStatsRecord', groupBy: { __typename?: 'ServiceFieldStatsDimensions', field?: Maybe<string> }, metrics: { __typename?: 'ServiceFieldStatsMetrics', fieldHistogram: { __typename?: 'DurationHistogram', durationMs?: Maybe<number> } } }> } }> };
+
+export type GetSchemaByTagQueryVariables = Exact<{
+  tag: Scalars['String'];
+  id: Scalars['ID'];
+}>;
+
+
+export type GetSchemaByTagQuery = { __typename?: 'Query', service?: Maybe<{ __typename: 'Service', schema?: Maybe<{ __typename?: 'Schema', hash: string, __schema: { __typename?: 'IntrospectionSchema', queryType: { __typename?: 'IntrospectionType', name?: Maybe<string> }, mutationType?: Maybe<{ __typename?: 'IntrospectionType', name?: Maybe<string> }>, subscriptionType?: Maybe<{ __typename?: 'IntrospectionType', name?: Maybe<string> }>, types: Array<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, description?: Maybe<string>, fields?: Maybe<Array<{ __typename?: 'IntrospectionField', name: string, description?: Maybe<string>, isDeprecated: boolean, deprecationReason?: Maybe<string>, args: Array<{ __typename?: 'IntrospectionInputValue', name: string, description?: Maybe<string>, defaultValue?: Maybe<string>, type: { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> } }>, type: { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> } }>>, inputFields?: Maybe<Array<{ __typename?: 'IntrospectionInputValue', name: string, description?: Maybe<string>, defaultValue?: Maybe<string>, type: { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> } }>>, interfaces?: Maybe<Array<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> }>>, enumValues?: Maybe<Array<{ __typename?: 'IntrospectionEnumValue', name: string, description?: Maybe<string>, isDeprecated: boolean, deprecationReason?: Maybe<string> }>>, possibleTypes?: Maybe<Array<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> }>> }>, directives: Array<{ __typename?: 'IntrospectionDirective', name: string, description?: Maybe<string>, locations: Array<IntrospectionDirectiveLocation>, args: Array<{ __typename?: 'IntrospectionInputValue', name: string, description?: Maybe<string>, defaultValue?: Maybe<string>, type: { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> } }> }> } }> }> };
+
+export type IntrospectionFullTypeFragment = { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, description?: Maybe<string>, fields?: Maybe<Array<{ __typename?: 'IntrospectionField', name: string, description?: Maybe<string>, isDeprecated: boolean, deprecationReason?: Maybe<string>, args: Array<{ __typename?: 'IntrospectionInputValue', name: string, description?: Maybe<string>, defaultValue?: Maybe<string>, type: { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> } }>, type: { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> } }>>, inputFields?: Maybe<Array<{ __typename?: 'IntrospectionInputValue', name: string, description?: Maybe<string>, defaultValue?: Maybe<string>, type: { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> } }>>, interfaces?: Maybe<Array<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> }>>, enumValues?: Maybe<Array<{ __typename?: 'IntrospectionEnumValue', name: string, description?: Maybe<string>, isDeprecated: boolean, deprecationReason?: Maybe<string> }>>, possibleTypes?: Maybe<Array<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> }>> };
+
+export type IntrospectionInputValueFragment = { __typename?: 'IntrospectionInputValue', name: string, description?: Maybe<string>, defaultValue?: Maybe<string>, type: { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> } };
+
+export type IntrospectionTypeRefFragment = { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> };

--- a/src/language-server/graphqlTypes.ts
+++ b/src/language-server/graphqlTypes.ts
@@ -27,53 +27,53 @@ export type Scalars = {
 
 export type Query = {
   __typename?: 'Query';
-  _odysseyFakeField?: Maybe<Scalars['Boolean']>;
+  _odysseyFakeField: Maybe<Scalars['Boolean']>;
   /** Account by ID */
-  account?: Maybe<Account>;
+  account: Maybe<Account>;
   /** Whether an account ID is available for mutation{newAccount(id:)} */
   accountIDAvailable: Scalars['Boolean'];
   /** All accounts */
-  allAccounts?: Maybe<Array<Account>>;
+  allAccounts: Maybe<Array<Account>>;
   /** All available plans */
   allPlans: Array<BillingPlan>;
   /** All services */
-  allServices?: Maybe<Array<Service>>;
+  allServices: Maybe<Array<Service>>;
   /** All timezones with their offsets from UTC */
   allTimezoneOffsets: Array<TimezoneOffset>;
   /** All users */
-  allUsers?: Maybe<Array<User>>;
+  allUsers: Maybe<Array<User>>;
   /** If this is true, the user is an Apollo administrator who can ignore restrictions based purely on billing plan. */
   canBypassPlanRestrictions: Scalars['Boolean'];
   diffSchemas: Array<Change>;
   /** Get the unsubscribe settings for a given email. */
-  emailPreferences?: Maybe<EmailPreferences>;
+  emailPreferences: Maybe<EmailPreferences>;
   experimentalFeatures: GlobalExperimentalFeatures;
   frontendUrlRoot: Scalars['String'];
   internalActiveCronJobs: Array<CronJob>;
-  internalAdminUsers?: Maybe<Array<InternalAdminUser>>;
+  internalAdminUsers: Maybe<Array<InternalAdminUser>>;
   internalUnresolvedCronExecutionFailures: Array<CronExecution>;
   /** Current identity, null if not authenticated */
-  me?: Maybe<Identity>;
+  me: Maybe<Identity>;
   /** Look up a plan by ID */
-  plan?: Maybe<BillingPlan>;
+  plan: Maybe<BillingPlan>;
   /** Service by ID */
-  service?: Maybe<Service>;
+  service: Maybe<Service>;
   /** Query statistics across all services. For admins only; normal users must go through AccountsStatsWindow or ServiceStatsWindow. */
   stats: StatsWindow;
   /** Get the studio settings for the current user */
-  studioSettings?: Maybe<UserSettings>;
+  studioSettings: Maybe<UserSettings>;
   /** The plan started by AccountMutation.startTeamSubscription */
   teamPlan: BillingPlan;
   /** The plan started by AccountMutation.startTrial */
   trialPlan: BillingPlan;
   /** User by ID */
-  user?: Maybe<User>;
+  user: Maybe<User>;
   /**
    * Access a variant by reference of the form `graphID@variantName`, or `graphID` for the default `current` variant.
    * Returns null when the graph or variant do not exist, or when the graph cannot be accessed.
    * Note that we can return more types implementing Error in the future.
    */
-  variant?: Maybe<GraphVariantLookup>;
+  variant: Maybe<GraphVariantLookup>;
 };
 
 
@@ -88,18 +88,18 @@ export type QueryAccountIdAvailableArgs = {
 
 
 export type QueryAllAccountsArgs = {
-  search?: Maybe<Scalars['String']>;
-  tier?: Maybe<BillingPlanTier>;
+  search: Maybe<Scalars['String']>;
+  tier: Maybe<BillingPlanTier>;
 };
 
 
 export type QueryAllServicesArgs = {
-  search?: Maybe<Scalars['String']>;
+  search: Maybe<Scalars['String']>;
 };
 
 
 export type QueryAllUsersArgs = {
-  search?: Maybe<Scalars['String']>;
+  search: Maybe<Scalars['String']>;
 };
 
 
@@ -116,7 +116,7 @@ export type QueryEmailPreferencesArgs = {
 
 
 export type QueryPlanArgs = {
-  id?: Maybe<Scalars['ID']>;
+  id: Maybe<Scalars['ID']>;
 };
 
 
@@ -127,8 +127,8 @@ export type QueryServiceArgs = {
 
 export type QueryStatsArgs = {
   from: Scalars['Timestamp'];
-  resolution?: Maybe<Resolution>;
-  to?: Maybe<Scalars['Timestamp']>;
+  resolution: Maybe<Resolution>;
+  to: Maybe<Scalars['Timestamp']>;
 };
 
 
@@ -148,7 +148,7 @@ export type QueryVariantArgs = {
 
 export type Account = {
   __typename?: 'Account';
-  auditLogExports?: Maybe<Array<AuditLogExport>>;
+  auditLogExports: Maybe<Array<AuditLogExport>>;
   /** These are the roles that the account is able to use */
   availableRoles: Array<UserPermission>;
   /**
@@ -158,21 +158,21 @@ export type Account = {
    * filename, if such information is available. Client MUST set the "x-apollo-csrf-token" header to
    * MediaUploadInfo.csrfToken.
    */
-  avatarUpload?: Maybe<AvatarUploadResult>;
+  avatarUpload: Maybe<AvatarUploadResult>;
   /**
    * Get an image URL for the account's avatar. Note that CORS is not enabled for these URLs. The size
    * argument is used for bandwidth reduction, and should be the size of the image as displayed in the
    * application. Apollo's media server will downscale larger images to at least the requested size,
    * but this will not happen for third-party media servers.
    */
-  avatarUrl?: Maybe<Scalars['String']>;
-  billingInfo?: Maybe<BillingInfo>;
-  companyUrl?: Maybe<Scalars['String']>;
-  currentBillingMonth?: Maybe<BillingMonth>;
+  avatarUrl: Maybe<Scalars['String']>;
+  billingInfo: Maybe<BillingInfo>;
+  companyUrl: Maybe<Scalars['String']>;
+  currentBillingMonth: Maybe<BillingMonth>;
   currentPlan: BillingPlan;
-  currentSubscription?: Maybe<BillingSubscription>;
+  currentSubscription: Maybe<BillingSubscription>;
   experimentalFeatures: AccountExperimentalFeatures;
-  expiredTrialSubscription?: Maybe<BillingSubscription>;
+  expiredTrialSubscription: Maybe<BillingSubscription>;
   graphIDAvailable: Scalars['Boolean'];
   hasBeenOnTrial: Scalars['Boolean'];
   id: Scalars['ID'];
@@ -181,38 +181,38 @@ export type Account = {
    * shouldn't be used in normal client apps).
    */
   internalID: Scalars['ID'];
-  invitations?: Maybe<Array<AccountInvitation>>;
-  invoices?: Maybe<Array<Invoice>>;
+  invitations: Maybe<Array<AccountInvitation>>;
+  invoices: Maybe<Array<Invoice>>;
   isOnExpiredTrial: Scalars['Boolean'];
   isOnTrial: Scalars['Boolean'];
-  memberships?: Maybe<Array<AccountMembership>>;
+  memberships: Maybe<Array<AccountMembership>>;
   name: Scalars['String'];
-  provisionedAt?: Maybe<Scalars['Timestamp']>;
-  recurlyEmail?: Maybe<Scalars['String']>;
-  requests?: Maybe<Scalars['Long']>;
-  requestsInCurrentBillingPeriod?: Maybe<Scalars['Long']>;
-  roles?: Maybe<AccountRoles>;
+  provisionedAt: Maybe<Scalars['Timestamp']>;
+  recurlyEmail: Maybe<Scalars['String']>;
+  requests: Maybe<Scalars['Long']>;
+  requestsInCurrentBillingPeriod: Maybe<Scalars['Long']>;
+  roles: Maybe<AccountRoles>;
   /** How many seats would be included in your next bill, as best estimated today */
-  seatCountForNextBill?: Maybe<Scalars['Int']>;
-  seats?: Maybe<Seats>;
+  seatCountForNextBill: Maybe<Scalars['Int']>;
+  seats: Maybe<Seats>;
   secondaryIDs: Array<Scalars['ID']>;
   services: Array<Service>;
   /**
    * If non-null, this organization tracks its members through an upstream, eg PingOne;
    * invitations are not possible on SSO-synchronized account.
    */
-  sso?: Maybe<OrganizationSso>;
-  state?: Maybe<AccountState>;
+  sso: Maybe<OrganizationSso>;
+  state: Maybe<AccountState>;
   /** A list of reusable invitations for the organization. */
-  staticInvitations?: Maybe<Array<OrganizationInviteLink>>;
+  staticInvitations: Maybe<Array<OrganizationInviteLink>>;
   /** @deprecated use Account.statsWindow instead */
   stats: AccountStatsWindow;
-  statsWindow?: Maybe<AccountStatsWindow>;
-  subscriptions?: Maybe<Array<BillingSubscription>>;
+  statsWindow: Maybe<AccountStatsWindow>;
+  subscriptions: Maybe<Array<BillingSubscription>>;
   /** Gets a ticket for this org, by id */
-  ticket?: Maybe<ZendeskTicket>;
+  ticket: Maybe<ZendeskTicket>;
   /** List of Zendesk tickets submitted for this org */
-  tickets?: Maybe<Array<ZendeskTicket>>;
+  tickets: Maybe<Array<ZendeskTicket>>;
 };
 
 
@@ -238,21 +238,21 @@ export type AccountRequestsArgs = {
 
 
 export type AccountServicesArgs = {
-  includeDeleted?: Maybe<Scalars['Boolean']>;
+  includeDeleted: Maybe<Scalars['Boolean']>;
 };
 
 
 export type AccountStatsArgs = {
   from: Scalars['Timestamp'];
-  resolution?: Maybe<Resolution>;
-  to?: Maybe<Scalars['Timestamp']>;
+  resolution: Maybe<Resolution>;
+  to: Maybe<Scalars['Timestamp']>;
 };
 
 
 export type AccountStatsWindowArgs = {
   from: Scalars['Timestamp'];
-  resolution?: Maybe<Resolution>;
-  to?: Maybe<Scalars['Timestamp']>;
+  resolution: Maybe<Resolution>;
+  to: Maybe<Scalars['Timestamp']>;
 };
 
 
@@ -262,15 +262,15 @@ export type AccountTicketArgs = {
 
 export type AuditLogExport = {
   __typename?: 'AuditLogExport';
-  actors?: Maybe<Array<Identity>>;
-  bigqueryTriggeredAt?: Maybe<Scalars['Timestamp']>;
-  completedAt?: Maybe<Scalars['Timestamp']>;
+  actors: Maybe<Array<Identity>>;
+  bigqueryTriggeredAt: Maybe<Scalars['Timestamp']>;
+  completedAt: Maybe<Scalars['Timestamp']>;
   createdAt: Scalars['Timestamp'];
-  exportedFiles?: Maybe<Array<Scalars['String']>>;
+  exportedFiles: Maybe<Array<Scalars['String']>>;
   from: Scalars['Timestamp'];
-  graphs?: Maybe<Array<Service>>;
+  graphs: Maybe<Array<Service>>;
   id: Scalars['ID'];
-  requester?: Maybe<User>;
+  requester: Maybe<User>;
   status: AuditStatus;
   to: Scalars['Timestamp'];
 };
@@ -299,9 +299,9 @@ export enum ActorType {
 
 export type Service = Identity & {
   __typename?: 'Service';
-  account?: Maybe<Account>;
-  accountId?: Maybe<Scalars['ID']>;
-  apiKeys?: Maybe<Array<GraphApiKey>>;
+  account: Maybe<Account>;
+  accountId: Maybe<Scalars['ID']>;
+  apiKeys: Maybe<Array<GraphApiKey>>;
   asActor: Actor;
   /**
    * Get an URL to which an avatar image can be uploaded. Client uploads by sending a PUT request
@@ -310,18 +310,18 @@ export type Service = Identity & {
    * filename, if such information is available. Client MUST set the "x-apollo-csrf-token" header to
    * MediaUploadInfo.csrfToken.
    */
-  avatarUpload?: Maybe<AvatarUploadResult>;
+  avatarUpload: Maybe<AvatarUploadResult>;
   /**
    * Get an image URL for the service's avatar. Note that CORS is not enabled for these URLs. The size
    * argument is used for bandwidth reduction, and should be the size of the image as displayed in the
    * application. Apollo's media server will downscale larger images to at least the requested size,
    * but this will not happen for third-party media servers.
    */
-  avatarUrl?: Maybe<Scalars['String']>;
+  avatarUrl: Maybe<Scalars['String']>;
   /** Get available notification endpoints */
-  channels?: Maybe<Array<Channel>>;
+  channels: Maybe<Array<Channel>>;
   /** Get check configuration for this graph. */
-  checkConfiguration?: Maybe<CheckConfiguration>;
+  checkConfiguration: Maybe<CheckConfiguration>;
   /**
    * List of options available for filtering checks for this graph by author.
    * If a filter is passed, constrains results to match the filter.
@@ -338,18 +338,18 @@ export type Service = Identity & {
    */
   checksSubgraphOptions: Array<Scalars['String']>;
   /** Get a check workflow for this graph by its ID */
-  checkWorkflow?: Maybe<CheckWorkflow>;
+  checkWorkflow: Maybe<CheckWorkflow>;
   /** Get check workflows for this graph ordered by creation time, most recent first. */
   checkWorkflows: Array<CheckWorkflow>;
   /** Given a graphCompositionID, return the results of composition. This can represent either a validation or a publish. */
-  compositionResultById?: Maybe<CompositionResult>;
+  compositionResultById: Maybe<CompositionResult>;
   createdAt: Scalars['Timestamp'];
-  createdBy?: Maybe<Identity>;
-  datadogMetricsConfig?: Maybe<DatadogMetricsConfig>;
-  deletedAt?: Maybe<Scalars['Timestamp']>;
-  description?: Maybe<Scalars['String']>;
-  devGraphOwner?: Maybe<User>;
-  firstReportedAt?: Maybe<Scalars['Timestamp']>;
+  createdBy: Maybe<Identity>;
+  datadogMetricsConfig: Maybe<DatadogMetricsConfig>;
+  deletedAt: Maybe<Scalars['Timestamp']>;
+  description: Maybe<Scalars['String']>;
+  devGraphOwner: Maybe<User>;
+  firstReportedAt: Maybe<Scalars['Timestamp']>;
   /**
    * When this is true, this graph will be hidden from non-admin members of the org who haven't been explicitly assigned a
    * role on this graph.
@@ -360,27 +360,27 @@ export type Service = Identity & {
    * List of implementing services that comprise a graph. A non-federated graph should have a single implementing service.
    * Set includeDeleted to see deleted implementing services.
    */
-  implementingServices?: Maybe<GraphImplementors>;
-  lastReportedAt?: Maybe<Scalars['Timestamp']>;
+  implementingServices: Maybe<GraphImplementors>;
+  lastReportedAt: Maybe<Scalars['Timestamp']>;
   /** Current identity, null if not authenticated. */
-  me?: Maybe<Identity>;
+  me: Maybe<Identity>;
   /**
    * This returns the composition result that was most recently published to the graph.
    * Only identities that canQuerySchemas and canQueryImplementingServices have access
    * to this field
    */
-  mostRecentCompositionPublish?: Maybe<CompositionPublishResult>;
-  myRole?: Maybe<UserPermission>;
+  mostRecentCompositionPublish: Maybe<CompositionPublishResult>;
+  myRole: Maybe<UserPermission>;
   /** @deprecated Use Service.title */
   name: Scalars['String'];
-  operation?: Maybe<Operation>;
+  operation: Maybe<Operation>;
   /** Gets the operations and their approved changes for this graph, checkID, and operationID. */
   operationsAcceptedChanges: Array<OperationAcceptedChange>;
   /** Get an operations check result for a specific check ID */
-  operationsCheck?: Maybe<OperationsCheckResult>;
+  operationsCheck: Maybe<OperationsCheckResult>;
   /** Get query triggers for a given variant. If variant is null all the triggers for this service will be gotten. */
-  queryTriggers?: Maybe<Array<QueryTrigger>>;
-  readme?: Maybe<Readme>;
+  queryTriggers: Maybe<Array<QueryTrigger>>;
+  readme: Maybe<Readme>;
   /**
    * Whether registry subscriptions (with any options) are enabled. If variant is not passed, returns true if configuration is present for any variant
    * @deprecated This field will be removed
@@ -388,30 +388,30 @@ export type Service = Identity & {
   registrySubscriptionsEnabled: Scalars['Boolean'];
   reportingEnabled: Scalars['Boolean'];
   /** The list of members that can access this graph, accounting for graph role overrides */
-  roleOverrides?: Maybe<Array<RoleOverride>>;
+  roleOverrides: Maybe<Array<RoleOverride>>;
   /** Which permissions the current user has for interacting with this service */
-  roles?: Maybe<ServiceRoles>;
+  roles: Maybe<ServiceRoles>;
   scheduledSummaries: Array<ScheduledSummary>;
   /** Get a schema by hash OR current tag */
-  schema?: Maybe<Schema>;
+  schema: Maybe<Schema>;
   /** Get the schema tag */
-  schemaTag?: Maybe<SchemaTag>;
-  schemaTagById?: Maybe<SchemaTag>;
+  schemaTag: Maybe<SchemaTag>;
+  schemaTagById: Maybe<SchemaTag>;
   /**
    * Get schema tags, with optional filtering to a set of tags. Always sorted by creation
    * date in reverse chronological order.
    */
-  schemaTags?: Maybe<Array<SchemaTag>>;
+  schemaTags: Maybe<Array<SchemaTag>>;
   /** @deprecated use Service.statsWindow instead */
   stats: ServiceStatsWindow;
-  statsWindow?: Maybe<ServiceStatsWindow>;
+  statsWindow: Maybe<ServiceStatsWindow>;
   /** Generate a test schema publish notification body */
   testSchemaPublishBody: Scalars['String'];
   title: Scalars['String'];
-  trace?: Maybe<Trace>;
+  trace: Maybe<Trace>;
   traceStorageEnabled: Scalars['Boolean'];
   /** A particular variant (sometimes called "tag") of the graph, often representing a live traffic environment (such as "prod"). Each variant can represent a specific URL or destination to query at, analytics, and its own schema history. */
-  variant?: Maybe<GraphVariant>;
+  variant: Maybe<GraphVariant>;
   /** The list of variants that exist for this graph */
   variants: Array<GraphVariant>;
 };
@@ -423,22 +423,22 @@ export type ServiceAvatarUrlArgs = {
 
 
 export type ServiceChannelsArgs = {
-  channelIds?: Maybe<Array<Scalars['ID']>>;
+  channelIds: Maybe<Array<Scalars['ID']>>;
 };
 
 
 export type ServiceChecksAuthorOptionsArgs = {
-  filter?: Maybe<CheckFilterInput>;
+  filter: Maybe<CheckFilterInput>;
 };
 
 
 export type ServiceChecksBranchOptionsArgs = {
-  filter?: Maybe<CheckFilterInput>;
+  filter: Maybe<CheckFilterInput>;
 };
 
 
 export type ServiceChecksSubgraphOptionsArgs = {
-  filter?: Maybe<CheckFilterInput>;
+  filter: Maybe<CheckFilterInput>;
 };
 
 
@@ -448,7 +448,7 @@ export type ServiceCheckWorkflowArgs = {
 
 
 export type ServiceCheckWorkflowsArgs = {
-  filter?: Maybe<CheckFilterInput>;
+  filter: Maybe<CheckFilterInput>;
   limit?: Scalars['Int'];
 };
 
@@ -460,12 +460,12 @@ export type ServiceCompositionResultByIdArgs = {
 
 export type ServiceImplementingServicesArgs = {
   graphVariant: Scalars['String'];
-  includeDeleted?: Maybe<Scalars['Boolean']>;
+  includeDeleted: Maybe<Scalars['Boolean']>;
 };
 
 
 export type ServiceLastReportedAtArgs = {
-  graphVariant?: Maybe<Scalars['String']>;
+  graphVariant: Maybe<Scalars['String']>;
 };
 
 
@@ -491,19 +491,19 @@ export type ServiceOperationsCheckArgs = {
 
 
 export type ServiceQueryTriggersArgs = {
-  graphVariant?: Maybe<Scalars['String']>;
-  operationNames?: Maybe<Array<Scalars['String']>>;
+  graphVariant: Maybe<Scalars['String']>;
+  operationNames: Maybe<Array<Scalars['String']>>;
 };
 
 
 export type ServiceRegistrySubscriptionsEnabledArgs = {
-  graphVariant?: Maybe<Scalars['String']>;
+  graphVariant: Maybe<Scalars['String']>;
 };
 
 
 export type ServiceSchemaArgs = {
-  hash?: Maybe<Scalars['ID']>;
-  tag?: Maybe<Scalars['String']>;
+  hash: Maybe<Scalars['ID']>;
+  tag: Maybe<Scalars['String']>;
 };
 
 
@@ -518,21 +518,21 @@ export type ServiceSchemaTagByIdArgs = {
 
 
 export type ServiceSchemaTagsArgs = {
-  tags?: Maybe<Array<Scalars['String']>>;
+  tags: Maybe<Array<Scalars['String']>>;
 };
 
 
 export type ServiceStatsArgs = {
   from: Scalars['Timestamp'];
-  resolution?: Maybe<Resolution>;
-  to?: Maybe<Scalars['Timestamp']>;
+  resolution: Maybe<Resolution>;
+  to: Maybe<Scalars['Timestamp']>;
 };
 
 
 export type ServiceStatsWindowArgs = {
   from: Scalars['Timestamp'];
-  resolution?: Maybe<Resolution>;
-  to?: Maybe<Scalars['Timestamp']>;
+  resolution: Maybe<Resolution>;
+  to: Maybe<Scalars['Timestamp']>;
 };
 
 
@@ -553,16 +553,16 @@ export type ServiceVariantArgs = {
 export type GraphApiKey = ApiKey & {
   __typename?: 'GraphApiKey';
   createdAt: Scalars['Timestamp'];
-  createdBy?: Maybe<Identity>;
+  createdBy: Maybe<Identity>;
   id: Scalars['ID'];
-  keyName?: Maybe<Scalars['String']>;
+  keyName: Maybe<Scalars['String']>;
   role: UserPermission;
   token: Scalars['String'];
 };
 
 export type ApiKey = {
   id: Scalars['ID'];
-  keyName?: Maybe<Scalars['String']>;
+  keyName: Maybe<Scalars['String']>;
   token: Scalars['String'];
 };
 
@@ -607,7 +607,7 @@ export type ChannelSubscription = {
   channels: Array<Channel>;
   enabled: Scalars['Boolean'];
   id: Scalars['ID'];
-  variant?: Maybe<Scalars['String']>;
+  variant: Maybe<Scalars['String']>;
 };
 
 export type CheckConfiguration = {
@@ -642,18 +642,18 @@ export type CheckConfiguration = {
   /** Time when check configuration was last updated */
   updatedAt: Scalars['Timestamp'];
   /** Identity of the last user to update the check configuration */
-  updatedBy?: Maybe<Identity>;
+  updatedBy: Maybe<Identity>;
 };
 
 /** Client filter configuration for a graph. */
 export type ClientFilter = {
   __typename?: 'ClientFilter';
   /** name of the client set by the user and reported alongside metrics */
-  name?: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
   /** ID, often the name, of the client set by the user and reported alongside metrics */
-  referenceID?: Maybe<Scalars['ID']>;
+  referenceID: Maybe<Scalars['ID']>;
   /** version of the client set by the user and reported alongside metrics */
-  version?: Maybe<Scalars['String']>;
+  version: Maybe<Scalars['String']>;
 };
 
 /** Excluded operation for a graph. */
@@ -665,10 +665,10 @@ export type ExcludedOperation = {
 
 /** Filter options available when listing checks. */
 export type CheckFilterInput = {
-  authors?: Maybe<Array<Scalars['String']>>;
-  branches?: Maybe<Array<Scalars['String']>>;
-  status?: Maybe<CheckFilterInputStatusOption>;
-  subgraphs?: Maybe<Array<Scalars['String']>>;
+  authors: Maybe<Array<Scalars['String']>>;
+  branches: Maybe<Array<Scalars['String']>>;
+  status: Maybe<CheckFilterInputStatusOption>;
+  subgraphs: Maybe<Array<Scalars['String']>>;
 };
 
 /** Options for filtering CheckWorkflows by status */
@@ -684,25 +684,25 @@ export type CheckWorkflow = {
    * The variant provided as a base to check against.  Only the differences from the
    * base schema will be tested in operations checks.
    */
-  baseVariant?: Maybe<GraphVariant>;
-  completedAt?: Maybe<Scalars['Timestamp']>;
+  baseVariant: Maybe<GraphVariant>;
+  completedAt: Maybe<Scalars['Timestamp']>;
   createdAt: Scalars['Timestamp'];
   /** Contextual parameters supplied by the runtime environment where the check was run. */
-  gitContext?: Maybe<GitContext>;
+  gitContext: Maybe<GitContext>;
   id: Scalars['ID'];
   /** The name of the implementing service that was responsible for triggering the validation. */
-  implementingServiceName?: Maybe<Scalars['String']>;
+  implementingServiceName: Maybe<Scalars['String']>;
   /** If this check was created by rerunning, the original check that was rerun. */
-  rerunOf?: Maybe<CheckWorkflow>;
+  rerunOf: Maybe<CheckWorkflow>;
   /** Checks created by re-running this check, most recent first. */
-  reruns?: Maybe<Array<CheckWorkflow>>;
-  startedAt?: Maybe<Scalars['Timestamp']>;
+  reruns: Maybe<Array<CheckWorkflow>>;
+  startedAt: Maybe<Scalars['Timestamp']>;
   /** Overall status of the workflow, based on the underlying task statuses. */
   status: CheckWorkflowStatus;
   /** The set of check tasks associated with this workflow, e.g. OperationsCheck, GraphComposition, etc. */
   tasks: Array<CheckWorkflowTask>;
   /** Configuration of validation at the time the check was run. */
-  validationConfig?: Maybe<SchemaDiffValidationConfig>;
+  validationConfig: Maybe<SchemaDiffValidationConfig>;
 };
 
 
@@ -714,9 +714,9 @@ export type CheckWorkflowRerunsArgs = {
 export type GraphVariant = {
   __typename?: 'GraphVariant';
   /** As new schema tags keep getting published, activeSchemaPublish refers to the latest. */
-  activeSchemaPublish?: Maybe<SchemaTag>;
+  activeSchemaPublish: Maybe<SchemaTag>;
   /** Explorer setting for default headers for a graph */
-  defaultHeaders?: Maybe<Scalars['String']>;
+  defaultHeaders: Maybe<Scalars['String']>;
   derivedVariantCount: Scalars['Int'];
   /** Graph the variant belongs to */
   graph: Service;
@@ -725,36 +725,36 @@ export type GraphVariant = {
   /** Global identifier for the graph variant, in the form `graph@variant`. */
   id: Scalars['ID'];
   /** Returns whether the variant is a contract variant */
-  isContract?: Maybe<Scalars['Boolean']>;
+  isContract: Maybe<Scalars['Boolean']>;
   /** Is this variant one of the current user's favorite variants? */
   isFavoriteOfCurrentUser: Scalars['Boolean'];
   /** If the variant is protected */
   isProtected: Scalars['Boolean'];
   isPublic: Scalars['Boolean'];
-  latestLaunch?: Maybe<Launch>;
-  launch?: Maybe<Launch>;
+  latestLaunch: Maybe<Launch>;
+  launch: Maybe<Launch>;
   launchHistory: Array<Launch>;
-  links?: Maybe<Array<LinkInfo>>;
+  links: Maybe<Array<LinkInfo>>;
   /** Name of the variant, like `variant`. */
   name: Scalars['String'];
   /** Which permissions the current user has for interacting with this variant */
   permissions: GraphVariantPermissions;
   /** Explorer setting for preflight script to run before the actual GraphQL operations is run. */
-  preflightScript?: Maybe<Scalars['String']>;
-  readme?: Maybe<Readme>;
+  preflightScript: Maybe<Scalars['String']>;
+  readme: Maybe<Readme>;
   /** The total number of requests for this variant in the last 24 hours */
-  requestsInLastDay?: Maybe<Scalars['Long']>;
+  requestsInLastDay: Maybe<Scalars['Long']>;
   /** If the graphql endpoint is set up to accept cookies */
-  sendCookies?: Maybe<Scalars['Boolean']>;
-  sourceVariant?: Maybe<GraphVariant>;
+  sendCookies: Maybe<Scalars['Boolean']>;
+  sourceVariant: Maybe<GraphVariant>;
   /** URL where the graph subscription can be queried. */
-  subscriptionUrl?: Maybe<Scalars['String']>;
+  subscriptionUrl: Maybe<Scalars['String']>;
   /** A list of supported directives */
-  supportedDirectives?: Maybe<Array<DirectiveSupportStatus>>;
+  supportedDirectives: Maybe<Array<DirectiveSupportStatus>>;
   /** URL where the graph can be queried. */
-  url?: Maybe<Scalars['String']>;
+  url: Maybe<Scalars['String']>;
   /** The last instant that usage information (e.g. operation stat, client stats) was reported for this variant */
-  usageLastReportedAt?: Maybe<Scalars['Timestamp']>;
+  usageLastReportedAt: Maybe<Scalars['Timestamp']>;
 };
 
 
@@ -772,10 +772,10 @@ export type GraphVariantLaunchHistoryArgs = {
 export type SchemaTag = {
   __typename?: 'SchemaTag';
   /** The composition result that corresponds to this schema repo tag, if it exists. */
-  compositionResult?: Maybe<CompositionResult>;
+  compositionResult: Maybe<CompositionResult>;
   createdAt: Scalars['Timestamp'];
-  diffToPrevious?: Maybe<SchemaDiff>;
-  gitContext?: Maybe<GitContext>;
+  diffToPrevious: Maybe<SchemaDiff>;
+  gitContext: Maybe<GitContext>;
   /**
    * List of previously uploaded SchemaTags under the same tag name, starting with
    * the selected published schema record. Sorted in reverse chronological order
@@ -814,14 +814,14 @@ export type SchemaTag = {
    * The Identity that published this schema and their client info, or null if this isn't
    * a publish. Sub-fields may be null if they weren't recorded.
    */
-  publishedBy?: Maybe<IdentityAndClientInfo>;
+  publishedBy: Maybe<IdentityAndClientInfo>;
   /**
    * Indicates the schemaTag of the schema's original upload, null if this is the
    * first upload of the schema.
    */
-  reversionFrom?: Maybe<SchemaTag>;
+  reversionFrom: Maybe<SchemaTag>;
   schema: Schema;
-  slackNotificationBody?: Maybe<Scalars['String']>;
+  slackNotificationBody: Maybe<Scalars['String']>;
   /** @deprecated Please use variant { name } instead */
   tag: Scalars['String'];
   /** The graph variant this schema tag belongs to. */
@@ -847,7 +847,7 @@ export type CompositionResult = {
    * Supergraph SDL generated by composition (this is not the CSDL, that is a deprecated format).
    * @deprecated Use supergraphSdl instead
    */
-  csdl?: Maybe<Scalars['GraphQLDocument']>;
+  csdl: Maybe<Scalars['GraphQLDocument']>;
   /**
    * List of errors during composition. Errors mean that Apollo was unable to compose the
    * graph's implementing services into a GraphQL schema. This partial schema should not be
@@ -859,13 +859,13 @@ export type CompositionResult = {
   /** List of subgraphs that are included in this composition. */
   subgraphConfigs: Array<SubgraphConfig>;
   /** Supergraph SDL generated by composition. */
-  supergraphSdl?: Maybe<Scalars['GraphQLDocument']>;
+  supergraphSdl: Maybe<Scalars['GraphQLDocument']>;
 };
 
 /** Represents an error from running schema composition on a list of service definitions. */
 export type SchemaCompositionError = {
   __typename?: 'SchemaCompositionError';
-  code?: Maybe<Scalars['String']>;
+  code: Maybe<Scalars['String']>;
   locations: Array<Maybe<SourceLocation>>;
   message: Scalars['String'];
 };
@@ -891,9 +891,9 @@ export type SchemaDiff = {
    * Clients affected by all changes in diff
    * @deprecated Unsupported.
    */
-  affectedClients?: Maybe<Array<AffectedClient>>;
+  affectedClients: Maybe<Array<AffectedClient>>;
   /** Operations affected by all changes in diff */
-  affectedQueries?: Maybe<Array<AffectedQuery>>;
+  affectedQueries: Maybe<Array<AffectedQuery>>;
   /** List of schema changes with associated affected clients and operations */
   changes: Array<Change>;
   /** Summary/counts for all changes in diff */
@@ -901,53 +901,53 @@ export type SchemaDiff = {
   /** Number of affected query operations that are neither marked as SAFE or IGNORED */
   numberOfAffectedOperations: Scalars['Int'];
   /** Number of operations that were validated during schema diff */
-  numberOfCheckedOperations?: Maybe<Scalars['Int']>;
+  numberOfCheckedOperations: Maybe<Scalars['Int']>;
   /** Indication of the success of the change, either failure, warning, or notice. */
   severity: ChangeSeverity;
   /** The tag against which this diff was created */
-  tag?: Maybe<Scalars['String']>;
+  tag: Maybe<Scalars['String']>;
   /** @deprecated use severity instead */
   type: ChangeType;
   /** Configuration of validation */
-  validationConfig?: Maybe<SchemaDiffValidationConfig>;
+  validationConfig: Maybe<SchemaDiffValidationConfig>;
 };
 
 export type AffectedClient = {
   __typename?: 'AffectedClient';
   /** ID, often the name, of the client set by the user and reported alongside metrics */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** version of the client set by the user and reported alongside metrics */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
 };
 
 export type AffectedQuery = {
   __typename?: 'AffectedQuery';
   /** If the operation would be approved if the check ran again. Returns null if queried from SchemaDiff.changes.affectedQueries.alreadyApproved */
-  alreadyApproved?: Maybe<Scalars['Boolean']>;
+  alreadyApproved: Maybe<Scalars['Boolean']>;
   /** If the operation would be ignored if the check ran again */
-  alreadyIgnored?: Maybe<Scalars['Boolean']>;
+  alreadyIgnored: Maybe<Scalars['Boolean']>;
   /** List of changes affecting this query. Returns null if queried from SchemaDiff.changes.affectedQueries.changes */
-  changes?: Maybe<Array<ChangeOnOperation>>;
+  changes: Maybe<Array<ChangeOnOperation>>;
   /** Name to display to the user for the operation */
-  displayName?: Maybe<Scalars['String']>;
+  displayName: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   /** Determines if this query validates against the proposed schema */
-  isValid?: Maybe<Scalars['Boolean']>;
+  isValid: Maybe<Scalars['Boolean']>;
   /** Whether this operation was ignored and its severity was downgraded for that reason */
-  markedAsIgnored?: Maybe<Scalars['Boolean']>;
+  markedAsIgnored: Maybe<Scalars['Boolean']>;
   /** Whether the changes were marked as safe and its severity was downgraded for that reason */
-  markedAsSafe?: Maybe<Scalars['Boolean']>;
+  markedAsSafe: Maybe<Scalars['Boolean']>;
   /** Name provided for the operation, which can be empty string if it is an anonymous operation */
-  name?: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
   /** First 128 characters of query signature for display */
-  signature?: Maybe<Scalars['String']>;
+  signature: Maybe<Scalars['String']>;
 };
 
 /** Info about a change in the context of an operation it affects */
 export type ChangeOnOperation = {
   __typename?: 'ChangeOnOperation';
   /** Human-readable explanation of the impact of this change on the operation */
-  impact?: Maybe<Scalars['String']>;
+  impact: Maybe<Scalars['String']>;
   /** The semantic info about this change, i.e. info about the change that doesn't depend on the operation */
   semanticChange: SemanticChange;
 };
@@ -955,22 +955,22 @@ export type ChangeOnOperation = {
 export type SemanticChange = {
   __typename?: 'SemanticChange';
   /** Target arg of change made. */
-  argNode?: Maybe<NamedIntrospectionArg>;
+  argNode: Maybe<NamedIntrospectionArg>;
   /**
    * Node related to the top level node that was changed, such as a field in an object,
    * a value in an enum or the object of an interface
    */
-  childNode?: Maybe<NamedIntrospectionValue>;
+  childNode: Maybe<NamedIntrospectionValue>;
   /** Semantic metadata about the type of change */
   definition: ChangeDefinition;
   /** Top level node affected by the change */
-  parentNode?: Maybe<NamedIntrospectionType>;
+  parentNode: Maybe<NamedIntrospectionType>;
 };
 
 export type NamedIntrospectionArg = {
   __typename?: 'NamedIntrospectionArg';
-  description?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
+  description: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
 };
 
 /**
@@ -981,9 +981,9 @@ export type NamedIntrospectionArg = {
  */
 export type NamedIntrospectionValue = {
   __typename?: 'NamedIntrospectionValue';
-  description?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  printedType?: Maybe<Scalars['String']>;
+  description: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
+  printedType: Maybe<Scalars['String']>;
 };
 
 /**
@@ -1108,9 +1108,9 @@ export enum ChangeSeverity {
  */
 export type NamedIntrospectionType = {
   __typename?: 'NamedIntrospectionType';
-  description?: Maybe<Scalars['String']>;
-  kind?: Maybe<IntrospectionTypeKind>;
-  name?: Maybe<Scalars['String']>;
+  description: Maybe<Scalars['String']>;
+  kind: Maybe<IntrospectionTypeKind>;
+  name: Maybe<Scalars['String']>;
 };
 
 export enum IntrospectionTypeKind {
@@ -1137,22 +1137,22 @@ export enum IntrospectionTypeKind {
 
 export type Change = {
   __typename?: 'Change';
-  affectedQueries?: Maybe<Array<AffectedQuery>>;
+  affectedQueries: Maybe<Array<AffectedQuery>>;
   /** Target arg of change made. */
-  argNode?: Maybe<NamedIntrospectionArg>;
+  argNode: Maybe<NamedIntrospectionArg>;
   /** Indication of the category of the change (e.g. addition, removal, edit). */
   category: ChangeCategory;
   /**
    * Node related to the top level node that was changed, such as a field in an object,
    * a value in an enum or the object of an interface
    */
-  childNode?: Maybe<NamedIntrospectionValue>;
+  childNode: Maybe<NamedIntrospectionValue>;
   /** Indication of the kind of target and action of the change, e.g. 'TYPE_REMOVED'. */
   code: Scalars['String'];
   /** Explanation of both the target of the change and how it was changed. */
   description: Scalars['String'];
   /** Top level node affected by the change */
-  parentNode?: Maybe<NamedIntrospectionType>;
+  parentNode: Maybe<NamedIntrospectionType>;
   /** Indication of the success of the overall change, either failure, warning, or notice. */
   severity: ChangeSeverity;
   /**
@@ -1246,26 +1246,26 @@ export type TypeChangeSummaryCounts = {
 export type SchemaDiffValidationConfig = {
   __typename?: 'SchemaDiffValidationConfig';
   /** Clients to ignore during validation. */
-  excludedClients?: Maybe<Array<ClientInfoFilterOutput>>;
+  excludedClients: Maybe<Array<ClientInfoFilterOutput>>;
   /**
    * delta in seconds from current time that determines the start of the window
    * for reported metrics included in a schema diff. A day window from the present
    * day would have a `from` value of -86400. In rare cases, this could be an ISO
    * timestamp if the user passed one in on diff creation
    */
-  from?: Maybe<Scalars['Timestamp']>;
+  from: Maybe<Scalars['Timestamp']>;
   /** Operation IDs to ignore during validation. */
-  ignoredOperations?: Maybe<Array<Scalars['ID']>>;
+  ignoredOperations: Maybe<Array<Scalars['ID']>>;
   /** Variants to include during validation. */
-  includedVariants?: Maybe<Array<Scalars['String']>>;
+  includedVariants: Maybe<Array<Scalars['String']>>;
   /** Minimum number of requests within the window for a query to be considered. */
-  queryCountThreshold?: Maybe<Scalars['Int']>;
+  queryCountThreshold: Maybe<Scalars['Int']>;
   /**
    * Number of requests within the window for a query to be considered, relative to
    * total request count. Expected values are between 0 and 0.05 (minimum 5% of
    * total request volume)
    */
-  queryCountThresholdPercentage?: Maybe<Scalars['Float']>;
+  queryCountThresholdPercentage: Maybe<Scalars['Float']>;
   /**
    * delta in seconds from current time that determines the end of the
    * window for reported metrics included in a schema diff. A day window
@@ -1273,26 +1273,26 @@ export type SchemaDiffValidationConfig = {
    * cases, this could be an ISO timestamp if the user passed one in on diff
    * creation
    */
-  to?: Maybe<Scalars['Timestamp']>;
+  to: Maybe<Scalars['Timestamp']>;
 };
 
 /** Filter options to exclude clients. Used as an output type for SchemaDiffValidationConfig. */
 export type ClientInfoFilterOutput = {
   __typename?: 'ClientInfoFilterOutput';
-  name?: Maybe<Scalars['String']>;
-  referenceID?: Maybe<Scalars['ID']>;
-  version?: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
+  referenceID: Maybe<Scalars['ID']>;
+  version: Maybe<Scalars['String']>;
 };
 
 export type GitContext = {
   __typename?: 'GitContext';
-  branch?: Maybe<Scalars['String']>;
-  commit?: Maybe<Scalars['ID']>;
-  committer?: Maybe<Scalars['String']>;
-  commitUrl?: Maybe<Scalars['String']>;
-  message?: Maybe<Scalars['String']>;
-  remoteHost?: Maybe<GitRemoteHost>;
-  remoteUrl?: Maybe<Scalars['String']>;
+  branch: Maybe<Scalars['String']>;
+  commit: Maybe<Scalars['ID']>;
+  committer: Maybe<Scalars['String']>;
+  commitUrl: Maybe<Scalars['String']>;
+  message: Maybe<Scalars['String']>;
+  remoteHost: Maybe<GitRemoteHost>;
+  remoteUrl: Maybe<Scalars['String']>;
 };
 
 export enum GitRemoteHost {
@@ -1305,21 +1305,21 @@ export enum GitRemoteHost {
 export type IdentityAndClientInfo = {
   __typename?: 'IdentityAndClientInfo';
   /** The clientName given to Apollo Cloud when the actor performed the action */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** The clientVersion given to Apollo Cloud when the actor performed the action */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
   /** Identity info about the actor */
-  identity?: Maybe<Identity>;
+  identity: Maybe<Identity>;
 };
 
 export type Schema = {
   __typename?: 'Schema';
   createdAt: Scalars['Timestamp'];
-  createTemporaryURL?: Maybe<TemporaryUrl>;
+  createTemporaryURL: Maybe<TemporaryUrl>;
   document: Scalars['GraphQLDocument'];
   /** The number of fields; this includes user defined fields only, excluding built-in types and fields */
   fieldCount: Scalars['Int'];
-  gitContext?: Maybe<GitContext>;
+  gitContext: Maybe<GitContext>;
   hash: Scalars['ID'];
   introspection: IntrospectionSchema;
   /** The number of types; this includes user defined types only, excluding built-in types */
@@ -1339,9 +1339,9 @@ export type TemporaryUrl = {
 export type IntrospectionSchema = {
   __typename?: 'IntrospectionSchema';
   directives: Array<IntrospectionDirective>;
-  mutationType?: Maybe<IntrospectionType>;
+  mutationType: Maybe<IntrospectionType>;
   queryType: IntrospectionType;
-  subscriptionType?: Maybe<IntrospectionType>;
+  subscriptionType: Maybe<IntrospectionType>;
   types: Array<IntrospectionType>;
 };
 
@@ -1353,7 +1353,7 @@ export type IntrospectionSchemaTypesArgs = {
 export type IntrospectionDirective = {
   __typename?: 'IntrospectionDirective';
   args: Array<IntrospectionInputValue>;
-  description?: Maybe<Scalars['String']>;
+  description: Maybe<Scalars['String']>;
   locations: Array<IntrospectionDirectiveLocation>;
   name: Scalars['String'];
 };
@@ -1361,8 +1361,8 @@ export type IntrospectionDirective = {
 /** Values associated with introspection result for an input field */
 export type IntrospectionInputValue = {
   __typename?: 'IntrospectionInputValue';
-  defaultValue?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
+  defaultValue: Maybe<Scalars['String']>;
+  description: Maybe<Scalars['String']>;
   name: Scalars['String'];
   type: IntrospectionType;
 };
@@ -1371,16 +1371,16 @@ export type IntrospectionInputValue = {
 export type IntrospectionType = {
   __typename?: 'IntrospectionType';
   /** the base kind of the type this references, ignoring lists and nullability */
-  baseKind?: Maybe<IntrospectionTypeKind>;
-  description?: Maybe<Scalars['String']>;
-  enumValues?: Maybe<Array<IntrospectionEnumValue>>;
-  fields?: Maybe<Array<IntrospectionField>>;
-  inputFields?: Maybe<Array<IntrospectionInputValue>>;
-  interfaces?: Maybe<Array<IntrospectionType>>;
-  kind?: Maybe<IntrospectionTypeKind>;
-  name?: Maybe<Scalars['String']>;
-  ofType?: Maybe<IntrospectionType>;
-  possibleTypes?: Maybe<Array<IntrospectionType>>;
+  baseKind: Maybe<IntrospectionTypeKind>;
+  description: Maybe<Scalars['String']>;
+  enumValues: Maybe<Array<IntrospectionEnumValue>>;
+  fields: Maybe<Array<IntrospectionField>>;
+  inputFields: Maybe<Array<IntrospectionInputValue>>;
+  interfaces: Maybe<Array<IntrospectionType>>;
+  kind: Maybe<IntrospectionTypeKind>;
+  name: Maybe<Scalars['String']>;
+  ofType: Maybe<IntrospectionType>;
+  possibleTypes: Maybe<Array<IntrospectionType>>;
   /** printed representation of type, including nested nullability and list ofTypes */
   printed: Scalars['String'];
 };
@@ -1395,9 +1395,9 @@ export type IntrospectionTypeEnumValuesArgs = {
 export type IntrospectionEnumValue = {
   __typename?: 'IntrospectionEnumValue';
   /** @deprecated Use deprecationReason instead */
-  depreactionReason?: Maybe<Scalars['String']>;
-  deprecationReason?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
+  depreactionReason: Maybe<Scalars['String']>;
+  deprecationReason: Maybe<Scalars['String']>;
+  description: Maybe<Scalars['String']>;
   isDeprecated: Scalars['Boolean'];
   name: Scalars['String'];
 };
@@ -1406,8 +1406,8 @@ export type IntrospectionEnumValue = {
 export type IntrospectionField = {
   __typename?: 'IntrospectionField';
   args: Array<IntrospectionInputValue>;
-  deprecationReason?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
+  deprecationReason: Maybe<Scalars['String']>;
+  description: Maybe<Scalars['String']>;
   isDeprecated: Scalars['Boolean'];
   name: Scalars['String'];
   type: IntrospectionType;
@@ -1465,41 +1465,41 @@ export enum IntrospectionDirectiveLocation {
  */
 export type TypeFilterConfig = {
   /** include abstract types (interfaces and unions) */
-  includeAbstractTypes?: Maybe<Scalars['Boolean']>;
+  includeAbstractTypes: Maybe<Scalars['Boolean']>;
   /** include built in scalars (i.e. Boolean, Int, etc) */
-  includeBuiltInTypes?: Maybe<Scalars['Boolean']>;
+  includeBuiltInTypes: Maybe<Scalars['Boolean']>;
   /** include reserved introspection types (i.e. __Type) */
-  includeIntrospectionTypes?: Maybe<Scalars['Boolean']>;
+  includeIntrospectionTypes: Maybe<Scalars['Boolean']>;
 };
 
 export type Launch = {
   __typename?: 'Launch';
-  approvedAt?: Maybe<Scalars['Timestamp']>;
-  build?: Maybe<Build>;
+  approvedAt: Maybe<Scalars['Timestamp']>;
+  build: Maybe<Build>;
   buildInput: BuildInput;
-  completedAt?: Maybe<Scalars['Timestamp']>;
+  completedAt: Maybe<Scalars['Timestamp']>;
   createdAt: Scalars['Timestamp'];
-  downstreamLaunches?: Maybe<Array<Launch>>;
+  downstreamLaunches: Maybe<Array<Launch>>;
   id: Scalars['ID'];
-  isAvailable?: Maybe<Scalars['Boolean']>;
-  isCompleted?: Maybe<Scalars['Boolean']>;
-  isPublished?: Maybe<Scalars['Boolean']>;
-  isTarget?: Maybe<Scalars['Boolean']>;
-  latestSequenceStep?: Maybe<LaunchSequenceStep>;
+  isAvailable: Maybe<Scalars['Boolean']>;
+  isCompleted: Maybe<Scalars['Boolean']>;
+  isPublished: Maybe<Scalars['Boolean']>;
+  isTarget: Maybe<Scalars['Boolean']>;
+  latestSequenceStep: Maybe<LaunchSequenceStep>;
   results: Array<LaunchResult>;
-  schemaTag?: Maybe<SchemaTag>;
+  schemaTag: Maybe<SchemaTag>;
   sequence: Array<LaunchSequenceStep>;
   shortenedID: Scalars['String'];
   status: LaunchStatus;
-  subgraphChanges?: Maybe<Array<SubgraphChange>>;
-  supersededAt?: Maybe<Scalars['Timestamp']>;
-  supersededBy?: Maybe<Launch>;
+  subgraphChanges: Maybe<Array<SubgraphChange>>;
+  supersededAt: Maybe<Scalars['Timestamp']>;
+  supersededBy: Maybe<Launch>;
 };
 
 export type Build = {
   __typename?: 'Build';
   input: BuildInput;
-  result?: Maybe<BuildResult>;
+  result: Maybe<BuildResult>;
 };
 
 export type BuildInput = CompositionBuildInput | FilterBuildInput;
@@ -1507,7 +1507,7 @@ export type BuildInput = CompositionBuildInput | FilterBuildInput;
 export type CompositionBuildInput = {
   __typename?: 'CompositionBuildInput';
   subgraphs: Array<Subgraph>;
-  version?: Maybe<Scalars['String']>;
+  version: Maybe<Scalars['String']>;
 };
 
 export type Subgraph = {
@@ -1538,7 +1538,7 @@ export type BuildFailure = {
 
 export type BuildError = {
   __typename?: 'BuildError';
-  code?: Maybe<Scalars['String']>;
+  code: Maybe<Scalars['String']>;
   locations: Array<SourceLocation>;
   message: Scalars['String'];
 };
@@ -1559,35 +1559,35 @@ export type LaunchSequenceStep = LaunchSequenceBuildStep | LaunchSequenceCheckSt
 
 export type LaunchSequenceBuildStep = {
   __typename?: 'LaunchSequenceBuildStep';
-  completedAt?: Maybe<Scalars['Timestamp']>;
-  startedAt?: Maybe<Scalars['Timestamp']>;
+  completedAt: Maybe<Scalars['Timestamp']>;
+  startedAt: Maybe<Scalars['Timestamp']>;
 };
 
 export type LaunchSequenceCheckStep = {
   __typename?: 'LaunchSequenceCheckStep';
-  completedAt?: Maybe<Scalars['Timestamp']>;
-  startedAt?: Maybe<Scalars['Timestamp']>;
+  completedAt: Maybe<Scalars['Timestamp']>;
+  startedAt: Maybe<Scalars['Timestamp']>;
 };
 
 export type LaunchSequenceCompletedStep = {
   __typename?: 'LaunchSequenceCompletedStep';
-  completedAt?: Maybe<Scalars['Timestamp']>;
+  completedAt: Maybe<Scalars['Timestamp']>;
 };
 
 export type LaunchSequenceInitiatedStep = {
   __typename?: 'LaunchSequenceInitiatedStep';
-  startedAt?: Maybe<Scalars['Timestamp']>;
+  startedAt: Maybe<Scalars['Timestamp']>;
 };
 
 export type LaunchSequencePublishStep = {
   __typename?: 'LaunchSequencePublishStep';
-  completedAt?: Maybe<Scalars['Timestamp']>;
-  startedAt?: Maybe<Scalars['Timestamp']>;
+  completedAt: Maybe<Scalars['Timestamp']>;
+  startedAt: Maybe<Scalars['Timestamp']>;
 };
 
 export type LaunchSequenceSupersededStep = {
   __typename?: 'LaunchSequenceSupersededStep';
-  completedAt?: Maybe<Scalars['Timestamp']>;
+  completedAt: Maybe<Scalars['Timestamp']>;
 };
 
 /** more result types will be supported in the future */
@@ -1621,7 +1621,7 @@ export type LinkInfo = {
   __typename?: 'LinkInfo';
   createdAt: Scalars['Timestamp'];
   id: Scalars['ID'];
-  title?: Maybe<Scalars['String']>;
+  title: Maybe<Scalars['String']>;
   type: LinkInfoType;
   url: Scalars['String'];
 };
@@ -1654,7 +1654,7 @@ export type Readme = {
   content: Scalars['String'];
   id: Scalars['ID'];
   lastUpdatedAt: Scalars['Timestamp'];
-  lastUpdatedBy?: Maybe<Identity>;
+  lastUpdatedBy: Maybe<Identity>;
 };
 
 /** Support for a single directive on a graph variant */
@@ -1673,7 +1673,7 @@ export enum CheckWorkflowStatus {
 }
 
 export type CheckWorkflowTask = {
-  completedAt?: Maybe<Scalars['Timestamp']>;
+  completedAt: Maybe<Scalars['Timestamp']>;
   createdAt: Scalars['Timestamp'];
   id: Scalars['ID'];
   status: CheckWorkflowTaskStatus;
@@ -1703,7 +1703,7 @@ export enum DatadogApiRegion {
 
 export type User = Identity & {
   __typename?: 'User';
-  acceptedPrivacyPolicyAt?: Maybe<Scalars['Timestamp']>;
+  acceptedPrivacyPolicyAt: Maybe<Scalars['Timestamp']>;
   /** @deprecated Replaced with User.memberships.account */
   accounts: Array<Account>;
   apiKeys: Array<UserApiKey>;
@@ -1715,43 +1715,43 @@ export type User = Identity & {
    * filename, if such information is available. Client MUST set the "x-apollo-csrf-token" header to
    * MediaUploadInfo.csrfToken.
    */
-  avatarUpload?: Maybe<AvatarUploadResult>;
+  avatarUpload: Maybe<AvatarUploadResult>;
   /**
    * Get an image URL for the user's avatar. Note that CORS is not enabled for these URLs. The size
    * argument is used for bandwidth reduction, and should be the size of the image as displayed in the
    * application. Apollo's media server will downscale larger images to at least the requested size,
    * but this will not happen for third-party media servers.
    */
-  avatarUrl?: Maybe<Scalars['String']>;
+  avatarUrl: Maybe<Scalars['String']>;
   betaFeaturesOn: Scalars['Boolean'];
   canUpdateAvatar: Scalars['Boolean'];
   canUpdateEmail: Scalars['Boolean'];
   canUpdateFullName: Scalars['Boolean'];
   createdAt: Scalars['Timestamp'];
-  email?: Maybe<Scalars['String']>;
-  emailModifiedAt?: Maybe<Scalars['Timestamp']>;
+  email: Maybe<Scalars['String']>;
+  emailModifiedAt: Maybe<Scalars['Timestamp']>;
   emailVerified: Scalars['Boolean'];
   experimentalFeatures: UserExperimentalFeatures;
-  featureIntros?: Maybe<FeatureIntros>;
+  featureIntros: Maybe<FeatureIntros>;
   fullName: Scalars['String'];
   /** The user's GitHub username, if they log in via GitHub. May be null even for GitHub users in some edge cases. */
-  githubUsername?: Maybe<Scalars['String']>;
+  githubUsername: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   /**
    * This role is reserved exclusively for internal MDG employees, and it controls what access they may have to other
    * organizations. Only admins are allowed to see this field.
    */
-  internalAdminRole?: Maybe<InternalMdgAdminRole>;
+  internalAdminRole: Maybe<InternalMdgAdminRole>;
   /** Last time any API token from this user was used against AGM services */
-  lastAuthenticatedAt?: Maybe<Scalars['Timestamp']>;
-  logoutAfterIdleMs?: Maybe<Scalars['Int']>;
+  lastAuthenticatedAt: Maybe<Scalars['Timestamp']>;
+  logoutAfterIdleMs: Maybe<Scalars['Int']>;
   memberships: Array<UserMembership>;
   name: Scalars['String'];
   odysseyCourses: Array<OdysseyCourse>;
   odysseyTasks: Array<OdysseyTask>;
   synchronized: Scalars['Boolean'];
   /** List of Zendesk tickets this user has submitted */
-  tickets?: Maybe<Array<ZendeskTicket>>;
+  tickets: Maybe<Array<ZendeskTicket>>;
   type: UserType;
 };
 
@@ -1768,7 +1768,7 @@ export type UserAvatarUrlArgs = {
 export type UserApiKey = ApiKey & {
   __typename?: 'UserApiKey';
   id: Scalars['ID'];
-  keyName?: Maybe<Scalars['String']>;
+  keyName: Maybe<Scalars['String']>;
   token: Scalars['String'];
 };
 
@@ -1801,29 +1801,29 @@ export type UserMembership = {
 
 export type OdysseyCourse = {
   __typename?: 'OdysseyCourse';
-  completedAt?: Maybe<Scalars['Timestamp']>;
-  enrolledAt?: Maybe<Scalars['Timestamp']>;
+  completedAt: Maybe<Scalars['Timestamp']>;
+  enrolledAt: Maybe<Scalars['Timestamp']>;
   id: Scalars['ID'];
 };
 
 export type OdysseyTask = {
   __typename?: 'OdysseyTask';
-  completedAt?: Maybe<Scalars['Timestamp']>;
+  completedAt: Maybe<Scalars['Timestamp']>;
   id: Scalars['ID'];
-  value?: Maybe<Scalars['String']>;
+  value: Maybe<Scalars['String']>;
 };
 
 export type ZendeskTicket = {
   __typename?: 'ZendeskTicket';
   createdAt: Scalars['Timestamp'];
   description: Scalars['String'];
-  graph?: Maybe<Service>;
+  graph: Maybe<Service>;
   id: Scalars['Int'];
-  organization?: Maybe<Account>;
+  organization: Maybe<Account>;
   priority: TicketPriority;
-  status?: Maybe<TicketStatus>;
+  status: Maybe<TicketStatus>;
   subject: Scalars['String'];
-  user?: Maybe<User>;
+  user: Maybe<User>;
 };
 
 export enum TicketPriority {
@@ -1886,7 +1886,7 @@ export type FederatedImplementingService = {
   /** Timestamp for when this implementing service was updated */
   updatedAt: Scalars['Timestamp'];
   /** URL of the graphql endpoint of the implementing service */
-  url?: Maybe<Scalars['String']>;
+  url: Maybe<Scalars['String']>;
 };
 
 /** Schema for an implementing service with associated metadata */
@@ -1923,12 +1923,12 @@ export type NonFederatedImplementingService = {
 export type CompositionPublishResult = CompositionResult & {
   __typename?: 'CompositionPublishResult';
   /** The produced composition config. Will be null if there are any errors */
-  compositionConfig?: Maybe<CompositionConfig>;
+  compositionConfig: Maybe<CompositionConfig>;
   /**
    * Supergraph SDL generated by composition (this is not the CSDL, that is a deprecated format).
    * @deprecated Use supergraphSdl instead
    */
-  csdl?: Maybe<Scalars['GraphQLDocument']>;
+  csdl: Maybe<Scalars['GraphQLDocument']>;
   /**
    * List of errors during composition. Errors mean that Apollo was unable to compose the
    * graph's implementing services into a GraphQL schema. This partial schema should not be
@@ -1940,10 +1940,10 @@ export type CompositionPublishResult = CompositionResult & {
   /** List of subgraphs that are included in this composition. */
   subgraphConfigs: Array<SubgraphConfig>;
   /** Supergraph SDL generated by composition. */
-  supergraphSdl?: Maybe<Scalars['GraphQLDocument']>;
+  supergraphSdl: Maybe<Scalars['GraphQLDocument']>;
   /** Whether the gateway link was updated. */
   updatedGateway: Scalars['Boolean'];
-  webhookNotificationBody?: Maybe<Scalars['String']>;
+  webhookNotificationBody: Maybe<Scalars['String']>;
 };
 
 /** The composition config exposed to the gateway */
@@ -1970,8 +1970,8 @@ export type ImplementingServiceLocation = {
 export type Operation = {
   __typename?: 'Operation';
   id: Scalars['ID'];
-  name?: Maybe<Scalars['String']>;
-  signature?: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
+  signature: Maybe<Scalars['String']>;
   truncated: Scalars['Boolean'];
 };
 
@@ -1988,32 +1988,32 @@ export type OperationAcceptedChange = {
 
 export type StoredApprovedChange = {
   __typename?: 'StoredApprovedChange';
-  argNode?: Maybe<NamedIntrospectionArgNoDescription>;
-  childNode?: Maybe<NamedIntrospectionValueNoDescription>;
+  argNode: Maybe<NamedIntrospectionArgNoDescription>;
+  childNode: Maybe<NamedIntrospectionValueNoDescription>;
   code: ChangeCode;
-  parentNode?: Maybe<NamedIntrospectionTypeNoDescription>;
+  parentNode: Maybe<NamedIntrospectionTypeNoDescription>;
 };
 
 export type NamedIntrospectionArgNoDescription = {
   __typename?: 'NamedIntrospectionArgNoDescription';
-  name?: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
 };
 
 export type NamedIntrospectionValueNoDescription = {
   __typename?: 'NamedIntrospectionValueNoDescription';
-  name?: Maybe<Scalars['String']>;
-  printedType?: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
+  printedType: Maybe<Scalars['String']>;
 };
 
 export type NamedIntrospectionTypeNoDescription = {
   __typename?: 'NamedIntrospectionTypeNoDescription';
-  name?: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
 };
 
 export type OperationsCheckResult = {
   __typename?: 'OperationsCheckResult';
   /** Operations affected by all changes in diff */
-  affectedQueries?: Maybe<Array<AffectedQuery>>;
+  affectedQueries: Maybe<Array<AffectedQuery>>;
   /** List of schema changes with associated affected clients and operations */
   changes: Array<Change>;
   /** Summary/counts for all changes in diff */
@@ -2033,11 +2033,11 @@ export type OperationsCheckResult = {
 
 export type OperationsCheckTask = CheckWorkflowTask & {
   __typename?: 'OperationsCheckTask';
-  completedAt?: Maybe<Scalars['Timestamp']>;
+  completedAt: Maybe<Scalars['Timestamp']>;
   createdAt: Scalars['Timestamp'];
   id: Scalars['ID'];
   /** The result of the check. */
-  result?: Maybe<OperationsCheckResult>;
+  result: Maybe<OperationsCheckResult>;
   status: CheckWorkflowTaskStatus;
   workflow: CheckWorkflow;
 };
@@ -2052,12 +2052,12 @@ export type QueryTrigger = ChannelSubscription & {
   id: Scalars['ID'];
   metric: QueryTriggerMetric;
   operationNames: Array<Scalars['String']>;
-  percentile?: Maybe<Scalars['Float']>;
+  percentile: Maybe<Scalars['Float']>;
   scope: QueryTriggerScope;
   serviceId: Scalars['String'];
   state: QueryTriggerState;
   threshold: Scalars['Float'];
-  variant?: Maybe<Scalars['String']>;
+  variant: Maybe<Scalars['String']>;
   window: QueryTriggerWindow;
 };
 
@@ -2092,7 +2092,7 @@ export enum QueryTriggerScope {
 export type QueryTriggerState = {
   __typename?: 'QueryTriggerState';
   evaluatedAt: Scalars['Timestamp'];
-  lastTriggeredAt?: Maybe<Scalars['Timestamp']>;
+  lastTriggeredAt: Maybe<Scalars['Timestamp']>;
   operations: Array<QueryTriggerStateOperation>;
   triggered: Scalars['Boolean'];
 };
@@ -2159,7 +2159,7 @@ export type ServiceRoles = {
 export type ScheduledSummary = ChannelSubscription & {
   __typename?: 'ScheduledSummary';
   /** @deprecated Use channels list instead */
-  channel?: Maybe<Channel>;
+  channel: Maybe<Channel>;
   channels: Array<Channel>;
   enabled: Scalars['Boolean'];
   id: Scalars['ID'];
@@ -2197,117 +2197,117 @@ export type ServiceStatsWindow = {
 
 /** A time window with a specified granularity over a given service. */
 export type ServiceStatsWindowEdgeServerInfosArgs = {
-  filter?: Maybe<ServiceEdgeServerInfosFilter>;
+  filter: Maybe<ServiceEdgeServerInfosFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<ServiceEdgeServerInfosOrderBySpec>>;
+  orderBy: Maybe<Array<ServiceEdgeServerInfosOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given service. */
 export type ServiceStatsWindowErrorStatsArgs = {
-  filter?: Maybe<ServiceErrorStatsFilter>;
+  filter: Maybe<ServiceErrorStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<ServiceErrorStatsOrderBySpec>>;
+  orderBy: Maybe<Array<ServiceErrorStatsOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given service. */
 export type ServiceStatsWindowFieldLatenciesArgs = {
-  filter?: Maybe<ServiceFieldLatenciesFilter>;
+  filter: Maybe<ServiceFieldLatenciesFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<ServiceFieldLatenciesOrderBySpec>>;
+  orderBy: Maybe<Array<ServiceFieldLatenciesOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given service. */
 export type ServiceStatsWindowFieldStatsArgs = {
-  filter?: Maybe<ServiceFieldStatsFilter>;
+  filter: Maybe<ServiceFieldStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<ServiceFieldStatsOrderBySpec>>;
+  orderBy: Maybe<Array<ServiceFieldStatsOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given service. */
 export type ServiceStatsWindowFieldUsageArgs = {
-  filter?: Maybe<ServiceFieldUsageFilter>;
+  filter: Maybe<ServiceFieldUsageFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<ServiceFieldUsageOrderBySpec>>;
+  orderBy: Maybe<Array<ServiceFieldUsageOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given service. */
 export type ServiceStatsWindowOperationCheckStatsArgs = {
-  filter?: Maybe<ServiceOperationCheckStatsFilter>;
+  filter: Maybe<ServiceOperationCheckStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<ServiceOperationCheckStatsOrderBySpec>>;
+  orderBy: Maybe<Array<ServiceOperationCheckStatsOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given service. */
 export type ServiceStatsWindowQueryStatsArgs = {
-  filter?: Maybe<ServiceQueryStatsFilter>;
+  filter: Maybe<ServiceQueryStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<ServiceQueryStatsOrderBySpec>>;
+  orderBy: Maybe<Array<ServiceQueryStatsOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given service. */
 export type ServiceStatsWindowTracePathErrorsRefsArgs = {
-  filter?: Maybe<ServiceTracePathErrorsRefsFilter>;
+  filter: Maybe<ServiceTracePathErrorsRefsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<ServiceTracePathErrorsRefsOrderBySpec>>;
+  orderBy: Maybe<Array<ServiceTracePathErrorsRefsOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given service. */
 export type ServiceStatsWindowTraceRefsArgs = {
-  filter?: Maybe<ServiceTraceRefsFilter>;
+  filter: Maybe<ServiceTraceRefsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<ServiceTraceRefsOrderBySpec>>;
+  orderBy: Maybe<Array<ServiceTraceRefsOrderBySpec>>;
 };
 
 /** Filter for data in ServiceEdgeServerInfos. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type ServiceEdgeServerInfosFilter = {
-  and?: Maybe<Array<ServiceEdgeServerInfosFilter>>;
+  and: Maybe<Array<ServiceEdgeServerInfosFilter>>;
   /** Selects rows whose bootId dimension equals the given value if not null. To query for the null value, use {in: {bootId: [null]}} instead. */
-  bootId?: Maybe<Scalars['ID']>;
+  bootId: Maybe<Scalars['ID']>;
   /** Selects rows whose executableSchemaId dimension equals the given value if not null. To query for the null value, use {in: {executableSchemaId: [null]}} instead. */
-  executableSchemaId?: Maybe<Scalars['ID']>;
-  in?: Maybe<ServiceEdgeServerInfosFilterIn>;
+  executableSchemaId: Maybe<Scalars['ID']>;
+  in: Maybe<ServiceEdgeServerInfosFilterIn>;
   /** Selects rows whose libraryVersion dimension equals the given value if not null. To query for the null value, use {in: {libraryVersion: [null]}} instead. */
-  libraryVersion?: Maybe<Scalars['String']>;
-  not?: Maybe<ServiceEdgeServerInfosFilter>;
-  or?: Maybe<Array<ServiceEdgeServerInfosFilter>>;
+  libraryVersion: Maybe<Scalars['String']>;
+  not: Maybe<ServiceEdgeServerInfosFilter>;
+  or: Maybe<Array<ServiceEdgeServerInfosFilter>>;
   /** Selects rows whose platform dimension equals the given value if not null. To query for the null value, use {in: {platform: [null]}} instead. */
-  platform?: Maybe<Scalars['String']>;
+  platform: Maybe<Scalars['String']>;
   /** Selects rows whose runtimeVersion dimension equals the given value if not null. To query for the null value, use {in: {runtimeVersion: [null]}} instead. */
-  runtimeVersion?: Maybe<Scalars['String']>;
+  runtimeVersion: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serverId dimension equals the given value if not null. To query for the null value, use {in: {serverId: [null]}} instead. */
-  serverId?: Maybe<Scalars['ID']>;
+  serverId: Maybe<Scalars['ID']>;
   /** Selects rows whose userVersion dimension equals the given value if not null. To query for the null value, use {in: {userVersion: [null]}} instead. */
-  userVersion?: Maybe<Scalars['String']>;
+  userVersion: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in ServiceEdgeServerInfos. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type ServiceEdgeServerInfosFilterIn = {
   /** Selects rows whose bootId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  bootId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  bootId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose executableSchemaId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  executableSchemaId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  executableSchemaId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose libraryVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  libraryVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  libraryVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose platform dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  platform?: Maybe<Array<Maybe<Scalars['String']>>>;
+  platform: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose runtimeVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  runtimeVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  runtimeVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serverId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serverId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serverId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose userVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  userVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  userVersion: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type ServiceEdgeServerInfosOrderBySpec = {
@@ -2343,62 +2343,62 @@ export type ServiceEdgeServerInfosRecord = {
 
 export type ServiceEdgeServerInfosDimensions = {
   __typename?: 'ServiceEdgeServerInfosDimensions';
-  bootId?: Maybe<Scalars['ID']>;
-  executableSchemaId?: Maybe<Scalars['ID']>;
-  libraryVersion?: Maybe<Scalars['String']>;
-  platform?: Maybe<Scalars['String']>;
-  runtimeVersion?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serverId?: Maybe<Scalars['ID']>;
-  userVersion?: Maybe<Scalars['String']>;
+  bootId: Maybe<Scalars['ID']>;
+  executableSchemaId: Maybe<Scalars['ID']>;
+  libraryVersion: Maybe<Scalars['String']>;
+  platform: Maybe<Scalars['String']>;
+  runtimeVersion: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serverId: Maybe<Scalars['ID']>;
+  userVersion: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in ServiceErrorStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type ServiceErrorStatsFilter = {
-  and?: Maybe<Array<ServiceErrorStatsFilter>>;
+  and: Maybe<Array<ServiceErrorStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
-  in?: Maybe<ServiceErrorStatsFilterIn>;
-  not?: Maybe<ServiceErrorStatsFilter>;
-  or?: Maybe<Array<ServiceErrorStatsFilter>>;
+  clientVersion: Maybe<Scalars['String']>;
+  in: Maybe<ServiceErrorStatsFilterIn>;
+  not: Maybe<ServiceErrorStatsFilter>;
+  or: Maybe<Array<ServiceErrorStatsFilter>>;
   /** Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead. */
-  path?: Maybe<Scalars['String']>;
+  path: Maybe<Scalars['String']>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in ServiceErrorStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type ServiceErrorStatsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  path?: Maybe<Array<Maybe<Scalars['String']>>>;
+  path: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  serviceVersion: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type ServiceErrorStatsOrderBySpec = {
@@ -2434,15 +2434,15 @@ export type ServiceErrorStatsRecord = {
 
 export type ServiceErrorStatsDimensions = {
   __typename?: 'ServiceErrorStatsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  path?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceVersion?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  path: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 export type ServiceErrorStatsMetrics = {
@@ -2453,26 +2453,26 @@ export type ServiceErrorStatsMetrics = {
 
 /** Filter for data in ServiceFieldLatencies. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type ServiceFieldLatenciesFilter = {
-  and?: Maybe<Array<ServiceFieldLatenciesFilter>>;
+  and: Maybe<Array<ServiceFieldLatenciesFilter>>;
   /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
-  field?: Maybe<Scalars['String']>;
-  in?: Maybe<ServiceFieldLatenciesFilterIn>;
-  not?: Maybe<ServiceFieldLatenciesFilter>;
-  or?: Maybe<Array<ServiceFieldLatenciesFilter>>;
+  field: Maybe<Scalars['String']>;
+  in: Maybe<ServiceFieldLatenciesFilterIn>;
+  not: Maybe<ServiceFieldLatenciesFilter>;
+  or: Maybe<Array<ServiceFieldLatenciesFilter>>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in ServiceFieldLatencies. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type ServiceFieldLatenciesFilterIn = {
   /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  field: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type ServiceFieldLatenciesOrderBySpec = {
@@ -2501,9 +2501,9 @@ export type ServiceFieldLatenciesRecord = {
 
 export type ServiceFieldLatenciesDimensions = {
   __typename?: 'ServiceFieldLatenciesDimensions';
-  field?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
+  field: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
 };
 
 export type ServiceFieldLatenciesMetrics = {
@@ -2513,9 +2513,9 @@ export type ServiceFieldLatenciesMetrics = {
 
 export type DurationHistogram = {
   __typename?: 'DurationHistogram';
-  averageDurationMs?: Maybe<Scalars['Float']>;
+  averageDurationMs: Maybe<Scalars['Float']>;
   buckets: Array<DurationHistogramBucket>;
-  durationMs?: Maybe<Scalars['Float']>;
+  durationMs: Maybe<Scalars['Float']>;
   /** Counts per durationBucket, where sequences of zeroes are replaced with the negative of their size */
   sparseBuckets: Array<Scalars['Long']>;
   totalCount: Scalars['Long'];
@@ -2537,50 +2537,50 @@ export type DurationHistogramBucket = {
 
 /** Filter for data in ServiceFieldStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type ServiceFieldStatsFilter = {
-  and?: Maybe<Array<ServiceFieldStatsFilter>>;
+  and: Maybe<Array<ServiceFieldStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
   /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
-  field?: Maybe<Scalars['String']>;
-  in?: Maybe<ServiceFieldStatsFilterIn>;
-  not?: Maybe<ServiceFieldStatsFilter>;
-  or?: Maybe<Array<ServiceFieldStatsFilter>>;
+  field: Maybe<Scalars['String']>;
+  in: Maybe<ServiceFieldStatsFilterIn>;
+  not: Maybe<ServiceFieldStatsFilter>;
+  or: Maybe<Array<ServiceFieldStatsFilter>>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in ServiceFieldStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type ServiceFieldStatsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  field: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  serviceVersion: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type ServiceFieldStatsOrderBySpec = {
@@ -2617,15 +2617,15 @@ export type ServiceFieldStatsRecord = {
 
 export type ServiceFieldStatsDimensions = {
   __typename?: 'ServiceFieldStatsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  field?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceVersion?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  field: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 export type ServiceFieldStatsMetrics = {
@@ -2637,46 +2637,46 @@ export type ServiceFieldStatsMetrics = {
 
 /** Filter for data in ServiceFieldUsage. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type ServiceFieldUsageFilter = {
-  and?: Maybe<Array<ServiceFieldUsageFilter>>;
+  and: Maybe<Array<ServiceFieldUsageFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
   /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
-  field?: Maybe<Scalars['String']>;
-  in?: Maybe<ServiceFieldUsageFilterIn>;
-  not?: Maybe<ServiceFieldUsageFilter>;
-  or?: Maybe<Array<ServiceFieldUsageFilter>>;
+  field: Maybe<Scalars['String']>;
+  in: Maybe<ServiceFieldUsageFilterIn>;
+  not: Maybe<ServiceFieldUsageFilter>;
+  or: Maybe<Array<ServiceFieldUsageFilter>>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in ServiceFieldUsage. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type ServiceFieldUsageFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  field: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type ServiceFieldUsageOrderBySpec = {
@@ -2711,14 +2711,14 @@ export type ServiceFieldUsageRecord = {
 
 export type ServiceFieldUsageDimensions = {
   __typename?: 'ServiceFieldUsageDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  field?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  field: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
 };
 
 export type ServiceFieldUsageMetrics = {
@@ -2729,34 +2729,34 @@ export type ServiceFieldUsageMetrics = {
 
 /** Filter for data in ServiceOperationCheckStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type ServiceOperationCheckStatsFilter = {
-  and?: Maybe<Array<ServiceOperationCheckStatsFilter>>;
+  and: Maybe<Array<ServiceOperationCheckStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
-  in?: Maybe<ServiceOperationCheckStatsFilterIn>;
-  not?: Maybe<ServiceOperationCheckStatsFilter>;
-  or?: Maybe<Array<ServiceOperationCheckStatsFilter>>;
+  clientVersion: Maybe<Scalars['String']>;
+  in: Maybe<ServiceOperationCheckStatsFilterIn>;
+  not: Maybe<ServiceOperationCheckStatsFilter>;
+  or: Maybe<Array<ServiceOperationCheckStatsFilter>>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in ServiceOperationCheckStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type ServiceOperationCheckStatsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type ServiceOperationCheckStatsOrderBySpec = {
@@ -2788,11 +2788,11 @@ export type ServiceOperationCheckStatsRecord = {
 
 export type ServiceOperationCheckStatsDimensions = {
   __typename?: 'ServiceOperationCheckStatsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  schemaTag?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  schemaTag: Maybe<Scalars['String']>;
 };
 
 export type ServiceOperationCheckStatsMetrics = {
@@ -2803,50 +2803,50 @@ export type ServiceOperationCheckStatsMetrics = {
 
 /** Filter for data in ServiceQueryStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type ServiceQueryStatsFilter = {
-  and?: Maybe<Array<ServiceQueryStatsFilter>>;
+  and: Maybe<Array<ServiceQueryStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
   /** Selects rows whose fromEngineproxy dimension equals the given value if not null. To query for the null value, use {in: {fromEngineproxy: [null]}} instead. */
-  fromEngineproxy?: Maybe<Scalars['String']>;
-  in?: Maybe<ServiceQueryStatsFilterIn>;
-  not?: Maybe<ServiceQueryStatsFilter>;
-  or?: Maybe<Array<ServiceQueryStatsFilter>>;
+  fromEngineproxy: Maybe<Scalars['String']>;
+  in: Maybe<ServiceQueryStatsFilterIn>;
+  not: Maybe<ServiceQueryStatsFilter>;
+  or: Maybe<Array<ServiceQueryStatsFilter>>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in ServiceQueryStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type ServiceQueryStatsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose fromEngineproxy dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  fromEngineproxy?: Maybe<Array<Maybe<Scalars['String']>>>;
+  fromEngineproxy: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  serviceVersion: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type ServiceQueryStatsOrderBySpec = {
@@ -2888,16 +2888,16 @@ export type ServiceQueryStatsRecord = {
 
 export type ServiceQueryStatsDimensions = {
   __typename?: 'ServiceQueryStatsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  fromEngineproxy?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  querySignature?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceVersion?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  fromEngineproxy: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  querySignature: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 export type ServiceQueryStatsMetrics = {
@@ -2916,66 +2916,66 @@ export type ServiceQueryStatsMetrics = {
 
 /** Filter for data in ServiceTracePathErrorsRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type ServiceTracePathErrorsRefsFilter = {
-  and?: Maybe<Array<ServiceTracePathErrorsRefsFilter>>;
+  and: Maybe<Array<ServiceTracePathErrorsRefsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
   /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
-  durationBucket?: Maybe<Scalars['Int']>;
+  durationBucket: Maybe<Scalars['Int']>;
   /** Selects rows whose errorMessage dimension equals the given value if not null. To query for the null value, use {in: {errorMessage: [null]}} instead. */
-  errorMessage?: Maybe<Scalars['String']>;
-  in?: Maybe<ServiceTracePathErrorsRefsFilterIn>;
-  not?: Maybe<ServiceTracePathErrorsRefsFilter>;
-  or?: Maybe<Array<ServiceTracePathErrorsRefsFilter>>;
+  errorMessage: Maybe<Scalars['String']>;
+  in: Maybe<ServiceTracePathErrorsRefsFilterIn>;
+  not: Maybe<ServiceTracePathErrorsRefsFilter>;
+  or: Maybe<Array<ServiceTracePathErrorsRefsFilter>>;
   /** Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead. */
-  path?: Maybe<Scalars['String']>;
+  path: Maybe<Scalars['String']>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
   /** Selects rows whose traceHttpStatusCode dimension equals the given value if not null. To query for the null value, use {in: {traceHttpStatusCode: [null]}} instead. */
-  traceHttpStatusCode?: Maybe<Scalars['Int']>;
+  traceHttpStatusCode: Maybe<Scalars['Int']>;
   /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
-  traceId?: Maybe<Scalars['ID']>;
+  traceId: Maybe<Scalars['ID']>;
 };
 
 /** Filter for data in ServiceTracePathErrorsRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type ServiceTracePathErrorsRefsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  durationBucket?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  durationBucket: Maybe<Array<Maybe<Scalars['Int']>>>;
   /** Selects rows whose errorMessage dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  errorMessage?: Maybe<Array<Maybe<Scalars['String']>>>;
+  errorMessage: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  path?: Maybe<Array<Maybe<Scalars['String']>>>;
+  path: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  serviceVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose traceHttpStatusCode dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  traceHttpStatusCode?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  traceHttpStatusCode: Maybe<Array<Maybe<Scalars['Int']>>>;
   /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  traceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  traceId: Maybe<Array<Maybe<Scalars['ID']>>>;
 };
 
 export type ServiceTracePathErrorsRefsOrderBySpec = {
@@ -3017,20 +3017,20 @@ export type ServiceTracePathErrorsRefsRecord = {
 
 export type ServiceTracePathErrorsRefsDimensions = {
   __typename?: 'ServiceTracePathErrorsRefsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  durationBucket?: Maybe<Scalars['Int']>;
-  errorMessage?: Maybe<Scalars['String']>;
-  path?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceVersion?: Maybe<Scalars['String']>;
-  traceHttpStatusCode?: Maybe<Scalars['Int']>;
-  traceId?: Maybe<Scalars['ID']>;
-  traceStartsAt?: Maybe<Scalars['Timestamp']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  durationBucket: Maybe<Scalars['Int']>;
+  errorMessage: Maybe<Scalars['String']>;
+  path: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
+  traceHttpStatusCode: Maybe<Scalars['Int']>;
+  traceId: Maybe<Scalars['ID']>;
+  traceStartsAt: Maybe<Scalars['Timestamp']>;
 };
 
 export type ServiceTracePathErrorsRefsMetrics = {
@@ -3042,54 +3042,54 @@ export type ServiceTracePathErrorsRefsMetrics = {
 
 /** Filter for data in ServiceTraceRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type ServiceTraceRefsFilter = {
-  and?: Maybe<Array<ServiceTraceRefsFilter>>;
+  and: Maybe<Array<ServiceTraceRefsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
   /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
-  durationBucket?: Maybe<Scalars['Int']>;
-  in?: Maybe<ServiceTraceRefsFilterIn>;
-  not?: Maybe<ServiceTraceRefsFilter>;
-  or?: Maybe<Array<ServiceTraceRefsFilter>>;
+  durationBucket: Maybe<Scalars['Int']>;
+  in: Maybe<ServiceTraceRefsFilterIn>;
+  not: Maybe<ServiceTraceRefsFilter>;
+  or: Maybe<Array<ServiceTraceRefsFilter>>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
   /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
-  traceId?: Maybe<Scalars['ID']>;
+  traceId: Maybe<Scalars['ID']>;
 };
 
 /** Filter for data in ServiceTraceRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type ServiceTraceRefsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  durationBucket?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  durationBucket: Maybe<Array<Maybe<Scalars['Int']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  serviceVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  traceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  traceId: Maybe<Array<Maybe<Scalars['ID']>>>;
 };
 
 export type ServiceTraceRefsOrderBySpec = {
@@ -3126,17 +3126,17 @@ export type ServiceTraceRefsRecord = {
 
 export type ServiceTraceRefsDimensions = {
   __typename?: 'ServiceTraceRefsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  durationBucket?: Maybe<Scalars['Int']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  querySignature?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceVersion?: Maybe<Scalars['String']>;
-  traceId?: Maybe<Scalars['ID']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  durationBucket: Maybe<Scalars['Int']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  querySignature: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
+  traceId: Maybe<Scalars['ID']>;
 };
 
 export type ServiceTraceRefsMetrics = {
@@ -3147,16 +3147,16 @@ export type ServiceTraceRefsMetrics = {
 
 export type Trace = {
   __typename?: 'Trace';
-  cacheMaxAgeMs?: Maybe<Scalars['Float']>;
-  cacheScope?: Maybe<CacheScope>;
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
+  cacheMaxAgeMs: Maybe<Scalars['Float']>;
+  cacheScope: Maybe<CacheScope>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
   durationMs: Scalars['Float'];
   endTime: Scalars['Timestamp'];
-  http?: Maybe<TraceHttp>;
+  http: Maybe<TraceHttp>;
   id: Scalars['ID'];
-  operationName?: Maybe<Scalars['String']>;
+  operationName: Maybe<Scalars['String']>;
   protobuf: Protobuf;
   root: TraceNode;
   signature: Scalars['String'];
@@ -3174,10 +3174,10 @@ export enum CacheScope {
 
 export type TraceHttp = {
   __typename?: 'TraceHTTP';
-  host?: Maybe<Scalars['String']>;
+  host: Maybe<Scalars['String']>;
   method: HttpMethod;
-  path?: Maybe<Scalars['String']>;
-  protocol?: Maybe<Scalars['String']>;
+  path: Maybe<Scalars['String']>;
+  protocol: Maybe<Scalars['String']>;
   requestHeaders: Array<StringToString>;
   responseHeaders: Array<StringToString>;
   secure: Scalars['Boolean'];
@@ -3206,16 +3206,16 @@ export type StringToString = {
 
 export type Protobuf = {
   __typename?: 'Protobuf';
-  json?: Maybe<Scalars['String']>;
-  object?: Maybe<Scalars['Object']>;
+  json: Maybe<Scalars['String']>;
+  object: Maybe<Scalars['Object']>;
   raw: Scalars['Blob'];
   text: Scalars['String'];
 };
 
 export type TraceNode = {
   __typename?: 'TraceNode';
-  cacheMaxAgeMs?: Maybe<Scalars['Float']>;
-  cacheScope?: Maybe<CacheScope>;
+  cacheMaxAgeMs: Maybe<Scalars['Float']>;
+  cacheScope: Maybe<CacheScope>;
   children: Array<TraceNode>;
   childrenIds: Array<Scalars['ID']>;
   descendants: Array<TraceNode>;
@@ -3223,13 +3223,13 @@ export type TraceNode = {
   endTime: Scalars['Timestamp'];
   errors: Array<TraceError>;
   id: Scalars['ID'];
-  key?: Maybe<Scalars['StringOrInt']>;
-  originalFieldName?: Maybe<Scalars['String']>;
+  key: Maybe<Scalars['StringOrInt']>;
+  originalFieldName: Maybe<Scalars['String']>;
   parent: Scalars['ID'];
-  parentId?: Maybe<Scalars['ID']>;
+  parentId: Maybe<Scalars['ID']>;
   path: Array<Scalars['String']>;
   startTime: Scalars['Timestamp'];
-  type?: Maybe<Scalars['String']>;
+  type: Maybe<Scalars['String']>;
 };
 
 export type TraceError = {
@@ -3237,7 +3237,7 @@ export type TraceError = {
   json: Scalars['String'];
   locations: Array<TraceSourceLocation>;
   message: Scalars['String'];
-  timestamp?: Maybe<Scalars['Timestamp']>;
+  timestamp: Maybe<Scalars['Timestamp']>;
 };
 
 export type TraceSourceLocation = {
@@ -3258,23 +3258,23 @@ export enum AuditStatus {
 export type BillingInfo = {
   __typename?: 'BillingInfo';
   address: BillingAddress;
-  cardType?: Maybe<Scalars['String']>;
-  firstName?: Maybe<Scalars['String']>;
-  lastFour?: Maybe<Scalars['Int']>;
-  lastName?: Maybe<Scalars['String']>;
-  month?: Maybe<Scalars['Int']>;
-  vatNumber?: Maybe<Scalars['String']>;
-  year?: Maybe<Scalars['Int']>;
+  cardType: Maybe<Scalars['String']>;
+  firstName: Maybe<Scalars['String']>;
+  lastFour: Maybe<Scalars['Int']>;
+  lastName: Maybe<Scalars['String']>;
+  month: Maybe<Scalars['Int']>;
+  vatNumber: Maybe<Scalars['String']>;
+  year: Maybe<Scalars['Int']>;
 };
 
 export type BillingAddress = {
   __typename?: 'BillingAddress';
-  address1?: Maybe<Scalars['String']>;
-  address2?: Maybe<Scalars['String']>;
-  city?: Maybe<Scalars['String']>;
-  country?: Maybe<Scalars['String']>;
-  state?: Maybe<Scalars['String']>;
-  zip?: Maybe<Scalars['String']>;
+  address1: Maybe<Scalars['String']>;
+  address2: Maybe<Scalars['String']>;
+  city: Maybe<Scalars['String']>;
+  country: Maybe<Scalars['String']>;
+  state: Maybe<Scalars['String']>;
+  zip: Maybe<Scalars['String']>;
 };
 
 export type BillingMonth = {
@@ -3288,15 +3288,15 @@ export type BillingPlan = {
   __typename?: 'BillingPlan';
   addons: Array<BillingPlanAddon>;
   billingModel: BillingModel;
-  billingPeriod?: Maybe<BillingPeriod>;
+  billingPeriod: Maybe<BillingPeriod>;
   capabilities: BillingPlanCapabilities;
-  description?: Maybe<Scalars['String']>;
+  description: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   isTrial: Scalars['Boolean'];
   kind: BillingPlanKind;
   name: Scalars['String'];
   /** The price of every seat */
-  pricePerSeatInUsdCents?: Maybe<Scalars['Int']>;
+  pricePerSeatInUsdCents: Maybe<Scalars['Int']>;
   /** The price of subscribing to this plan with a quantity of 1 (currently always the case) */
   pricePerUnitInUsdCents: Scalars['Int'];
   /** Whether the plan is accessible by all users in QueryRoot.allPlans, QueryRoot.plan, or AccountMutation.setPlan */
@@ -3331,8 +3331,8 @@ export type BillingPlanCapabilities = {
   federation: Scalars['Boolean'];
   launches: Scalars['Boolean'];
   maxAuditInDays: Scalars['Int'];
-  maxRangeInDays?: Maybe<Scalars['Int']>;
-  maxRequestsPerMonth?: Maybe<Scalars['Long']>;
+  maxRangeInDays: Maybe<Scalars['Int']>;
+  maxRequestsPerMonth: Maybe<Scalars['Long']>;
   metrics: Scalars['Boolean'];
   notifications: Scalars['Boolean'];
   operationRegistry: Scalars['Boolean'];
@@ -3365,13 +3365,13 @@ export type BillingSubscription = {
   autoRenew: Scalars['Boolean'];
   /** The price of the subscription when ignoring add-ons (such as seats), ie quantity * pricePerUnitInUsdCents */
   basePriceInUsdCents: Scalars['Long'];
-  canceledAt?: Maybe<Scalars['Timestamp']>;
+  canceledAt: Maybe<Scalars['Timestamp']>;
   currentPeriodEndsAt: Scalars['Timestamp'];
   currentPeriodStartedAt: Scalars['Timestamp'];
-  expiresAt?: Maybe<Scalars['Timestamp']>;
+  expiresAt: Maybe<Scalars['Timestamp']>;
   plan: BillingPlan;
   /** The price of every seat */
-  pricePerSeatInUsdCents?: Maybe<Scalars['Int']>;
+  pricePerSeatInUsdCents: Maybe<Scalars['Int']>;
   /** The price of every unit in the subscription (hence multiplied by quantity to get to the basePriceInUsdCents) */
   pricePerUnitInUsdCents: Scalars['Int'];
   quantity: Scalars['Int'];
@@ -3384,7 +3384,7 @@ export type BillingSubscription = {
    * When this subscription's trial period expires (if it is a trial). Not the same as the
    * subscription's Recurly expiration).
    */
-  trialExpiresAt?: Maybe<Scalars['Timestamp']>;
+  trialExpiresAt: Maybe<Scalars['Timestamp']>;
   uuid: Scalars['ID'];
 };
 
@@ -3422,25 +3422,25 @@ export type AccountExperimentalFeatures = {
 export type AccountInvitation = {
   __typename?: 'AccountInvitation';
   /** An accepted invitation cannot be used anymore */
-  acceptedAt?: Maybe<Scalars['Timestamp']>;
+  acceptedAt: Maybe<Scalars['Timestamp']>;
   /** Who accepted the invitation */
-  acceptedBy?: Maybe<User>;
+  acceptedBy: Maybe<User>;
   /** Time the invitation was created */
   createdAt: Scalars['Timestamp'];
   /** Who created the invitation */
-  createdBy?: Maybe<User>;
+  createdBy: Maybe<User>;
   email: Scalars['String'];
   id: Scalars['ID'];
   /** Last time we sent an email for the invitation */
-  lastSentAt?: Maybe<Scalars['Timestamp']>;
+  lastSentAt: Maybe<Scalars['Timestamp']>;
   /** Access role for the invitee */
   role: UserPermission;
 };
 
 export type Invoice = {
   __typename?: 'Invoice';
-  closedAt?: Maybe<Scalars['Timestamp']>;
-  collectionMethod?: Maybe<Scalars['String']>;
+  closedAt: Maybe<Scalars['Timestamp']>;
+  collectionMethod: Maybe<Scalars['String']>;
   createdAt: Scalars['Timestamp'];
   invoiceNumber: Scalars['Int'];
   state: InvoiceState;
@@ -3462,7 +3462,7 @@ export type AccountMembership = {
   account: Account;
   createdAt: Scalars['Timestamp'];
   /** If this membership is a free seat (based on role) */
-  free?: Maybe<Scalars['Boolean']>;
+  free: Maybe<Scalars['Boolean']>;
   permission: UserPermission;
   user: User;
 };
@@ -3547,121 +3547,121 @@ export type AccountStatsWindow = {
 
 /** A time window with a specified granularity over a given account. */
 export type AccountStatsWindowEdgeServerInfosArgs = {
-  filter?: Maybe<AccountEdgeServerInfosFilter>;
+  filter: Maybe<AccountEdgeServerInfosFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<AccountEdgeServerInfosOrderBySpec>>;
+  orderBy: Maybe<Array<AccountEdgeServerInfosOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given account. */
 export type AccountStatsWindowErrorStatsArgs = {
-  filter?: Maybe<AccountErrorStatsFilter>;
+  filter: Maybe<AccountErrorStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<AccountErrorStatsOrderBySpec>>;
+  orderBy: Maybe<Array<AccountErrorStatsOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given account. */
 export type AccountStatsWindowFieldLatenciesArgs = {
-  filter?: Maybe<AccountFieldLatenciesFilter>;
+  filter: Maybe<AccountFieldLatenciesFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<AccountFieldLatenciesOrderBySpec>>;
+  orderBy: Maybe<Array<AccountFieldLatenciesOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given account. */
 export type AccountStatsWindowFieldStatsArgs = {
-  filter?: Maybe<AccountFieldStatsFilter>;
+  filter: Maybe<AccountFieldStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<AccountFieldStatsOrderBySpec>>;
+  orderBy: Maybe<Array<AccountFieldStatsOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given account. */
 export type AccountStatsWindowFieldUsageArgs = {
-  filter?: Maybe<AccountFieldUsageFilter>;
+  filter: Maybe<AccountFieldUsageFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<AccountFieldUsageOrderBySpec>>;
+  orderBy: Maybe<Array<AccountFieldUsageOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given account. */
 export type AccountStatsWindowOperationCheckStatsArgs = {
-  filter?: Maybe<AccountOperationCheckStatsFilter>;
+  filter: Maybe<AccountOperationCheckStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<AccountOperationCheckStatsOrderBySpec>>;
+  orderBy: Maybe<Array<AccountOperationCheckStatsOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given account. */
 export type AccountStatsWindowQueryStatsArgs = {
-  filter?: Maybe<AccountQueryStatsFilter>;
+  filter: Maybe<AccountQueryStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<AccountQueryStatsOrderBySpec>>;
+  orderBy: Maybe<Array<AccountQueryStatsOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given account. */
 export type AccountStatsWindowTracePathErrorsRefsArgs = {
-  filter?: Maybe<AccountTracePathErrorsRefsFilter>;
+  filter: Maybe<AccountTracePathErrorsRefsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<AccountTracePathErrorsRefsOrderBySpec>>;
+  orderBy: Maybe<Array<AccountTracePathErrorsRefsOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given account. */
 export type AccountStatsWindowTraceRefsArgs = {
-  filter?: Maybe<AccountTraceRefsFilter>;
+  filter: Maybe<AccountTraceRefsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<AccountTraceRefsOrderBySpec>>;
+  orderBy: Maybe<Array<AccountTraceRefsOrderBySpec>>;
 };
 
 /** Filter for data in AccountEdgeServerInfos. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type AccountEdgeServerInfosFilter = {
-  and?: Maybe<Array<AccountEdgeServerInfosFilter>>;
+  and: Maybe<Array<AccountEdgeServerInfosFilter>>;
   /** Selects rows whose bootId dimension equals the given value if not null. To query for the null value, use {in: {bootId: [null]}} instead. */
-  bootId?: Maybe<Scalars['ID']>;
+  bootId: Maybe<Scalars['ID']>;
   /** Selects rows whose executableSchemaId dimension equals the given value if not null. To query for the null value, use {in: {executableSchemaId: [null]}} instead. */
-  executableSchemaId?: Maybe<Scalars['ID']>;
-  in?: Maybe<AccountEdgeServerInfosFilterIn>;
+  executableSchemaId: Maybe<Scalars['ID']>;
+  in: Maybe<AccountEdgeServerInfosFilterIn>;
   /** Selects rows whose libraryVersion dimension equals the given value if not null. To query for the null value, use {in: {libraryVersion: [null]}} instead. */
-  libraryVersion?: Maybe<Scalars['String']>;
-  not?: Maybe<AccountEdgeServerInfosFilter>;
-  or?: Maybe<Array<AccountEdgeServerInfosFilter>>;
+  libraryVersion: Maybe<Scalars['String']>;
+  not: Maybe<AccountEdgeServerInfosFilter>;
+  or: Maybe<Array<AccountEdgeServerInfosFilter>>;
   /** Selects rows whose platform dimension equals the given value if not null. To query for the null value, use {in: {platform: [null]}} instead. */
-  platform?: Maybe<Scalars['String']>;
+  platform: Maybe<Scalars['String']>;
   /** Selects rows whose runtimeVersion dimension equals the given value if not null. To query for the null value, use {in: {runtimeVersion: [null]}} instead. */
-  runtimeVersion?: Maybe<Scalars['String']>;
+  runtimeVersion: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serverId dimension equals the given value if not null. To query for the null value, use {in: {serverId: [null]}} instead. */
-  serverId?: Maybe<Scalars['ID']>;
+  serverId: Maybe<Scalars['ID']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
   /** Selects rows whose userVersion dimension equals the given value if not null. To query for the null value, use {in: {userVersion: [null]}} instead. */
-  userVersion?: Maybe<Scalars['String']>;
+  userVersion: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in AccountEdgeServerInfos. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type AccountEdgeServerInfosFilterIn = {
   /** Selects rows whose bootId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  bootId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  bootId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose executableSchemaId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  executableSchemaId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  executableSchemaId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose libraryVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  libraryVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  libraryVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose platform dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  platform?: Maybe<Array<Maybe<Scalars['String']>>>;
+  platform: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose runtimeVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  runtimeVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  runtimeVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serverId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serverId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serverId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose userVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  userVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  userVersion: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type AccountEdgeServerInfosOrderBySpec = {
@@ -3693,67 +3693,67 @@ export type AccountEdgeServerInfosRecord = {
 
 export type AccountEdgeServerInfosDimensions = {
   __typename?: 'AccountEdgeServerInfosDimensions';
-  bootId?: Maybe<Scalars['ID']>;
-  executableSchemaId?: Maybe<Scalars['ID']>;
-  libraryVersion?: Maybe<Scalars['String']>;
-  platform?: Maybe<Scalars['String']>;
-  runtimeVersion?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serverId?: Maybe<Scalars['ID']>;
-  serviceId?: Maybe<Scalars['ID']>;
-  userVersion?: Maybe<Scalars['String']>;
+  bootId: Maybe<Scalars['ID']>;
+  executableSchemaId: Maybe<Scalars['ID']>;
+  libraryVersion: Maybe<Scalars['String']>;
+  platform: Maybe<Scalars['String']>;
+  runtimeVersion: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serverId: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
+  userVersion: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in AccountErrorStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type AccountErrorStatsFilter = {
-  and?: Maybe<Array<AccountErrorStatsFilter>>;
+  and: Maybe<Array<AccountErrorStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
-  in?: Maybe<AccountErrorStatsFilterIn>;
-  not?: Maybe<AccountErrorStatsFilter>;
-  or?: Maybe<Array<AccountErrorStatsFilter>>;
+  clientVersion: Maybe<Scalars['String']>;
+  in: Maybe<AccountErrorStatsFilterIn>;
+  not: Maybe<AccountErrorStatsFilter>;
+  or: Maybe<Array<AccountErrorStatsFilter>>;
   /** Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead. */
-  path?: Maybe<Scalars['String']>;
+  path: Maybe<Scalars['String']>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
   /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in AccountErrorStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type AccountErrorStatsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  path?: Maybe<Array<Maybe<Scalars['String']>>>;
+  path: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  serviceVersion: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type AccountErrorStatsOrderBySpec = {
@@ -3790,16 +3790,16 @@ export type AccountErrorStatsRecord = {
 
 export type AccountErrorStatsDimensions = {
   __typename?: 'AccountErrorStatsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  path?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  path: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceId: Maybe<Scalars['ID']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 export type AccountErrorStatsMetrics = {
@@ -3810,30 +3810,30 @@ export type AccountErrorStatsMetrics = {
 
 /** Filter for data in AccountFieldLatencies. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type AccountFieldLatenciesFilter = {
-  and?: Maybe<Array<AccountFieldLatenciesFilter>>;
+  and: Maybe<Array<AccountFieldLatenciesFilter>>;
   /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
-  field?: Maybe<Scalars['String']>;
-  in?: Maybe<AccountFieldLatenciesFilterIn>;
-  not?: Maybe<AccountFieldLatenciesFilter>;
-  or?: Maybe<Array<AccountFieldLatenciesFilter>>;
+  field: Maybe<Scalars['String']>;
+  in: Maybe<AccountFieldLatenciesFilterIn>;
+  not: Maybe<AccountFieldLatenciesFilter>;
+  or: Maybe<Array<AccountFieldLatenciesFilter>>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
 };
 
 /** Filter for data in AccountFieldLatencies. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type AccountFieldLatenciesFilterIn = {
   /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  field: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
 };
 
 export type AccountFieldLatenciesOrderBySpec = {
@@ -3863,10 +3863,10 @@ export type AccountFieldLatenciesRecord = {
 
 export type AccountFieldLatenciesDimensions = {
   __typename?: 'AccountFieldLatenciesDimensions';
-  field?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
+  field: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceId: Maybe<Scalars['ID']>;
 };
 
 export type AccountFieldLatenciesMetrics = {
@@ -3876,54 +3876,54 @@ export type AccountFieldLatenciesMetrics = {
 
 /** Filter for data in AccountFieldStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type AccountFieldStatsFilter = {
-  and?: Maybe<Array<AccountFieldStatsFilter>>;
+  and: Maybe<Array<AccountFieldStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
   /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
-  field?: Maybe<Scalars['String']>;
-  in?: Maybe<AccountFieldStatsFilterIn>;
-  not?: Maybe<AccountFieldStatsFilter>;
-  or?: Maybe<Array<AccountFieldStatsFilter>>;
+  field: Maybe<Scalars['String']>;
+  in: Maybe<AccountFieldStatsFilterIn>;
+  not: Maybe<AccountFieldStatsFilter>;
+  or: Maybe<Array<AccountFieldStatsFilter>>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
   /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in AccountFieldStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type AccountFieldStatsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  field: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  serviceVersion: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type AccountFieldStatsOrderBySpec = {
@@ -3961,16 +3961,16 @@ export type AccountFieldStatsRecord = {
 
 export type AccountFieldStatsDimensions = {
   __typename?: 'AccountFieldStatsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  field?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  field: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceId: Maybe<Scalars['ID']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 export type AccountFieldStatsMetrics = {
@@ -3982,50 +3982,50 @@ export type AccountFieldStatsMetrics = {
 
 /** Filter for data in AccountFieldUsage. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type AccountFieldUsageFilter = {
-  and?: Maybe<Array<AccountFieldUsageFilter>>;
+  and: Maybe<Array<AccountFieldUsageFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
   /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
-  field?: Maybe<Scalars['String']>;
-  in?: Maybe<AccountFieldUsageFilterIn>;
-  not?: Maybe<AccountFieldUsageFilter>;
-  or?: Maybe<Array<AccountFieldUsageFilter>>;
+  field: Maybe<Scalars['String']>;
+  in: Maybe<AccountFieldUsageFilterIn>;
+  not: Maybe<AccountFieldUsageFilter>;
+  or: Maybe<Array<AccountFieldUsageFilter>>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
 };
 
 /** Filter for data in AccountFieldUsage. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type AccountFieldUsageFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  field: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
 };
 
 export type AccountFieldUsageOrderBySpec = {
@@ -4061,15 +4061,15 @@ export type AccountFieldUsageRecord = {
 
 export type AccountFieldUsageDimensions = {
   __typename?: 'AccountFieldUsageDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  field?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  field: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceId: Maybe<Scalars['ID']>;
 };
 
 export type AccountFieldUsageMetrics = {
@@ -4080,38 +4080,38 @@ export type AccountFieldUsageMetrics = {
 
 /** Filter for data in AccountOperationCheckStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type AccountOperationCheckStatsFilter = {
-  and?: Maybe<Array<AccountOperationCheckStatsFilter>>;
+  and: Maybe<Array<AccountOperationCheckStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
-  in?: Maybe<AccountOperationCheckStatsFilterIn>;
-  not?: Maybe<AccountOperationCheckStatsFilter>;
-  or?: Maybe<Array<AccountOperationCheckStatsFilter>>;
+  clientVersion: Maybe<Scalars['String']>;
+  in: Maybe<AccountOperationCheckStatsFilterIn>;
+  not: Maybe<AccountOperationCheckStatsFilter>;
+  or: Maybe<Array<AccountOperationCheckStatsFilter>>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
 };
 
 /** Filter for data in AccountOperationCheckStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type AccountOperationCheckStatsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
 };
 
 export type AccountOperationCheckStatsOrderBySpec = {
@@ -4144,12 +4144,12 @@ export type AccountOperationCheckStatsRecord = {
 
 export type AccountOperationCheckStatsDimensions = {
   __typename?: 'AccountOperationCheckStatsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceId: Maybe<Scalars['ID']>;
 };
 
 export type AccountOperationCheckStatsMetrics = {
@@ -4160,54 +4160,54 @@ export type AccountOperationCheckStatsMetrics = {
 
 /** Filter for data in AccountQueryStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type AccountQueryStatsFilter = {
-  and?: Maybe<Array<AccountQueryStatsFilter>>;
+  and: Maybe<Array<AccountQueryStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
   /** Selects rows whose fromEngineproxy dimension equals the given value if not null. To query for the null value, use {in: {fromEngineproxy: [null]}} instead. */
-  fromEngineproxy?: Maybe<Scalars['String']>;
-  in?: Maybe<AccountQueryStatsFilterIn>;
-  not?: Maybe<AccountQueryStatsFilter>;
-  or?: Maybe<Array<AccountQueryStatsFilter>>;
+  fromEngineproxy: Maybe<Scalars['String']>;
+  in: Maybe<AccountQueryStatsFilterIn>;
+  not: Maybe<AccountQueryStatsFilter>;
+  or: Maybe<Array<AccountQueryStatsFilter>>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
   /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in AccountQueryStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type AccountQueryStatsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose fromEngineproxy dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  fromEngineproxy?: Maybe<Array<Maybe<Scalars['String']>>>;
+  fromEngineproxy: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  serviceVersion: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type AccountQueryStatsOrderBySpec = {
@@ -4250,17 +4250,17 @@ export type AccountQueryStatsRecord = {
 
 export type AccountQueryStatsDimensions = {
   __typename?: 'AccountQueryStatsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  fromEngineproxy?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  querySignature?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  fromEngineproxy: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  querySignature: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceId: Maybe<Scalars['ID']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 export type AccountQueryStatsMetrics = {
@@ -4279,70 +4279,70 @@ export type AccountQueryStatsMetrics = {
 
 /** Filter for data in AccountTracePathErrorsRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type AccountTracePathErrorsRefsFilter = {
-  and?: Maybe<Array<AccountTracePathErrorsRefsFilter>>;
+  and: Maybe<Array<AccountTracePathErrorsRefsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
   /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
-  durationBucket?: Maybe<Scalars['Int']>;
+  durationBucket: Maybe<Scalars['Int']>;
   /** Selects rows whose errorMessage dimension equals the given value if not null. To query for the null value, use {in: {errorMessage: [null]}} instead. */
-  errorMessage?: Maybe<Scalars['String']>;
-  in?: Maybe<AccountTracePathErrorsRefsFilterIn>;
-  not?: Maybe<AccountTracePathErrorsRefsFilter>;
-  or?: Maybe<Array<AccountTracePathErrorsRefsFilter>>;
+  errorMessage: Maybe<Scalars['String']>;
+  in: Maybe<AccountTracePathErrorsRefsFilterIn>;
+  not: Maybe<AccountTracePathErrorsRefsFilter>;
+  or: Maybe<Array<AccountTracePathErrorsRefsFilter>>;
   /** Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead. */
-  path?: Maybe<Scalars['String']>;
+  path: Maybe<Scalars['String']>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
   /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
   /** Selects rows whose traceHttpStatusCode dimension equals the given value if not null. To query for the null value, use {in: {traceHttpStatusCode: [null]}} instead. */
-  traceHttpStatusCode?: Maybe<Scalars['Int']>;
+  traceHttpStatusCode: Maybe<Scalars['Int']>;
   /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
-  traceId?: Maybe<Scalars['ID']>;
+  traceId: Maybe<Scalars['ID']>;
 };
 
 /** Filter for data in AccountTracePathErrorsRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type AccountTracePathErrorsRefsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  durationBucket?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  durationBucket: Maybe<Array<Maybe<Scalars['Int']>>>;
   /** Selects rows whose errorMessage dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  errorMessage?: Maybe<Array<Maybe<Scalars['String']>>>;
+  errorMessage: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  path?: Maybe<Array<Maybe<Scalars['String']>>>;
+  path: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  serviceVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose traceHttpStatusCode dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  traceHttpStatusCode?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  traceHttpStatusCode: Maybe<Array<Maybe<Scalars['Int']>>>;
   /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  traceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  traceId: Maybe<Array<Maybe<Scalars['ID']>>>;
 };
 
 export type AccountTracePathErrorsRefsOrderBySpec = {
@@ -4385,21 +4385,21 @@ export type AccountTracePathErrorsRefsRecord = {
 
 export type AccountTracePathErrorsRefsDimensions = {
   __typename?: 'AccountTracePathErrorsRefsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  durationBucket?: Maybe<Scalars['Int']>;
-  errorMessage?: Maybe<Scalars['String']>;
-  path?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
-  traceHttpStatusCode?: Maybe<Scalars['Int']>;
-  traceId?: Maybe<Scalars['ID']>;
-  traceStartsAt?: Maybe<Scalars['Timestamp']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  durationBucket: Maybe<Scalars['Int']>;
+  errorMessage: Maybe<Scalars['String']>;
+  path: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceId: Maybe<Scalars['ID']>;
+  serviceVersion: Maybe<Scalars['String']>;
+  traceHttpStatusCode: Maybe<Scalars['Int']>;
+  traceId: Maybe<Scalars['ID']>;
+  traceStartsAt: Maybe<Scalars['Timestamp']>;
 };
 
 export type AccountTracePathErrorsRefsMetrics = {
@@ -4411,58 +4411,58 @@ export type AccountTracePathErrorsRefsMetrics = {
 
 /** Filter for data in AccountTraceRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type AccountTraceRefsFilter = {
-  and?: Maybe<Array<AccountTraceRefsFilter>>;
+  and: Maybe<Array<AccountTraceRefsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
   /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
-  durationBucket?: Maybe<Scalars['Int']>;
-  in?: Maybe<AccountTraceRefsFilterIn>;
-  not?: Maybe<AccountTraceRefsFilter>;
-  or?: Maybe<Array<AccountTraceRefsFilter>>;
+  durationBucket: Maybe<Scalars['Int']>;
+  in: Maybe<AccountTraceRefsFilterIn>;
+  not: Maybe<AccountTraceRefsFilter>;
+  or: Maybe<Array<AccountTraceRefsFilter>>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
   /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
   /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
-  traceId?: Maybe<Scalars['ID']>;
+  traceId: Maybe<Scalars['ID']>;
 };
 
 /** Filter for data in AccountTraceRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type AccountTraceRefsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  durationBucket?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  durationBucket: Maybe<Array<Maybe<Scalars['Int']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  serviceVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  traceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  traceId: Maybe<Array<Maybe<Scalars['ID']>>>;
 };
 
 export type AccountTraceRefsOrderBySpec = {
@@ -4500,18 +4500,18 @@ export type AccountTraceRefsRecord = {
 
 export type AccountTraceRefsDimensions = {
   __typename?: 'AccountTraceRefsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  durationBucket?: Maybe<Scalars['Int']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  querySignature?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
-  traceId?: Maybe<Scalars['ID']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  durationBucket: Maybe<Scalars['Int']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  querySignature: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceId: Maybe<Scalars['ID']>;
+  serviceVersion: Maybe<Scalars['String']>;
+  traceId: Maybe<Scalars['ID']>;
 };
 
 export type AccountTraceRefsMetrics = {
@@ -4552,17 +4552,17 @@ export type CronJob = {
 
 
 export type CronJobRecentExecutionsArgs = {
-  n?: Maybe<Scalars['Int']>;
+  n: Maybe<Scalars['Int']>;
 };
 
 export type CronExecution = {
   __typename?: 'CronExecution';
-  completedAt?: Maybe<Scalars['Timestamp']>;
-  failure?: Maybe<Scalars['String']>;
+  completedAt: Maybe<Scalars['Timestamp']>;
+  failure: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   job: CronJob;
-  resolvedAt?: Maybe<Scalars['Timestamp']>;
-  resolvedBy?: Maybe<Actor>;
+  resolvedAt: Maybe<Scalars['Timestamp']>;
+  resolvedBy: Maybe<Actor>;
   schedule: Scalars['String'];
   startedAt: Scalars['Timestamp'];
 };
@@ -4594,121 +4594,121 @@ export type StatsWindow = {
 
 /** A time window with a specified granularity. */
 export type StatsWindowEdgeServerInfosArgs = {
-  filter?: Maybe<EdgeServerInfosFilter>;
+  filter: Maybe<EdgeServerInfosFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<EdgeServerInfosOrderBySpec>>;
+  orderBy: Maybe<Array<EdgeServerInfosOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity. */
 export type StatsWindowErrorStatsArgs = {
-  filter?: Maybe<ErrorStatsFilter>;
+  filter: Maybe<ErrorStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<ErrorStatsOrderBySpec>>;
+  orderBy: Maybe<Array<ErrorStatsOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity. */
 export type StatsWindowFieldLatenciesArgs = {
-  filter?: Maybe<FieldLatenciesFilter>;
+  filter: Maybe<FieldLatenciesFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<FieldLatenciesOrderBySpec>>;
+  orderBy: Maybe<Array<FieldLatenciesOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity. */
 export type StatsWindowFieldStatsArgs = {
-  filter?: Maybe<FieldStatsFilter>;
+  filter: Maybe<FieldStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<FieldStatsOrderBySpec>>;
+  orderBy: Maybe<Array<FieldStatsOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity. */
 export type StatsWindowFieldUsageArgs = {
-  filter?: Maybe<FieldUsageFilter>;
+  filter: Maybe<FieldUsageFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<FieldUsageOrderBySpec>>;
+  orderBy: Maybe<Array<FieldUsageOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity. */
 export type StatsWindowOperationCheckStatsArgs = {
-  filter?: Maybe<OperationCheckStatsFilter>;
+  filter: Maybe<OperationCheckStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<OperationCheckStatsOrderBySpec>>;
+  orderBy: Maybe<Array<OperationCheckStatsOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity. */
 export type StatsWindowQueryStatsArgs = {
-  filter?: Maybe<QueryStatsFilter>;
+  filter: Maybe<QueryStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<QueryStatsOrderBySpec>>;
+  orderBy: Maybe<Array<QueryStatsOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity. */
 export type StatsWindowTracePathErrorsRefsArgs = {
-  filter?: Maybe<TracePathErrorsRefsFilter>;
+  filter: Maybe<TracePathErrorsRefsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<TracePathErrorsRefsOrderBySpec>>;
+  orderBy: Maybe<Array<TracePathErrorsRefsOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity. */
 export type StatsWindowTraceRefsArgs = {
-  filter?: Maybe<TraceRefsFilter>;
+  filter: Maybe<TraceRefsFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<TraceRefsOrderBySpec>>;
+  orderBy: Maybe<Array<TraceRefsOrderBySpec>>;
 };
 
 /** Filter for data in EdgeServerInfos. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type EdgeServerInfosFilter = {
-  and?: Maybe<Array<EdgeServerInfosFilter>>;
+  and: Maybe<Array<EdgeServerInfosFilter>>;
   /** Selects rows whose bootId dimension equals the given value if not null. To query for the null value, use {in: {bootId: [null]}} instead. */
-  bootId?: Maybe<Scalars['ID']>;
+  bootId: Maybe<Scalars['ID']>;
   /** Selects rows whose executableSchemaId dimension equals the given value if not null. To query for the null value, use {in: {executableSchemaId: [null]}} instead. */
-  executableSchemaId?: Maybe<Scalars['ID']>;
-  in?: Maybe<EdgeServerInfosFilterIn>;
+  executableSchemaId: Maybe<Scalars['ID']>;
+  in: Maybe<EdgeServerInfosFilterIn>;
   /** Selects rows whose libraryVersion dimension equals the given value if not null. To query for the null value, use {in: {libraryVersion: [null]}} instead. */
-  libraryVersion?: Maybe<Scalars['String']>;
-  not?: Maybe<EdgeServerInfosFilter>;
-  or?: Maybe<Array<EdgeServerInfosFilter>>;
+  libraryVersion: Maybe<Scalars['String']>;
+  not: Maybe<EdgeServerInfosFilter>;
+  or: Maybe<Array<EdgeServerInfosFilter>>;
   /** Selects rows whose platform dimension equals the given value if not null. To query for the null value, use {in: {platform: [null]}} instead. */
-  platform?: Maybe<Scalars['String']>;
+  platform: Maybe<Scalars['String']>;
   /** Selects rows whose runtimeVersion dimension equals the given value if not null. To query for the null value, use {in: {runtimeVersion: [null]}} instead. */
-  runtimeVersion?: Maybe<Scalars['String']>;
+  runtimeVersion: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serverId dimension equals the given value if not null. To query for the null value, use {in: {serverId: [null]}} instead. */
-  serverId?: Maybe<Scalars['ID']>;
+  serverId: Maybe<Scalars['ID']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
   /** Selects rows whose userVersion dimension equals the given value if not null. To query for the null value, use {in: {userVersion: [null]}} instead. */
-  userVersion?: Maybe<Scalars['String']>;
+  userVersion: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in EdgeServerInfos. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type EdgeServerInfosFilterIn = {
   /** Selects rows whose bootId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  bootId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  bootId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose executableSchemaId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  executableSchemaId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  executableSchemaId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose libraryVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  libraryVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  libraryVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose platform dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  platform?: Maybe<Array<Maybe<Scalars['String']>>>;
+  platform: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose runtimeVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  runtimeVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  runtimeVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serverId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serverId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serverId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose userVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  userVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  userVersion: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type EdgeServerInfosOrderBySpec = {
@@ -4740,71 +4740,71 @@ export type EdgeServerInfosRecord = {
 
 export type EdgeServerInfosDimensions = {
   __typename?: 'EdgeServerInfosDimensions';
-  bootId?: Maybe<Scalars['ID']>;
-  executableSchemaId?: Maybe<Scalars['ID']>;
-  libraryVersion?: Maybe<Scalars['String']>;
-  platform?: Maybe<Scalars['String']>;
-  runtimeVersion?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serverId?: Maybe<Scalars['ID']>;
-  serviceId?: Maybe<Scalars['ID']>;
-  userVersion?: Maybe<Scalars['String']>;
+  bootId: Maybe<Scalars['ID']>;
+  executableSchemaId: Maybe<Scalars['ID']>;
+  libraryVersion: Maybe<Scalars['String']>;
+  platform: Maybe<Scalars['String']>;
+  runtimeVersion: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serverId: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
+  userVersion: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in ErrorStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type ErrorStatsFilter = {
   /** Selects rows whose accountId dimension equals the given value if not null. To query for the null value, use {in: {accountId: [null]}} instead. */
-  accountId?: Maybe<Scalars['ID']>;
-  and?: Maybe<Array<ErrorStatsFilter>>;
+  accountId: Maybe<Scalars['ID']>;
+  and: Maybe<Array<ErrorStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
-  in?: Maybe<ErrorStatsFilterIn>;
-  not?: Maybe<ErrorStatsFilter>;
-  or?: Maybe<Array<ErrorStatsFilter>>;
+  clientVersion: Maybe<Scalars['String']>;
+  in: Maybe<ErrorStatsFilterIn>;
+  not: Maybe<ErrorStatsFilter>;
+  or: Maybe<Array<ErrorStatsFilter>>;
   /** Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead. */
-  path?: Maybe<Scalars['String']>;
+  path: Maybe<Scalars['String']>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
   /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in ErrorStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type ErrorStatsFilterIn = {
   /** Selects rows whose accountId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  accountId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  accountId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  path?: Maybe<Array<Maybe<Scalars['String']>>>;
+  path: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  serviceVersion: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type ErrorStatsOrderBySpec = {
@@ -4842,17 +4842,17 @@ export type ErrorStatsRecord = {
 
 export type ErrorStatsDimensions = {
   __typename?: 'ErrorStatsDimensions';
-  accountId?: Maybe<Scalars['ID']>;
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  path?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
+  accountId: Maybe<Scalars['ID']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  path: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceId: Maybe<Scalars['ID']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 export type ErrorStatsMetrics = {
@@ -4863,30 +4863,30 @@ export type ErrorStatsMetrics = {
 
 /** Filter for data in FieldLatencies. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type FieldLatenciesFilter = {
-  and?: Maybe<Array<FieldLatenciesFilter>>;
+  and: Maybe<Array<FieldLatenciesFilter>>;
   /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
-  field?: Maybe<Scalars['String']>;
-  in?: Maybe<FieldLatenciesFilterIn>;
-  not?: Maybe<FieldLatenciesFilter>;
-  or?: Maybe<Array<FieldLatenciesFilter>>;
+  field: Maybe<Scalars['String']>;
+  in: Maybe<FieldLatenciesFilterIn>;
+  not: Maybe<FieldLatenciesFilter>;
+  or: Maybe<Array<FieldLatenciesFilter>>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
 };
 
 /** Filter for data in FieldLatencies. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type FieldLatenciesFilterIn = {
   /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  field: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
 };
 
 export type FieldLatenciesOrderBySpec = {
@@ -4916,10 +4916,10 @@ export type FieldLatenciesRecord = {
 
 export type FieldLatenciesDimensions = {
   __typename?: 'FieldLatenciesDimensions';
-  field?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
+  field: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceId: Maybe<Scalars['ID']>;
 };
 
 export type FieldLatenciesMetrics = {
@@ -4930,57 +4930,57 @@ export type FieldLatenciesMetrics = {
 /** Filter for data in FieldStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type FieldStatsFilter = {
   /** Selects rows whose accountId dimension equals the given value if not null. To query for the null value, use {in: {accountId: [null]}} instead. */
-  accountId?: Maybe<Scalars['ID']>;
-  and?: Maybe<Array<FieldStatsFilter>>;
+  accountId: Maybe<Scalars['ID']>;
+  and: Maybe<Array<FieldStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
   /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
-  field?: Maybe<Scalars['String']>;
-  in?: Maybe<FieldStatsFilterIn>;
-  not?: Maybe<FieldStatsFilter>;
-  or?: Maybe<Array<FieldStatsFilter>>;
+  field: Maybe<Scalars['String']>;
+  in: Maybe<FieldStatsFilterIn>;
+  not: Maybe<FieldStatsFilter>;
+  or: Maybe<Array<FieldStatsFilter>>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
   /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in FieldStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type FieldStatsFilterIn = {
   /** Selects rows whose accountId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  accountId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  accountId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  field: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  serviceVersion: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type FieldStatsOrderBySpec = {
@@ -5019,17 +5019,17 @@ export type FieldStatsRecord = {
 
 export type FieldStatsDimensions = {
   __typename?: 'FieldStatsDimensions';
-  accountId?: Maybe<Scalars['ID']>;
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  field?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
+  accountId: Maybe<Scalars['ID']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  field: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceId: Maybe<Scalars['ID']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 export type FieldStatsMetrics = {
@@ -5041,50 +5041,50 @@ export type FieldStatsMetrics = {
 
 /** Filter for data in FieldUsage. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type FieldUsageFilter = {
-  and?: Maybe<Array<FieldUsageFilter>>;
+  and: Maybe<Array<FieldUsageFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
   /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
-  field?: Maybe<Scalars['String']>;
-  in?: Maybe<FieldUsageFilterIn>;
-  not?: Maybe<FieldUsageFilter>;
-  or?: Maybe<Array<FieldUsageFilter>>;
+  field: Maybe<Scalars['String']>;
+  in: Maybe<FieldUsageFilterIn>;
+  not: Maybe<FieldUsageFilter>;
+  or: Maybe<Array<FieldUsageFilter>>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
 };
 
 /** Filter for data in FieldUsage. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type FieldUsageFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  field: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
 };
 
 export type FieldUsageOrderBySpec = {
@@ -5120,15 +5120,15 @@ export type FieldUsageRecord = {
 
 export type FieldUsageDimensions = {
   __typename?: 'FieldUsageDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  field?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  field: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceId: Maybe<Scalars['ID']>;
 };
 
 export type FieldUsageMetrics = {
@@ -5139,38 +5139,38 @@ export type FieldUsageMetrics = {
 
 /** Filter for data in OperationCheckStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type OperationCheckStatsFilter = {
-  and?: Maybe<Array<OperationCheckStatsFilter>>;
+  and: Maybe<Array<OperationCheckStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
-  in?: Maybe<OperationCheckStatsFilterIn>;
-  not?: Maybe<OperationCheckStatsFilter>;
-  or?: Maybe<Array<OperationCheckStatsFilter>>;
+  clientVersion: Maybe<Scalars['String']>;
+  in: Maybe<OperationCheckStatsFilterIn>;
+  not: Maybe<OperationCheckStatsFilter>;
+  or: Maybe<Array<OperationCheckStatsFilter>>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
 };
 
 /** Filter for data in OperationCheckStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type OperationCheckStatsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
 };
 
 export type OperationCheckStatsOrderBySpec = {
@@ -5203,12 +5203,12 @@ export type OperationCheckStatsRecord = {
 
 export type OperationCheckStatsDimensions = {
   __typename?: 'OperationCheckStatsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceId: Maybe<Scalars['ID']>;
 };
 
 export type OperationCheckStatsMetrics = {
@@ -5220,57 +5220,57 @@ export type OperationCheckStatsMetrics = {
 /** Filter for data in QueryStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type QueryStatsFilter = {
   /** Selects rows whose accountId dimension equals the given value if not null. To query for the null value, use {in: {accountId: [null]}} instead. */
-  accountId?: Maybe<Scalars['ID']>;
-  and?: Maybe<Array<QueryStatsFilter>>;
+  accountId: Maybe<Scalars['ID']>;
+  and: Maybe<Array<QueryStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
   /** Selects rows whose fromEngineproxy dimension equals the given value if not null. To query for the null value, use {in: {fromEngineproxy: [null]}} instead. */
-  fromEngineproxy?: Maybe<Scalars['String']>;
-  in?: Maybe<QueryStatsFilterIn>;
-  not?: Maybe<QueryStatsFilter>;
-  or?: Maybe<Array<QueryStatsFilter>>;
+  fromEngineproxy: Maybe<Scalars['String']>;
+  in: Maybe<QueryStatsFilterIn>;
+  not: Maybe<QueryStatsFilter>;
+  or: Maybe<Array<QueryStatsFilter>>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
   /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in QueryStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type QueryStatsFilterIn = {
   /** Selects rows whose accountId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  accountId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  accountId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose fromEngineproxy dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  fromEngineproxy?: Maybe<Array<Maybe<Scalars['String']>>>;
+  fromEngineproxy: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  serviceVersion: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type QueryStatsOrderBySpec = {
@@ -5314,18 +5314,18 @@ export type QueryStatsRecord = {
 
 export type QueryStatsDimensions = {
   __typename?: 'QueryStatsDimensions';
-  accountId?: Maybe<Scalars['ID']>;
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  fromEngineproxy?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  querySignature?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
+  accountId: Maybe<Scalars['ID']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  fromEngineproxy: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  querySignature: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceId: Maybe<Scalars['ID']>;
+  serviceVersion: Maybe<Scalars['String']>;
 };
 
 export type QueryStatsMetrics = {
@@ -5344,70 +5344,70 @@ export type QueryStatsMetrics = {
 
 /** Filter for data in TracePathErrorsRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type TracePathErrorsRefsFilter = {
-  and?: Maybe<Array<TracePathErrorsRefsFilter>>;
+  and: Maybe<Array<TracePathErrorsRefsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
   /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
-  durationBucket?: Maybe<Scalars['Int']>;
+  durationBucket: Maybe<Scalars['Int']>;
   /** Selects rows whose errorMessage dimension equals the given value if not null. To query for the null value, use {in: {errorMessage: [null]}} instead. */
-  errorMessage?: Maybe<Scalars['String']>;
-  in?: Maybe<TracePathErrorsRefsFilterIn>;
-  not?: Maybe<TracePathErrorsRefsFilter>;
-  or?: Maybe<Array<TracePathErrorsRefsFilter>>;
+  errorMessage: Maybe<Scalars['String']>;
+  in: Maybe<TracePathErrorsRefsFilterIn>;
+  not: Maybe<TracePathErrorsRefsFilter>;
+  or: Maybe<Array<TracePathErrorsRefsFilter>>;
   /** Selects rows whose path dimension equals the given value if not null. To query for the null value, use {in: {path: [null]}} instead. */
-  path?: Maybe<Scalars['String']>;
+  path: Maybe<Scalars['String']>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
   /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
   /** Selects rows whose traceHttpStatusCode dimension equals the given value if not null. To query for the null value, use {in: {traceHttpStatusCode: [null]}} instead. */
-  traceHttpStatusCode?: Maybe<Scalars['Int']>;
+  traceHttpStatusCode: Maybe<Scalars['Int']>;
   /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
-  traceId?: Maybe<Scalars['ID']>;
+  traceId: Maybe<Scalars['ID']>;
 };
 
 /** Filter for data in TracePathErrorsRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type TracePathErrorsRefsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  durationBucket?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  durationBucket: Maybe<Array<Maybe<Scalars['Int']>>>;
   /** Selects rows whose errorMessage dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  errorMessage?: Maybe<Array<Maybe<Scalars['String']>>>;
+  errorMessage: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  path?: Maybe<Array<Maybe<Scalars['String']>>>;
+  path: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  serviceVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose traceHttpStatusCode dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  traceHttpStatusCode?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  traceHttpStatusCode: Maybe<Array<Maybe<Scalars['Int']>>>;
   /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  traceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  traceId: Maybe<Array<Maybe<Scalars['ID']>>>;
 };
 
 export type TracePathErrorsRefsOrderBySpec = {
@@ -5450,22 +5450,22 @@ export type TracePathErrorsRefsRecord = {
 
 export type TracePathErrorsRefsDimensions = {
   __typename?: 'TracePathErrorsRefsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  durationBucket?: Maybe<Scalars['Int']>;
-  errorMessage?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  durationBucket: Maybe<Scalars['Int']>;
+  errorMessage: Maybe<Scalars['String']>;
   /** If metrics were collected from a federated service, this field will be prefixed with `service:<SERVICE_NAME>.` */
-  path?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
-  traceHttpStatusCode?: Maybe<Scalars['Int']>;
-  traceId?: Maybe<Scalars['ID']>;
-  traceStartsAt?: Maybe<Scalars['Timestamp']>;
+  path: Maybe<Scalars['String']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceId: Maybe<Scalars['ID']>;
+  serviceVersion: Maybe<Scalars['String']>;
+  traceHttpStatusCode: Maybe<Scalars['Int']>;
+  traceId: Maybe<Scalars['ID']>;
+  traceStartsAt: Maybe<Scalars['Timestamp']>;
 };
 
 export type TracePathErrorsRefsMetrics = {
@@ -5477,58 +5477,58 @@ export type TracePathErrorsRefsMetrics = {
 
 /** Filter for data in TraceRefs. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
 export type TraceRefsFilter = {
-  and?: Maybe<Array<TraceRefsFilter>>;
+  and: Maybe<Array<TraceRefsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
+  clientName: Maybe<Scalars['String']>;
   /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+  clientVersion: Maybe<Scalars['String']>;
   /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
-  durationBucket?: Maybe<Scalars['Int']>;
-  in?: Maybe<TraceRefsFilterIn>;
-  not?: Maybe<TraceRefsFilter>;
-  or?: Maybe<Array<TraceRefsFilter>>;
+  durationBucket: Maybe<Scalars['Int']>;
+  in: Maybe<TraceRefsFilterIn>;
+  not: Maybe<TraceRefsFilter>;
+  or: Maybe<Array<TraceRefsFilter>>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
+  queryId: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  queryName: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
+  serviceId: Maybe<Scalars['ID']>;
   /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
+  serviceVersion: Maybe<Scalars['String']>;
   /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
-  traceId?: Maybe<Scalars['ID']>;
+  traceId: Maybe<Scalars['ID']>;
 };
 
 /** Filter for data in TraceRefs. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type TraceRefsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  clientReferenceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  clientVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  durationBucket?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  durationBucket: Maybe<Array<Maybe<Scalars['Int']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  queryId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  queryName: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaHash: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  schemaTag: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  serviceId: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  serviceVersion: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  traceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  traceId: Maybe<Array<Maybe<Scalars['ID']>>>;
 };
 
 export type TraceRefsOrderBySpec = {
@@ -5566,18 +5566,18 @@ export type TraceRefsRecord = {
 
 export type TraceRefsDimensions = {
   __typename?: 'TraceRefsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  durationBucket?: Maybe<Scalars['Int']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  querySignature?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
-  traceId?: Maybe<Scalars['ID']>;
+  clientName: Maybe<Scalars['String']>;
+  clientReferenceId: Maybe<Scalars['ID']>;
+  clientVersion: Maybe<Scalars['String']>;
+  durationBucket: Maybe<Scalars['Int']>;
+  queryId: Maybe<Scalars['ID']>;
+  queryName: Maybe<Scalars['String']>;
+  querySignature: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
+  schemaTag: Maybe<Scalars['String']>;
+  serviceId: Maybe<Scalars['ID']>;
+  serviceVersion: Maybe<Scalars['String']>;
+  traceId: Maybe<Scalars['ID']>;
 };
 
 export type TraceRefsMetrics = {
@@ -5624,38 +5624,38 @@ export type Error = {
 
 export type Mutation = {
   __typename?: 'Mutation';
-  account?: Maybe<AccountMutation>;
+  account: Maybe<AccountMutation>;
   /**
    * Finalize a password reset with a token included in the E-mail link,
    * returns the corresponding login email when successful
    */
-  finalizePasswordReset?: Maybe<Scalars['String']>;
+  finalizePasswordReset: Maybe<Scalars['String']>;
   /** Join an account with a token */
-  joinAccount?: Maybe<Account>;
-  me?: Maybe<IdentityMutation>;
-  newAccount?: Maybe<Account>;
-  newService?: Maybe<Service>;
+  joinAccount: Maybe<Account>;
+  me: Maybe<IdentityMutation>;
+  newAccount: Maybe<Account>;
+  newService: Maybe<Service>;
   /** Refresh all plans from third-party billing service */
-  plansRefreshBilling?: Maybe<Scalars['Void']>;
+  plansRefreshBilling: Maybe<Scalars['Void']>;
   /** Report a running GraphQL server's schema. */
-  reportSchema?: Maybe<ReportSchemaResult>;
+  reportSchema: Maybe<ReportSchemaResult>;
   /** Ask for a user's password to be reset by E-mail */
-  resetPassword?: Maybe<Scalars['Void']>;
-  resolveAllInternalCronExecutions?: Maybe<Scalars['Void']>;
-  resolveInternalCronExecution?: Maybe<CronExecution>;
-  service?: Maybe<ServiceMutation>;
+  resetPassword: Maybe<Scalars['Void']>;
+  resolveAllInternalCronExecutions: Maybe<Scalars['Void']>;
+  resolveInternalCronExecution: Maybe<CronExecution>;
+  service: Maybe<ServiceMutation>;
   /** Set the subscriptions for a given email */
-  setSubscriptions?: Maybe<EmailPreferences>;
+  setSubscriptions: Maybe<EmailPreferences>;
   /** Set the studio settings for the current user */
-  setUserSettings?: Maybe<UserSettings>;
-  signUp?: Maybe<User>;
+  setUserSettings: Maybe<UserSettings>;
+  signUp: Maybe<User>;
   /** This is called by the form shown to users after they delete their user or organization account. */
-  submitPostDeletionFeedback?: Maybe<Scalars['Void']>;
+  submitPostDeletionFeedback: Maybe<Scalars['Void']>;
   /** Mutation for basic engagement tracking in studio */
-  track?: Maybe<Scalars['Void']>;
+  track: Maybe<Scalars['Void']>;
   /** Unsubscribe a given email from all emails */
-  unsubscribeFromAll?: Maybe<EmailPreferences>;
-  user?: Maybe<UserMutation>;
+  unsubscribeFromAll: Maybe<EmailPreferences>;
+  user: Maybe<UserMutation>;
 };
 
 
@@ -5677,24 +5677,24 @@ export type MutationJoinAccountArgs = {
 
 
 export type MutationNewAccountArgs = {
-  companyUrl?: Maybe<Scalars['String']>;
+  companyUrl: Maybe<Scalars['String']>;
   id: Scalars['ID'];
 };
 
 
 export type MutationNewServiceArgs = {
   accountId: Scalars['ID'];
-  description?: Maybe<Scalars['String']>;
+  description: Maybe<Scalars['String']>;
   hiddenFromUninvitedNonAdminAccountMembers?: Scalars['Boolean'];
   id: Scalars['ID'];
   isDev?: Scalars['Boolean'];
-  name?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
+  title: Maybe<Scalars['String']>;
 };
 
 
 export type MutationReportSchemaArgs = {
-  coreSchema?: Maybe<Scalars['String']>;
+  coreSchema: Maybe<Scalars['String']>;
   report: SchemaReport;
 };
 
@@ -5705,8 +5705,8 @@ export type MutationResetPasswordArgs = {
 
 
 export type MutationResolveAllInternalCronExecutionsArgs = {
-  group?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
+  group: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
 };
 
 
@@ -5728,7 +5728,7 @@ export type MutationSetSubscriptionsArgs = {
 
 
 export type MutationSetUserSettingsArgs = {
-  newSettings?: Maybe<UserSettingsInput>;
+  newSettings: Maybe<UserSettingsInput>;
 };
 
 
@@ -5736,13 +5736,13 @@ export type MutationSignUpArgs = {
   email: Scalars['String'];
   fullName: Scalars['String'];
   password: Scalars['String'];
-  referrer?: Maybe<Scalars['String']>;
-  trackingGoogleClientId?: Maybe<Scalars['String']>;
-  trackingMarketoClientId?: Maybe<Scalars['String']>;
-  userSegment?: Maybe<UserSegment>;
-  utmCampaign?: Maybe<Scalars['String']>;
-  utmMedium?: Maybe<Scalars['String']>;
-  utmSource?: Maybe<Scalars['String']>;
+  referrer: Maybe<Scalars['String']>;
+  trackingGoogleClientId: Maybe<Scalars['String']>;
+  trackingMarketoClientId: Maybe<Scalars['String']>;
+  userSegment: Maybe<UserSegment>;
+  utmCampaign: Maybe<Scalars['String']>;
+  utmMedium: Maybe<Scalars['String']>;
+  utmSource: Maybe<Scalars['String']>;
 };
 
 
@@ -5772,65 +5772,65 @@ export type MutationUserArgs = {
 
 export type AccountMutation = {
   __typename?: 'AccountMutation';
-  auditExport?: Maybe<AuditLogExportMutation>;
+  auditExport: Maybe<AuditLogExportMutation>;
   /** Cancel a pending change from an annual team subscription to a monthly team subscription when the current period expires. */
-  cancelConvertAnnualTeamSubscriptionToMonthlyAtNextPeriod?: Maybe<Account>;
+  cancelConvertAnnualTeamSubscriptionToMonthlyAtNextPeriod: Maybe<Account>;
   /** Cancel account subscriptions, subscriptions will remain active until the end of the paid period */
-  cancelSubscriptions?: Maybe<Account>;
+  cancelSubscriptions: Maybe<Account>;
   /** Changes an annual team subscription to a monthly team subscription when the current period expires. */
-  convertAnnualTeamSubscriptionToMonthlyAtNextPeriod?: Maybe<Account>;
+  convertAnnualTeamSubscriptionToMonthlyAtNextPeriod: Maybe<Account>;
   /** Changes a monthly team subscription to an annual team subscription. */
-  convertMonthlyTeamSubscriptionToAnnual?: Maybe<Account>;
-  createStaticInvitation?: Maybe<OrganizationInviteLink>;
+  convertMonthlyTeamSubscriptionToAnnual: Maybe<Account>;
+  createStaticInvitation: Maybe<OrganizationInviteLink>;
   /** Delete the account's avatar. Requires Account.canUpdateAvatar to be true. */
-  deleteAvatar?: Maybe<AvatarDeleteError>;
+  deleteAvatar: Maybe<AvatarDeleteError>;
   /** Acknowledge that a trial has expired and return to community */
-  dismissExpiredTrial?: Maybe<Account>;
+  dismissExpiredTrial: Maybe<Account>;
   /** Apollo admins only: extend an ongoing trial */
-  extendTrial?: Maybe<Account>;
+  extendTrial: Maybe<Account>;
   /** Hard delete an account and all associated services */
-  hardDelete?: Maybe<Scalars['Void']>;
+  hardDelete: Maybe<Scalars['Void']>;
   /** Send an invitation to join the account by E-mail */
-  invite?: Maybe<AccountInvitation>;
+  invite: Maybe<AccountInvitation>;
   /** Reactivate a canceled current subscription */
-  reactivateCurrentSubscription?: Maybe<Account>;
+  reactivateCurrentSubscription: Maybe<Account>;
   /** Refresh billing information from third-party billing service */
-  refreshBilling?: Maybe<Scalars['Void']>;
+  refreshBilling: Maybe<Scalars['Void']>;
   /** Delete an invitation */
-  removeInvitation?: Maybe<Scalars['Void']>;
+  removeInvitation: Maybe<Scalars['Void']>;
   /** Remove a member of the account */
-  removeMember?: Maybe<Account>;
-  requestAuditExport?: Maybe<Account>;
+  removeMember: Maybe<Account>;
+  requestAuditExport: Maybe<Account>;
   /** Send a new E-mail for an existing invitation */
-  resendInvitation?: Maybe<AccountInvitation>;
-  revokeStaticInvitation?: Maybe<OrganizationInviteLink>;
+  resendInvitation: Maybe<AccountInvitation>;
+  revokeStaticInvitation: Maybe<OrganizationInviteLink>;
   /** Apollo admins only: set the billing plan to an arbitrary plan */
-  setPlan?: Maybe<Scalars['Void']>;
+  setPlan: Maybe<Scalars['Void']>;
   /** Start a new team subscription with the given billing period */
-  startTeamSubscription?: Maybe<Account>;
+  startTeamSubscription: Maybe<Account>;
   /** Start a team trial */
-  startTrial?: Maybe<Account>;
+  startTrial: Maybe<Account>;
   /** This is called by the form shown to users after they cancel their team subscription. */
-  submitTeamCancellationFeedback?: Maybe<Scalars['Void']>;
+  submitTeamCancellationFeedback: Maybe<Scalars['Void']>;
   /** Apollo admins only: terminate any ongoing subscriptions in the account, without refunds */
-  terminateSubscriptions?: Maybe<Account>;
+  terminateSubscriptions: Maybe<Account>;
   /** Update the billing address for a Recurly token */
-  updateBillingAddress?: Maybe<Account>;
+  updateBillingAddress: Maybe<Account>;
   /** Update the billing information from a Recurly token */
-  updateBillingInfo?: Maybe<Scalars['Void']>;
-  updateCompanyUrl?: Maybe<Account>;
+  updateBillingInfo: Maybe<Scalars['Void']>;
+  updateCompanyUrl: Maybe<Account>;
   /** Set the E-mail address of the account, used notably for billing */
-  updateEmail?: Maybe<Scalars['Void']>;
+  updateEmail: Maybe<Scalars['Void']>;
   /** Update the account ID */
-  updateID?: Maybe<Account>;
+  updateID: Maybe<Account>;
   /** Update the company name */
-  updateName?: Maybe<Scalars['Void']>;
+  updateName: Maybe<Scalars['Void']>;
   /** Apollo admins only: enable or disable an account for PingOne SSO login */
-  updatePingOneSSOIDPID?: Maybe<Account>;
+  updatePingOneSSOIDPID: Maybe<Account>;
   /** Updates the role assigned to new SSO users. */
-  updateSSODefaultRole?: Maybe<OrganizationSso>;
+  updateSSODefaultRole: Maybe<OrganizationSso>;
   /** A (currently) internal to Apollo mutation to update a user's role within an organization */
-  updateUserPermission?: Maybe<User>;
+  updateUserPermission: Maybe<User>;
 };
 
 
@@ -5851,12 +5851,12 @@ export type AccountMutationExtendTrialArgs = {
 
 export type AccountMutationInviteArgs = {
   email: Scalars['String'];
-  role?: Maybe<UserPermission>;
+  role: Maybe<UserPermission>;
 };
 
 
 export type AccountMutationRemoveInvitationArgs = {
-  id?: Maybe<Scalars['ID']>;
+  id: Maybe<Scalars['ID']>;
 };
 
 
@@ -5866,15 +5866,15 @@ export type AccountMutationRemoveMemberArgs = {
 
 
 export type AccountMutationRequestAuditExportArgs = {
-  actors?: Maybe<Array<ActorInput>>;
+  actors: Maybe<Array<ActorInput>>;
   from: Scalars['Timestamp'];
-  graphIds?: Maybe<Array<Scalars['String']>>;
+  graphIds: Maybe<Array<Scalars['String']>>;
   to: Scalars['Timestamp'];
 };
 
 
 export type AccountMutationResendInvitationArgs = {
-  id?: Maybe<Scalars['ID']>;
+  id: Maybe<Scalars['ID']>;
 };
 
 
@@ -5909,7 +5909,7 @@ export type AccountMutationUpdateBillingInfoArgs = {
 
 
 export type AccountMutationUpdateCompanyUrlArgs = {
-  companyUrl?: Maybe<Scalars['String']>;
+  companyUrl: Maybe<Scalars['String']>;
 };
 
 
@@ -5929,7 +5929,7 @@ export type AccountMutationUpdateNameArgs = {
 
 
 export type AccountMutationUpdatePingOneSsoidpidArgs = {
-  idpid?: Maybe<Scalars['String']>;
+  idpid: Maybe<Scalars['String']>;
 };
 
 
@@ -5945,8 +5945,8 @@ export type AccountMutationUpdateUserPermissionArgs = {
 
 export type AuditLogExportMutation = {
   __typename?: 'AuditLogExportMutation';
-  cancel?: Maybe<Account>;
-  delete?: Maybe<Account>;
+  cancel: Maybe<Account>;
+  delete: Maybe<Account>;
 };
 
 export type AvatarDeleteError = {
@@ -5968,7 +5968,7 @@ export type ActorInput = {
 /** Billing address inpnut */
 export type BillingAddressInput = {
   address1: Scalars['String'];
-  address2?: Maybe<Scalars['String']>;
+  address2: Maybe<Scalars['String']>;
   city: Scalars['String'];
   country: Scalars['String'];
   state: Scalars['String'];
@@ -5996,13 +5996,13 @@ export type ServiceMutation = {
    */
   checkSchema: CheckSchemaResult;
   /** Make changes to a check workflow. */
-  checkWorkflow?: Maybe<CheckWorkflowMutation>;
+  checkWorkflow: Maybe<CheckWorkflowMutation>;
   createCompositionStatusSubscription: SchemaPublishSubscription;
   createSchemaPublishSubscription: SchemaPublishSubscription;
   /** Soft delete a graph. Data associated with the graph is not permanently deleted; Apollo support can undo. */
-  delete?: Maybe<Scalars['Void']>;
+  delete: Maybe<Scalars['Void']>;
   /** Delete the service's avatar. Requires Service.roles.canUpdateAvatar to be true. */
-  deleteAvatar?: Maybe<AvatarDeleteError>;
+  deleteAvatar: Maybe<AvatarDeleteError>;
   /** Delete an existing channel */
   deleteChannel: Scalars['Boolean'];
   /** Delete an existing query trigger */
@@ -6017,10 +6017,10 @@ export type ServiceMutation = {
   deleteScheduledSummary: Scalars['Boolean'];
   deleteSchemaTag: DeleteSchemaTagResult;
   /** Given a UTC timestamp, delete all traces associated with this Service, on that corresponding day. If a timestamp to is provided, deletes all days inclusive. */
-  deleteTraces?: Maybe<Scalars['Void']>;
-  disableDatadogForwardingLegacyMetricNames?: Maybe<Service>;
+  deleteTraces: Maybe<Scalars['Void']>;
+  disableDatadogForwardingLegacyMetricNames: Maybe<Service>;
   /** Hard delete a graph and all data associated with it. Its ID cannot be reused. */
-  hardDelete?: Maybe<Scalars['Void']>;
+  hardDelete: Maybe<Scalars['Void']>;
   /** @deprecated Use service.id */
   id: Scalars['ID'];
   /**
@@ -6030,7 +6030,7 @@ export type ServiceMutation = {
    * Returns true if the operation is newly ignored,
    * false if it already was.
    */
-  ignoreOperationsInChecks?: Maybe<IgnoreOperationsInChecksResult>;
+  ignoreOperationsInChecks: Maybe<IgnoreOperationsInChecksResult>;
   /**
    * Mark the changeset that affects an operation in a given check instance as safe.
    * Note that only operations marked as behavior changes are allowed to be marked as safe.
@@ -6038,17 +6038,17 @@ export type ServiceMutation = {
   markChangesForOperationAsSafe: MarkChangesForOperationAsSafeResult;
   newKey: GraphApiKey;
   /** Adds an override to the given users permission for this graph */
-  overrideUserPermission?: Maybe<Service>;
+  overrideUserPermission: Maybe<Service>;
   /** Returns a preview of the Core and API schema contracts derived from a source variant and a set of filter configurations */
   previewContractVariant: ContractVariantPreviewResult;
   /** Promote the schema with the given SHA-256 hash to active for the given variant/tag. */
   promoteSchema: PromoteSchemaResponseOrError;
-  registerOperationsWithResponse?: Maybe<RegisterOperationsMutationResponse>;
+  registerOperationsWithResponse: Maybe<RegisterOperationsMutationResponse>;
   removeImplementingServiceAndTriggerComposition: CompositionAndRemoveResult;
-  removeKey?: Maybe<Scalars['Void']>;
-  renameKey?: Maybe<GraphApiKey>;
+  removeKey: Maybe<Scalars['Void']>;
+  renameKey: Maybe<GraphApiKey>;
   /** @deprecated use Mutation.reportSchema instead */
-  reportServerInfo?: Maybe<ReportServerInfoResult>;
+  reportServerInfo: Maybe<ReportServerInfoResult>;
   service: Service;
   /**
    * Store a given schema document. This schema will be attached to the graph but
@@ -6056,41 +6056,41 @@ export type ServiceMutation = {
    */
   storeSchemaDocument: StoreSchemaResponseOrError;
   /** Test Slack notification channel */
-  testSlackChannel?: Maybe<Scalars['Void']>;
+  testSlackChannel: Maybe<Scalars['Void']>;
   testSubscriptionForChannel: Scalars['String'];
-  transfer?: Maybe<Service>;
-  triggerRepublish?: Maybe<Scalars['Void']>;
-  undelete?: Maybe<Service>;
+  transfer: Maybe<Service>;
+  triggerRepublish: Maybe<Scalars['Void']>;
+  undelete: Maybe<Service>;
   /**
    * Revert the effects of ignoreOperation.
    * Returns true if the operation is no longer ignored,
    * false if it wasn't.
    */
-  unignoreOperationsInChecks?: Maybe<UnignoreOperationsInChecksResult>;
+  unignoreOperationsInChecks: Maybe<UnignoreOperationsInChecksResult>;
   /** Unmark changes for an operation as safe. */
   unmarkChangesForOperationAsSafe: MarkChangesForOperationAsSafeResult;
   /** Update schema check configuration for a graph. */
   updateCheckConfiguration: CheckConfiguration;
-  updateDatadogMetricsConfig?: Maybe<DatadogMetricsConfig>;
-  updateDescription?: Maybe<Service>;
+  updateDatadogMetricsConfig: Maybe<DatadogMetricsConfig>;
+  updateDescription: Maybe<Service>;
   /** Update hiddenFromUninvitedNonAdminAccountMembers */
-  updateHiddenFromUninvitedNonAdminAccountMembers?: Maybe<Service>;
-  updateReadme?: Maybe<Service>;
-  updateTitle?: Maybe<Service>;
-  uploadSchema?: Maybe<UploadSchemaMutationResponse>;
-  upsertChannel?: Maybe<Channel>;
+  updateHiddenFromUninvitedNonAdminAccountMembers: Maybe<Service>;
+  updateReadme: Maybe<Service>;
+  updateTitle: Maybe<Service>;
+  uploadSchema: Maybe<UploadSchemaMutationResponse>;
+  upsertChannel: Maybe<Channel>;
   /** Creates a contract schema from a source variant and a set of filter configurations */
   upsertContractVariant: ContractVariantUpsertResult;
-  upsertImplementingServiceAndTriggerComposition?: Maybe<CompositionAndUpsertResult>;
+  upsertImplementingServiceAndTriggerComposition: Maybe<CompositionAndUpsertResult>;
   /** Create/update PagerDuty notification channel */
-  upsertPagerDutyChannel?: Maybe<PagerDutyChannel>;
-  upsertQueryTrigger?: Maybe<QueryTrigger>;
+  upsertPagerDutyChannel: Maybe<PagerDutyChannel>;
+  upsertQueryTrigger: Maybe<QueryTrigger>;
   /** Create or update a subscription for a service. */
   upsertRegistrySubscription: RegistrySubscription;
-  upsertScheduledSummary?: Maybe<ScheduledSummary>;
+  upsertScheduledSummary: Maybe<ScheduledSummary>;
   /** Create/update Slack notification channel */
-  upsertSlackChannel?: Maybe<SlackChannel>;
-  upsertWebhookChannel?: Maybe<WebhookChannel>;
+  upsertSlackChannel: Maybe<SlackChannel>;
+  upsertWebhookChannel: Maybe<WebhookChannel>;
   validateOperations: ValidateOperationsResult;
   /**
    * This mutation will not result in any changes to the implementing service
@@ -6101,30 +6101,30 @@ export type ServiceMutation = {
    */
   validatePartialSchemaOfImplementingServiceAgainstGraph: CompositionValidationResult;
   /** Make changes to a graph variant. */
-  variant?: Maybe<GraphVariantMutation>;
+  variant: Maybe<GraphVariantMutation>;
 };
 
 
 export type ServiceMutationCheckPartialSchemaArgs = {
-  frontend?: Maybe<Scalars['String']>;
-  gitContext?: Maybe<GitContextInput>;
+  frontend: Maybe<Scalars['String']>;
+  gitContext: Maybe<GitContextInput>;
   graphVariant: Scalars['String'];
-  historicParameters?: Maybe<HistoricQueryParameters>;
+  historicParameters: Maybe<HistoricQueryParameters>;
   implementingServiceName: Scalars['String'];
   partialSchema: PartialSchemaInput;
-  useMaximumRetention?: Maybe<Scalars['Boolean']>;
+  useMaximumRetention: Maybe<Scalars['Boolean']>;
 };
 
 
 export type ServiceMutationCheckSchemaArgs = {
   baseSchemaTag?: Maybe<Scalars['String']>;
-  frontend?: Maybe<Scalars['String']>;
-  gitContext?: Maybe<GitContextInput>;
-  historicParameters?: Maybe<HistoricQueryParameters>;
-  proposedSchema?: Maybe<IntrospectionSchemaInput>;
-  proposedSchemaDocument?: Maybe<Scalars['String']>;
-  proposedSchemaHash?: Maybe<Scalars['String']>;
-  useMaximumRetention?: Maybe<Scalars['Boolean']>;
+  frontend: Maybe<Scalars['String']>;
+  gitContext: Maybe<GitContextInput>;
+  historicParameters: Maybe<HistoricQueryParameters>;
+  proposedSchema: Maybe<IntrospectionSchemaInput>;
+  proposedSchemaDocument: Maybe<Scalars['String']>;
+  proposedSchemaHash: Maybe<Scalars['String']>;
+  useMaximumRetention: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -6177,7 +6177,7 @@ export type ServiceMutationDeleteSchemaTagArgs = {
 
 export type ServiceMutationDeleteTracesArgs = {
   from: Scalars['Timestamp'];
-  to?: Maybe<Scalars['Timestamp']>;
+  to: Maybe<Scalars['Timestamp']>;
 };
 
 
@@ -6193,13 +6193,13 @@ export type ServiceMutationMarkChangesForOperationAsSafeArgs = {
 
 
 export type ServiceMutationNewKeyArgs = {
-  keyName?: Maybe<Scalars['String']>;
+  keyName: Maybe<Scalars['String']>;
   role?: UserPermission;
 };
 
 
 export type ServiceMutationOverrideUserPermissionArgs = {
-  permission?: Maybe<UserPermission>;
+  permission: Maybe<UserPermission>;
   userID: Scalars['ID'];
 };
 
@@ -6212,17 +6212,17 @@ export type ServiceMutationPreviewContractVariantArgs = {
 
 export type ServiceMutationPromoteSchemaArgs = {
   graphVariant: Scalars['String'];
-  historicParameters?: Maybe<HistoricQueryParameters>;
+  historicParameters: Maybe<HistoricQueryParameters>;
   overrideComposedSchema?: Scalars['Boolean'];
   sha256: Scalars['SHA256'];
 };
 
 
 export type ServiceMutationRegisterOperationsWithResponseArgs = {
-  clientIdentity?: Maybe<RegisteredClientIdentityInput>;
-  gitContext?: Maybe<GitContextInput>;
+  clientIdentity: Maybe<RegisteredClientIdentityInput>;
+  gitContext: Maybe<GitContextInput>;
   graphVariant?: Scalars['String'];
-  manifestVersion?: Maybe<Scalars['Int']>;
+  manifestVersion: Maybe<Scalars['Int']>;
   operations: Array<RegisteredOperationInput>;
 };
 
@@ -6235,18 +6235,18 @@ export type ServiceMutationRemoveImplementingServiceAndTriggerCompositionArgs = 
 
 
 export type ServiceMutationRemoveKeyArgs = {
-  id?: Maybe<Scalars['ID']>;
+  id: Maybe<Scalars['ID']>;
 };
 
 
 export type ServiceMutationRenameKeyArgs = {
   id: Scalars['ID'];
-  newKeyName?: Maybe<Scalars['String']>;
+  newKeyName: Maybe<Scalars['String']>;
 };
 
 
 export type ServiceMutationReportServerInfoArgs = {
-  executableSchema?: Maybe<Scalars['String']>;
+  executableSchema: Maybe<Scalars['String']>;
   info: EdgeServerInfo;
 };
 
@@ -6290,20 +6290,20 @@ export type ServiceMutationUnmarkChangesForOperationAsSafeArgs = {
 
 
 export type ServiceMutationUpdateCheckConfigurationArgs = {
-  excludedClients?: Maybe<Array<ClientFilterInput>>;
-  excludedOperations?: Maybe<Array<ExcludedOperationInput>>;
-  includeBaseVariant?: Maybe<Scalars['Boolean']>;
-  includedVariants?: Maybe<Array<Scalars['String']>>;
-  operationCountThreshold?: Maybe<Scalars['Int']>;
-  operationCountThresholdPercentage?: Maybe<Scalars['Float']>;
-  timeRangeSeconds?: Maybe<Scalars['Long']>;
+  excludedClients: Maybe<Array<ClientFilterInput>>;
+  excludedOperations: Maybe<Array<ExcludedOperationInput>>;
+  includeBaseVariant: Maybe<Scalars['Boolean']>;
+  includedVariants: Maybe<Array<Scalars['String']>>;
+  operationCountThreshold: Maybe<Scalars['Int']>;
+  operationCountThresholdPercentage: Maybe<Scalars['Float']>;
+  timeRangeSeconds: Maybe<Scalars['Long']>;
 };
 
 
 export type ServiceMutationUpdateDatadogMetricsConfigArgs = {
-  apiKey?: Maybe<Scalars['String']>;
-  apiRegion?: Maybe<DatadogApiRegion>;
-  enabled?: Maybe<Scalars['Boolean']>;
+  apiKey: Maybe<Scalars['String']>;
+  apiRegion: Maybe<DatadogApiRegion>;
+  enabled: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -6329,20 +6329,20 @@ export type ServiceMutationUpdateTitleArgs = {
 
 export type ServiceMutationUploadSchemaArgs = {
   errorOnBadRequest?: Scalars['Boolean'];
-  gitContext?: Maybe<GitContextInput>;
-  historicParameters?: Maybe<HistoricQueryParameters>;
+  gitContext: Maybe<GitContextInput>;
+  historicParameters: Maybe<HistoricQueryParameters>;
   overrideComposedSchema?: Scalars['Boolean'];
-  schema?: Maybe<IntrospectionSchemaInput>;
-  schemaDocument?: Maybe<Scalars['String']>;
+  schema: Maybe<IntrospectionSchemaInput>;
+  schemaDocument: Maybe<Scalars['String']>;
   tag: Scalars['String'];
 };
 
 
 export type ServiceMutationUpsertChannelArgs = {
-  id?: Maybe<Scalars['ID']>;
-  pagerDutyChannel?: Maybe<PagerDutyChannelInput>;
-  slackChannel?: Maybe<SlackChannelInput>;
-  webhookChannel?: Maybe<WebhookChannelInput>;
+  id: Maybe<Scalars['ID']>;
+  pagerDutyChannel: Maybe<PagerDutyChannelInput>;
+  slackChannel: Maybe<SlackChannelInput>;
+  webhookChannel: Maybe<WebhookChannelInput>;
 };
 
 
@@ -6355,60 +6355,60 @@ export type ServiceMutationUpsertContractVariantArgs = {
 
 export type ServiceMutationUpsertImplementingServiceAndTriggerCompositionArgs = {
   activePartialSchema: PartialSchemaInput;
-  gitContext?: Maybe<GitContextInput>;
+  gitContext: Maybe<GitContextInput>;
   graphVariant: Scalars['String'];
   name: Scalars['String'];
   revision: Scalars['String'];
-  url?: Maybe<Scalars['String']>;
+  url: Maybe<Scalars['String']>;
 };
 
 
 export type ServiceMutationUpsertPagerDutyChannelArgs = {
   channel: PagerDutyChannelInput;
-  id?: Maybe<Scalars['ID']>;
+  id: Maybe<Scalars['ID']>;
 };
 
 
 export type ServiceMutationUpsertQueryTriggerArgs = {
-  id?: Maybe<Scalars['ID']>;
+  id: Maybe<Scalars['ID']>;
   trigger: QueryTriggerInput;
 };
 
 
 export type ServiceMutationUpsertRegistrySubscriptionArgs = {
-  channelID?: Maybe<Scalars['ID']>;
-  id?: Maybe<Scalars['ID']>;
-  options?: Maybe<SubscriptionOptionsInput>;
-  variant?: Maybe<Scalars['String']>;
+  channelID: Maybe<Scalars['ID']>;
+  id: Maybe<Scalars['ID']>;
+  options: Maybe<SubscriptionOptionsInput>;
+  variant: Maybe<Scalars['String']>;
 };
 
 
 export type ServiceMutationUpsertScheduledSummaryArgs = {
-  channelID?: Maybe<Scalars['ID']>;
-  enabled?: Maybe<Scalars['Boolean']>;
-  id?: Maybe<Scalars['ID']>;
-  tag?: Maybe<Scalars['String']>;
-  timezone?: Maybe<Scalars['String']>;
-  variant?: Maybe<Scalars['String']>;
+  channelID: Maybe<Scalars['ID']>;
+  enabled: Maybe<Scalars['Boolean']>;
+  id: Maybe<Scalars['ID']>;
+  tag: Maybe<Scalars['String']>;
+  timezone: Maybe<Scalars['String']>;
+  variant: Maybe<Scalars['String']>;
 };
 
 
 export type ServiceMutationUpsertSlackChannelArgs = {
   channel: SlackChannelInput;
-  id?: Maybe<Scalars['ID']>;
+  id: Maybe<Scalars['ID']>;
 };
 
 
 export type ServiceMutationUpsertWebhookChannelArgs = {
-  id?: Maybe<Scalars['ID']>;
-  name?: Maybe<Scalars['String']>;
-  secretToken?: Maybe<Scalars['String']>;
+  id: Maybe<Scalars['ID']>;
+  name: Maybe<Scalars['String']>;
+  secretToken: Maybe<Scalars['String']>;
   url: Scalars['String'];
 };
 
 
 export type ServiceMutationValidateOperationsArgs = {
-  gitContext?: Maybe<GitContextInput>;
+  gitContext: Maybe<GitContextInput>;
   operations: Array<OperationDocumentInput>;
   tag?: Maybe<Scalars['String']>;
 };
@@ -6427,19 +6427,19 @@ export type ServiceMutationVariantArgs = {
 
 /** This is stored with a schema when it is uploaded */
 export type GitContextInput = {
-  branch?: Maybe<Scalars['String']>;
-  commit?: Maybe<Scalars['ID']>;
-  committer?: Maybe<Scalars['String']>;
-  message?: Maybe<Scalars['String']>;
-  remoteUrl?: Maybe<Scalars['String']>;
+  branch: Maybe<Scalars['String']>;
+  commit: Maybe<Scalars['ID']>;
+  committer: Maybe<Scalars['String']>;
+  message: Maybe<Scalars['String']>;
+  remoteUrl: Maybe<Scalars['String']>;
 };
 
 export type HistoricQueryParameters = {
   /** A list of clients to filter out during validation. */
-  excludedClients?: Maybe<Array<ClientInfoFilter>>;
-  from?: Maybe<Scalars['Timestamp']>;
+  excludedClients: Maybe<Array<ClientInfoFilter>>;
+  from: Maybe<Scalars['Timestamp']>;
   /** A list of operation IDs to filter out during validation. */
-  ignoredOperations?: Maybe<Array<Scalars['ID']>>;
+  ignoredOperations: Maybe<Array<Scalars['ID']>>;
   /**
    * A list of variants to include in the validation. If no variants are provided
    * then this defaults to the "current" variant along with the base variant. The
@@ -6448,23 +6448,23 @@ export type HistoricQueryParameters = {
    * same as null inside of `in`, and 'current') in this metrics fetch. This strategy
    * supports users who have not tagged their metrics or schema.
    */
-  includedVariants?: Maybe<Array<Scalars['String']>>;
+  includedVariants: Maybe<Array<Scalars['String']>>;
   /** Minimum number of requests within the window for a query to be considered. */
-  queryCountThreshold?: Maybe<Scalars['Int']>;
+  queryCountThreshold: Maybe<Scalars['Int']>;
   /**
    * Number of requests within the window for a query to be considered, relative to
    * total request count. Expected values are between 0 and 0.05 (minimum 5% of total
    * request volume)
    */
-  queryCountThresholdPercentage?: Maybe<Scalars['Float']>;
-  to?: Maybe<Scalars['Timestamp']>;
+  queryCountThresholdPercentage: Maybe<Scalars['Float']>;
+  to: Maybe<Scalars['Timestamp']>;
 };
 
 /** Filter options to exclude by client reference ID, client name, and client version. */
 export type ClientInfoFilter = {
-  name?: Maybe<Scalars['String']>;
-  referenceID?: Maybe<Scalars['ID']>;
-  version?: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
+  referenceID: Maybe<Scalars['ID']>;
+  version: Maybe<Scalars['String']>;
 };
 
 /**
@@ -6483,22 +6483,22 @@ export type PartialSchemaInput = {
    * Hash of the partial schema to associate; error is thrown if only the hash is
    * specified and the hash has not been seen before
    */
-  hash?: Maybe<Scalars['String']>;
+  hash: Maybe<Scalars['String']>;
   /**
    * Contents of the partial schema in SDL syntax, but may reference types
    * that aren't defined in this document
    */
-  sdl?: Maybe<Scalars['String']>;
+  sdl: Maybe<Scalars['String']>;
 };
 
 export type CheckPartialSchemaResult = {
   __typename?: 'CheckPartialSchemaResult';
   /** Result of traffic validation. This will be null if composition validation was unsuccessful. */
-  checkSchemaResult?: Maybe<CheckSchemaResult>;
+  checkSchemaResult: Maybe<CheckSchemaResult>;
   /** Result of composition validation run before the schema check. */
   compositionValidationResult: CompositionValidationResult;
   /** Workflow associated with the composition validation. */
-  workflow?: Maybe<CheckWorkflow>;
+  workflow: Maybe<CheckWorkflow>;
 };
 
 export type CheckSchemaResult = {
@@ -6508,9 +6508,9 @@ export type CheckSchemaResult = {
   /** ID of the operations check that was created */
   operationsCheckID: Scalars['ID'];
   /** Generated url to view schema diff in Engine */
-  targetUrl?: Maybe<Scalars['String']>;
+  targetUrl: Maybe<Scalars['String']>;
   /** Workflow associated with this check result */
-  workflow?: Maybe<CheckWorkflow>;
+  workflow: Maybe<CheckWorkflow>;
 };
 
 /** Metadata about the result of compositions validation run in the cloud */
@@ -6523,12 +6523,12 @@ export type CompositionValidationResult = CompositionResult & {
    * in running composition. Will be null if any errors are encountered. Also may contain a schema hash if
    * one could be computed, which can be used for schema validation.
    */
-  compositionValidationDetails?: Maybe<CompositionValidationDetails>;
+  compositionValidationDetails: Maybe<CompositionValidationDetails>;
   /**
    * Supergraph SDL generated by composition (this is not the CSDL, that is a deprecated format).
    * @deprecated Use supergraphSdl instead
    */
-  csdl?: Maybe<Scalars['GraphQLDocument']>;
+  csdl: Maybe<Scalars['GraphQLDocument']>;
   /**
    * List of errors during composition. Errors mean that Apollo was unable to compose the
    * graph's implementing services into a GraphQL schema. This partial schema should not be
@@ -6542,9 +6542,9 @@ export type CompositionValidationResult = CompositionResult & {
   /** List of subgraphs that are included in this composition. */
   subgraphConfigs: Array<SubgraphConfig>;
   /** Supergraph SDL generated by composition. */
-  supergraphSdl?: Maybe<Scalars['GraphQLDocument']>;
+  supergraphSdl: Maybe<Scalars['GraphQLDocument']>;
   /** If created as part of a check workflow, the associated workflow task. */
-  workflowTask?: Maybe<CompositionCheckTask>;
+  workflowTask: Maybe<CompositionCheckTask>;
 };
 
 /** The composition config exposed to the gateway */
@@ -6553,7 +6553,7 @@ export type CompositionValidationDetails = {
   /** List of implementing service partial schemas that comprised the graph composed during validation */
   implementingServices: Array<FederatedImplementingServicePartialSchema>;
   /** Hash of the composed schema */
-  schemaHash?: Maybe<Scalars['String']>;
+  schemaHash: Maybe<Scalars['String']>;
 };
 
 /** A minimal representation of a federated implementing service, using only a name and partial schema SDL */
@@ -6567,61 +6567,61 @@ export type FederatedImplementingServicePartialSchema = {
 
 export type CompositionCheckTask = CheckWorkflowTask & {
   __typename?: 'CompositionCheckTask';
-  completedAt?: Maybe<Scalars['Timestamp']>;
+  completedAt: Maybe<Scalars['Timestamp']>;
   createdAt: Scalars['Timestamp'];
   id: Scalars['ID'];
   /** The result of the composition. */
-  result?: Maybe<CompositionResult>;
+  result: Maybe<CompositionResult>;
   status: CheckWorkflowTaskStatus;
   workflow: CheckWorkflow;
 };
 
 /** __Schema introspection type */
 export type IntrospectionSchemaInput = {
-  description?: Maybe<Scalars['String']>;
+  description: Maybe<Scalars['String']>;
   directives: Array<IntrospectionDirectiveInput>;
-  mutationType?: Maybe<IntrospectionTypeRefInput>;
+  mutationType: Maybe<IntrospectionTypeRefInput>;
   queryType: IntrospectionTypeRefInput;
-  subscriptionType?: Maybe<IntrospectionTypeRefInput>;
-  types?: Maybe<Array<IntrospectionTypeInput>>;
+  subscriptionType: Maybe<IntrospectionTypeRefInput>;
+  types: Maybe<Array<IntrospectionTypeInput>>;
 };
 
 export type IntrospectionDirectiveInput = {
   args: Array<IntrospectionInputValueInput>;
-  description?: Maybe<Scalars['String']>;
-  isRepeatable?: Maybe<Scalars['Boolean']>;
+  description: Maybe<Scalars['String']>;
+  isRepeatable: Maybe<Scalars['Boolean']>;
   locations: Array<IntrospectionDirectiveLocation>;
   name: Scalars['String'];
 };
 
 /** __Value introspection type */
 export type IntrospectionInputValueInput = {
-  defaultValue?: Maybe<Scalars['String']>;
-  deprecationReason?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  isDeprecated?: Maybe<Scalars['Boolean']>;
+  defaultValue: Maybe<Scalars['String']>;
+  deprecationReason: Maybe<Scalars['String']>;
+  description: Maybe<Scalars['String']>;
+  isDeprecated: Maybe<Scalars['Boolean']>;
   name: Scalars['String'];
   type: IntrospectionTypeInput;
 };
 
 /** __Type introspection type */
 export type IntrospectionTypeInput = {
-  description?: Maybe<Scalars['String']>;
-  enumValues?: Maybe<Array<IntrospectionEnumValueInput>>;
-  fields?: Maybe<Array<IntrospectionFieldInput>>;
-  inputFields?: Maybe<Array<IntrospectionInputValueInput>>;
-  interfaces?: Maybe<Array<IntrospectionTypeInput>>;
+  description: Maybe<Scalars['String']>;
+  enumValues: Maybe<Array<IntrospectionEnumValueInput>>;
+  fields: Maybe<Array<IntrospectionFieldInput>>;
+  inputFields: Maybe<Array<IntrospectionInputValueInput>>;
+  interfaces: Maybe<Array<IntrospectionTypeInput>>;
   kind: IntrospectionTypeKind;
-  name?: Maybe<Scalars['String']>;
-  ofType?: Maybe<IntrospectionTypeInput>;
-  possibleTypes?: Maybe<Array<IntrospectionTypeInput>>;
-  specifiedByUrl?: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
+  ofType: Maybe<IntrospectionTypeInput>;
+  possibleTypes: Maybe<Array<IntrospectionTypeInput>>;
+  specifiedByUrl: Maybe<Scalars['String']>;
 };
 
 /** __EnumValue introspection type */
 export type IntrospectionEnumValueInput = {
-  deprecationReason?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
+  deprecationReason: Maybe<Scalars['String']>;
+  description: Maybe<Scalars['String']>;
   isDeprecated: Scalars['Boolean'];
   name: Scalars['String'];
 };
@@ -6629,8 +6629,8 @@ export type IntrospectionEnumValueInput = {
 /** __Field introspection type */
 export type IntrospectionFieldInput = {
   args: Array<IntrospectionInputValueInput>;
-  deprecationReason?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
+  deprecationReason: Maybe<Scalars['String']>;
+  description: Maybe<Scalars['String']>;
   isDeprecated: Scalars['Boolean'];
   name: Scalars['String'];
   type: IntrospectionTypeInput;
@@ -6638,22 +6638,22 @@ export type IntrospectionFieldInput = {
 
 /** Shallow __Type introspection type */
 export type IntrospectionTypeRefInput = {
-  kind?: Maybe<Scalars['String']>;
+  kind: Maybe<Scalars['String']>;
   name: Scalars['String'];
 };
 
 export type CheckWorkflowMutation = {
   __typename?: 'CheckWorkflowMutation';
   /** Re-run a check workflow using the current configuration. A new workflow is created and returned. */
-  rerun?: Maybe<CheckWorkflowRerunResult>;
+  rerun: Maybe<CheckWorkflowRerunResult>;
 };
 
 export type CheckWorkflowRerunResult = {
   __typename?: 'CheckWorkflowRerunResult';
   /** Check workflow created by re-running. */
-  result?: Maybe<CheckWorkflow>;
+  result: Maybe<CheckWorkflow>;
   /** Check workflow that was rerun. */
-  source?: Maybe<CheckWorkflow>;
+  source: Maybe<CheckWorkflow>;
 };
 
 export type SchemaPublishSubscription = ChannelSubscription & {
@@ -6663,7 +6663,7 @@ export type SchemaPublishSubscription = ChannelSubscription & {
   enabled: Scalars['Boolean'];
   id: Scalars['ID'];
   lastUpdatedAt: Scalars['Timestamp'];
-  variant?: Maybe<Scalars['String']>;
+  variant: Maybe<Scalars['String']>;
 };
 
 export type DeleteSchemaTagResult = {
@@ -6684,7 +6684,7 @@ export type MarkChangesForOperationAsSafeResult = {
    * This might return null if no behavior changes were found for the affected operation ID.
    * This is a weird situation that should never happen.
    */
-  affectedOperation?: Maybe<AffectedQuery>;
+  affectedOperation: Maybe<AffectedQuery>;
   message: Scalars['String'];
   success: Scalars['Boolean'];
 };
@@ -6751,30 +6751,30 @@ export enum PromoteSchemaResponseCode {
 export type RegisteredClientIdentityInput = {
   identifier: Scalars['String'];
   name: Scalars['String'];
-  version?: Maybe<Scalars['String']>;
+  version: Maybe<Scalars['String']>;
 };
 
 export type RegisteredOperationInput = {
-  document?: Maybe<Scalars['String']>;
-  metadata?: Maybe<RegisteredOperationMetadataInput>;
+  document: Maybe<Scalars['String']>;
+  metadata: Maybe<RegisteredOperationMetadataInput>;
   signature: Scalars['ID'];
 };
 
 export type RegisteredOperationMetadataInput = {
   /** This will be used to link existing records in Engine to a new ID. */
-  engineSignature?: Maybe<Scalars['String']>;
+  engineSignature: Maybe<Scalars['String']>;
 };
 
 export type RegisterOperationsMutationResponse = {
   __typename?: 'RegisterOperationsMutationResponse';
-  invalidOperations?: Maybe<Array<InvalidOperation>>;
-  newOperations?: Maybe<Array<RegisteredOperation>>;
+  invalidOperations: Maybe<Array<InvalidOperation>>;
+  newOperations: Maybe<Array<RegisteredOperation>>;
   registrationSuccess: Scalars['Boolean'];
 };
 
 export type InvalidOperation = {
   __typename?: 'InvalidOperation';
-  errors?: Maybe<Array<OperationValidationError>>;
+  errors: Maybe<Array<OperationValidationError>>;
   signature: Scalars['ID'];
 };
 
@@ -6792,7 +6792,7 @@ export type RegisteredOperation = {
 export type CompositionAndRemoveResult = {
   __typename?: 'CompositionAndRemoveResult';
   /** The produced composition config. Will be null if there are any errors */
-  compositionConfig?: Maybe<CompositionConfig>;
+  compositionConfig: Maybe<CompositionConfig>;
   /** Whether the removed implementing service existed. */
   didExist: Scalars['Boolean'];
   /**
@@ -6815,17 +6815,17 @@ export type EdgeServerInfo = {
   /** A unique identifier for the executable GraphQL served by the edge server. length must be <= 64 characters. */
   executableSchemaId: Scalars['String'];
   /** The graph variant, defaults to 'current' */
-  graphVariant?: Scalars['String'];
+  graphVariant: Scalars['String'];
   /** The version of the edge server reporting agent, e.g. apollo-server-2.8, graphql-java-3.1, etc. length must be <= 256 characters. */
-  libraryVersion?: Maybe<Scalars['String']>;
+  libraryVersion: Maybe<Scalars['String']>;
   /** The infra environment in which this edge server is running, e.g. localhost, Kubernetes, AWS Lambda, Google CloudRun, AWS ECS, etc. length must be <= 256 characters. */
-  platform?: Maybe<Scalars['String']>;
+  platform: Maybe<Scalars['String']>;
   /** The runtime in which the edge server is running, e.g. node 12.03, zulu8.46.0.19-ca-jdk8.0.252-macosx_x64, etc. length must be <= 256 characters. */
-  runtimeVersion?: Maybe<Scalars['String']>;
+  runtimeVersion: Maybe<Scalars['String']>;
   /** If available, an identifier for the edge server instance, such that when restarting this instance it will have the same serverId, with a different bootId. For example, in Kubernetes this might be the pod name. Length must be <= 256 characters. */
-  serverId?: Maybe<Scalars['String']>;
+  serverId: Maybe<Scalars['String']>;
   /** An identifier used to distinguish the version (from the user's perspective) of the edge server's code itself. For instance, the git sha of the server's repository or the docker sha of the associated image this server runs with. Length must be <= 256 characters. */
-  userVersion?: Maybe<Scalars['String']>;
+  userVersion: Maybe<Scalars['String']>;
 };
 
 export type ReportServerInfoResult = {
@@ -6853,15 +6853,15 @@ export type StoreSchemaResponse = {
 
 /** Slack notification message */
 export type SlackNotificationInput = {
-  color?: Maybe<Scalars['String']>;
+  color: Maybe<Scalars['String']>;
   fallback: Scalars['String'];
-  fields?: Maybe<Array<SlackNotificationField>>;
-  iconUrl?: Maybe<Scalars['String']>;
-  text?: Maybe<Scalars['String']>;
-  timestamp?: Maybe<Scalars['Timestamp']>;
-  title?: Maybe<Scalars['String']>;
-  titleLink?: Maybe<Scalars['String']>;
-  username?: Maybe<Scalars['String']>;
+  fields: Maybe<Array<SlackNotificationField>>;
+  iconUrl: Maybe<Scalars['String']>;
+  text: Maybe<Scalars['String']>;
+  timestamp: Maybe<Scalars['Timestamp']>;
+  title: Maybe<Scalars['String']>;
+  titleLink: Maybe<Scalars['String']>;
+  username: Maybe<Scalars['String']>;
 };
 
 export type SlackNotificationField = {
@@ -6880,11 +6880,11 @@ export type UnignoreOperationsInChecksResult = {
  */
 export type ClientFilterInput = {
   /** name of the client set by the user and reported alongside metrics */
-  name?: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
   /** ID, often the name, of the client set by the user and reported alongside metrics */
-  referenceID?: Maybe<Scalars['ID']>;
+  referenceID: Maybe<Scalars['ID']>;
   /** version of the client set by the user and reported alongside metrics */
-  version?: Maybe<Scalars['String']>;
+  version: Maybe<Scalars['String']>;
 };
 
 /** Option to filter by operation ID. */
@@ -6898,25 +6898,25 @@ export type UploadSchemaMutationResponse = {
   code: Scalars['String'];
   message: Scalars['String'];
   success: Scalars['Boolean'];
-  tag?: Maybe<SchemaTag>;
+  tag: Maybe<SchemaTag>;
 };
 
 /** PagerDuty notification channel parameters */
 export type PagerDutyChannelInput = {
-  name?: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
   routingKey: Scalars['String'];
 };
 
 /** Slack notification channel parameters */
 export type SlackChannelInput = {
-  name?: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
   url: Scalars['String'];
 };
 
 /** PagerDuty notification channel parameters */
 export type WebhookChannelInput = {
-  name?: Maybe<Scalars['String']>;
-  secretToken?: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
+  secretToken: Maybe<Scalars['String']>;
   url: Scalars['String'];
 };
 
@@ -6936,7 +6936,7 @@ export type ContractVariantUpsertSuccess = {
 export type CompositionAndUpsertResult = {
   __typename?: 'CompositionAndUpsertResult';
   /** The produced composition config. Will be null if there are any errors */
-  compositionConfig?: Maybe<CompositionConfig>;
+  compositionConfig: Maybe<CompositionConfig>;
   /**
    * List of errors during composition. Errors mean that Apollo was unable to compose the
    * graph's implementing services into a GraphQL schema. This partial schema should not be
@@ -6966,16 +6966,16 @@ export type PagerDutyChannel = Channel & {
 
 /** Query trigger */
 export type QueryTriggerInput = {
-  channelIds?: Maybe<Array<Scalars['String']>>;
+  channelIds: Maybe<Array<Scalars['String']>>;
   comparisonOperator: ComparisonOperator;
-  enabled?: Maybe<Scalars['Boolean']>;
-  excludedOperationNames?: Maybe<Array<Scalars['String']>>;
+  enabled: Maybe<Scalars['Boolean']>;
+  excludedOperationNames: Maybe<Array<Scalars['String']>>;
   metric: QueryTriggerMetric;
-  operationNames?: Maybe<Array<Scalars['String']>>;
-  percentile?: Maybe<Scalars['Float']>;
-  scope?: Maybe<QueryTriggerScope>;
+  operationNames: Maybe<Array<Scalars['String']>>;
+  percentile: Maybe<Scalars['Float']>;
+  scope: Maybe<QueryTriggerScope>;
   threshold: Scalars['Float'];
-  variant?: Maybe<Scalars['String']>;
+  variant: Maybe<Scalars['String']>;
   window: QueryTriggerWindow;
 };
 
@@ -6986,7 +6986,7 @@ export type SubscriptionOptionsInput = {
 
 export type RegistrySubscription = ChannelSubscription & {
   __typename?: 'RegistrySubscription';
-  channel?: Maybe<Channel>;
+  channel: Maybe<Channel>;
   /** @deprecated Use channels list instead */
   channels: Array<Channel>;
   createdAt: Scalars['Timestamp'];
@@ -6994,7 +6994,7 @@ export type RegistrySubscription = ChannelSubscription & {
   id: Scalars['ID'];
   lastUpdatedAt: Scalars['Timestamp'];
   options: SubscriptionOptions;
-  variant?: Maybe<Scalars['String']>;
+  variant: Maybe<Scalars['String']>;
 };
 
 export type SubscriptionOptions = {
@@ -7017,7 +7017,7 @@ export type WebhookChannel = Channel & {
   __typename?: 'WebhookChannel';
   id: Scalars['ID'];
   name: Scalars['String'];
-  secretToken?: Maybe<Scalars['String']>;
+  secretToken: Maybe<Scalars['String']>;
   subscriptions: Array<ChannelSubscription>;
   url: Scalars['String'];
 };
@@ -7026,7 +7026,7 @@ export type OperationDocumentInput = {
   /** Operation document body */
   body: Scalars['String'];
   /** Operation name */
-  name?: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
 };
 
 export type ValidateOperationsResult = {
@@ -7061,7 +7061,7 @@ export type OperationDocument = {
   /** Operation document body */
   body: Scalars['String'];
   /** Operation name */
-  name?: Maybe<Scalars['String']>;
+  name: Maybe<Scalars['String']>;
 };
 
 export enum ValidationErrorType {
@@ -7074,7 +7074,7 @@ export enum ValidationErrorType {
 export type GraphVariantMutation = {
   __typename?: 'GraphVariantMutation';
   addLinkToVariant: GraphVariant;
-  enableTagAndInaccessible?: Maybe<GraphVariant>;
+  enableTagAndInaccessible: Maybe<GraphVariant>;
   /** Graph ID of the variant */
   graphId: Scalars['String'];
   /** Global identifier for the graph variant, in the form `graph@variant`. */
@@ -7084,20 +7084,20 @@ export type GraphVariantMutation = {
   relaunch: RelaunchResult;
   removeLinkFromVariant: GraphVariant;
   setIsFavoriteOfCurrentUser: GraphVariant;
-  updateDefaultHeaders?: Maybe<GraphVariant>;
-  updateIsProtected?: Maybe<GraphVariant>;
-  updatePreflightScript?: Maybe<GraphVariant>;
-  updateSendCookies?: Maybe<GraphVariant>;
-  updateSubscriptionURL?: Maybe<GraphVariant>;
-  updateURL?: Maybe<GraphVariant>;
-  updateVariantIsPublic?: Maybe<GraphVariant>;
-  updateVariantReadme?: Maybe<GraphVariant>;
+  updateDefaultHeaders: Maybe<GraphVariant>;
+  updateIsProtected: Maybe<GraphVariant>;
+  updatePreflightScript: Maybe<GraphVariant>;
+  updateSendCookies: Maybe<GraphVariant>;
+  updateSubscriptionURL: Maybe<GraphVariant>;
+  updateURL: Maybe<GraphVariant>;
+  updateVariantIsPublic: Maybe<GraphVariant>;
+  updateVariantReadme: Maybe<GraphVariant>;
 };
 
 
 /** Modifies a variant of a graph, also called a schema tag in parts of our product. */
 export type GraphVariantMutationAddLinkToVariantArgs = {
-  title?: Maybe<Scalars['String']>;
+  title: Maybe<Scalars['String']>;
   type: LinkInfoType;
   url: Scalars['String'];
 };
@@ -7123,7 +7123,7 @@ export type GraphVariantMutationSetIsFavoriteOfCurrentUserArgs = {
 
 /** Modifies a variant of a graph, also called a schema tag in parts of our product. */
 export type GraphVariantMutationUpdateDefaultHeadersArgs = {
-  defaultHeaders?: Maybe<Scalars['String']>;
+  defaultHeaders: Maybe<Scalars['String']>;
 };
 
 
@@ -7135,7 +7135,7 @@ export type GraphVariantMutationUpdateIsProtectedArgs = {
 
 /** Modifies a variant of a graph, also called a schema tag in parts of our product. */
 export type GraphVariantMutationUpdatePreflightScriptArgs = {
-  preflightScript?: Maybe<Scalars['String']>;
+  preflightScript: Maybe<Scalars['String']>;
 };
 
 
@@ -7147,13 +7147,13 @@ export type GraphVariantMutationUpdateSendCookiesArgs = {
 
 /** Modifies a variant of a graph, also called a schema tag in parts of our product. */
 export type GraphVariantMutationUpdateSubscriptionUrlArgs = {
-  subscriptionUrl?: Maybe<Scalars['String']>;
+  subscriptionUrl: Maybe<Scalars['String']>;
 };
 
 
 /** Modifies a variant of a graph, also called a schema tag in parts of our product. */
 export type GraphVariantMutationUpdateUrlArgs = {
-  url?: Maybe<Scalars['String']>;
+  url: Maybe<Scalars['String']>;
 };
 
 
@@ -7183,48 +7183,48 @@ export type RelaunchError = {
 
 export type UserMutation = {
   __typename?: 'UserMutation';
-  acceptPrivacyPolicy?: Maybe<Scalars['Void']>;
+  acceptPrivacyPolicy: Maybe<Scalars['Void']>;
   /** Change the user's password */
-  changePassword?: Maybe<Scalars['Void']>;
-  createOdysseyCourses?: Maybe<Array<OdysseyCourse>>;
-  createOdysseyTasks?: Maybe<Array<OdysseyTask>>;
+  changePassword: Maybe<Scalars['Void']>;
+  createOdysseyCourses: Maybe<Array<OdysseyCourse>>;
+  createOdysseyTasks: Maybe<Array<OdysseyTask>>;
   /** Delete the user's avatar. Requires User.canUpdateAvatar to be true. */
-  deleteAvatar?: Maybe<AvatarDeleteError>;
+  deleteAvatar: Maybe<AvatarDeleteError>;
   /** Hard deletes the associated user. Throws an error otherwise with reason included. */
-  hardDelete?: Maybe<Scalars['Void']>;
+  hardDelete: Maybe<Scalars['Void']>;
   /** Create a new API key for this user. Must take in a name for this key. */
   newKey: UserApiKey;
   /**
    * Create a new API key for this user if there are no current API keys.
    * If an API key already exists, this will return one at random and not create a new one.
    */
-  provisionKey?: Maybe<ApiKeyProvision>;
+  provisionKey: Maybe<ApiKeyProvision>;
   /** Refresh information about the user from its upstream service (eg list of organizations from GitHub) */
-  refresh?: Maybe<User>;
+  refresh: Maybe<User>;
   /** Removes the given key from this user. Can be used to remove either a web cookie or a user API key. */
-  removeKey?: Maybe<Scalars['Void']>;
+  removeKey: Maybe<Scalars['Void']>;
   /** Renames the given key to the new key name. */
-  renameKey?: Maybe<UserApiKey>;
-  resendVerificationEmail?: Maybe<Scalars['Void']>;
-  setOdysseyCourse?: Maybe<OdysseyCourse>;
-  setOdysseyTask?: Maybe<OdysseyTask>;
+  renameKey: Maybe<UserApiKey>;
+  resendVerificationEmail: Maybe<Scalars['Void']>;
+  setOdysseyCourse: Maybe<OdysseyCourse>;
+  setOdysseyTask: Maybe<OdysseyTask>;
   /** Submit a zendesk ticket for this user */
-  submitZendeskTicket?: Maybe<ZendeskTicket>;
+  submitZendeskTicket: Maybe<ZendeskTicket>;
   /** Update information about a user; all arguments are optional */
-  update?: Maybe<User>;
+  update: Maybe<User>;
   /** Updates this users' preference concerning opting into beta features. */
-  updateBetaFeaturesOn?: Maybe<User>;
+  updateBetaFeaturesOn: Maybe<User>;
   /** Update the status of a feature for this. For example, if you want to hide an introductory popup. */
-  updateFeatureIntros?: Maybe<User>;
+  updateFeatureIntros: Maybe<User>;
   /**
    * Update user to have the given internal mdg admin role.
    * It is necessary to be an MDG_INTERNAL_SUPER_ADMIN to perform update.
    * Additionally, upserting a null value explicitly revokes this user's
    * admin status.
    */
-  updateRole?: Maybe<User>;
+  updateRole: Maybe<User>;
   user: User;
-  verifyEmail?: Maybe<User>;
+  verifyEmail: Maybe<User>;
 };
 
 
@@ -7261,7 +7261,7 @@ export type UserMutationRemoveKeyArgs = {
 
 export type UserMutationRenameKeyArgs = {
   id: Scalars['ID'];
-  newKeyName?: Maybe<Scalars['String']>;
+  newKeyName: Maybe<Scalars['String']>;
 };
 
 
@@ -7276,22 +7276,22 @@ export type UserMutationSetOdysseyTaskArgs = {
 
 
 export type UserMutationSubmitZendeskTicketArgs = {
-  collaborators?: Maybe<Array<Scalars['String']>>;
+  collaborators: Maybe<Array<Scalars['String']>>;
   email: Scalars['String'];
   ticket: ZendeskTicketInput;
 };
 
 
 export type UserMutationUpdateArgs = {
-  email?: Maybe<Scalars['String']>;
-  fullName?: Maybe<Scalars['String']>;
-  referrer?: Maybe<Scalars['String']>;
-  trackingGoogleClientId?: Maybe<Scalars['String']>;
-  trackingMarketoClientId?: Maybe<Scalars['String']>;
-  userSegment?: Maybe<UserSegment>;
-  utmCampaign?: Maybe<Scalars['String']>;
-  utmMedium?: Maybe<Scalars['String']>;
-  utmSource?: Maybe<Scalars['String']>;
+  email: Maybe<Scalars['String']>;
+  fullName: Maybe<Scalars['String']>;
+  referrer: Maybe<Scalars['String']>;
+  trackingGoogleClientId: Maybe<Scalars['String']>;
+  trackingMarketoClientId: Maybe<Scalars['String']>;
+  userSegment: Maybe<UserSegment>;
+  utmCampaign: Maybe<Scalars['String']>;
+  utmMedium: Maybe<Scalars['String']>;
+  utmSource: Maybe<Scalars['String']>;
 };
 
 
@@ -7301,12 +7301,12 @@ export type UserMutationUpdateBetaFeaturesOnArgs = {
 
 
 export type UserMutationUpdateFeatureIntrosArgs = {
-  newFeatureIntros?: Maybe<FeatureIntrosInput>;
+  newFeatureIntros: Maybe<FeatureIntrosInput>;
 };
 
 
 export type UserMutationUpdateRoleArgs = {
-  newRole?: Maybe<InternalMdgAdminRole>;
+  newRole: Maybe<InternalMdgAdminRole>;
 };
 
 
@@ -7315,14 +7315,14 @@ export type UserMutationVerifyEmailArgs = {
 };
 
 export type OdysseyCourseInput = {
-  completedAt?: Maybe<Scalars['Timestamp']>;
+  completedAt: Maybe<Scalars['Timestamp']>;
   courseId: Scalars['String'];
 };
 
 export type OdysseyTaskInput = {
-  completedAt?: Maybe<Scalars['Timestamp']>;
+  completedAt: Maybe<Scalars['Timestamp']>;
   taskId: Scalars['String'];
-  value?: Maybe<Scalars['String']>;
+  value: Maybe<Scalars['String']>;
 };
 
 export type ApiKeyProvision = {
@@ -7334,8 +7334,8 @@ export type ApiKeyProvision = {
 /** Zendesk ticket input */
 export type ZendeskTicketInput = {
   description: Scalars['String'];
-  graphId?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['String']>;
+  graphId: Maybe<Scalars['String']>;
+  organizationId: Maybe<Scalars['String']>;
   priority: TicketPriority;
   subject: Scalars['String'];
 };
@@ -7351,9 +7351,9 @@ export enum UserSegment {
 
 /** Feature Intros Input Type */
 export type FeatureIntrosInput = {
-  devGraph?: Maybe<Scalars['Boolean']>;
-  federatedGraph?: Maybe<Scalars['Boolean']>;
-  freeConsumerSeats?: Maybe<Scalars['Boolean']>;
+  devGraph: Maybe<Scalars['Boolean']>;
+  federatedGraph: Maybe<Scalars['Boolean']>;
+  freeConsumerSeats: Maybe<Scalars['Boolean']>;
 };
 
 export type SchemaReport = {
@@ -7364,15 +7364,15 @@ export type SchemaReport = {
   /** The graph ref (eg, 'id@variant') */
   graphRef: Scalars['String'];
   /** The version of the edge server reporting agent, e.g. apollo-server-2.8, graphql-java-3.1, etc. length must be <= 256 characters. */
-  libraryVersion?: Maybe<Scalars['String']>;
+  libraryVersion: Maybe<Scalars['String']>;
   /** The infra environment in which this edge server is running, e.g. localhost, Kubernetes, AWS Lambda, Google CloudRun, AWS ECS, etc. length must be <= 256 characters. */
-  platform?: Maybe<Scalars['String']>;
+  platform: Maybe<Scalars['String']>;
   /** The runtime in which the edge server is running, e.g. node 12.03, zulu8.46.0.19-ca-jdk8.0.252-macosx_x64, etc. length must be <= 256 characters. */
-  runtimeVersion?: Maybe<Scalars['String']>;
+  runtimeVersion: Maybe<Scalars['String']>;
   /** If available, an identifier for the edge server instance, such that when restarting this instance it will have the same serverId, with a different bootId. For example, in Kubernetes this might be the pod name. Length must be <= 256 characters. */
-  serverId?: Maybe<Scalars['String']>;
+  serverId: Maybe<Scalars['String']>;
   /** An identifier used to distinguish the version (from the user's perspective) of the edge server's code itself. For instance, the git sha of the server's repository or the docker sha of the associated image this server runs with. Length must be <= 256 characters. */
-  userVersion?: Maybe<Scalars['String']>;
+  userVersion: Maybe<Scalars['String']>;
 };
 
 export type ReportSchemaResult = {
@@ -7382,13 +7382,13 @@ export type ReportSchemaResult = {
 
 /** Explorer user settings input */
 export type UserSettingsInput = {
-  appNavCollapsed?: Maybe<Scalars['Boolean']>;
-  autoManageVariables?: Maybe<Scalars['Boolean']>;
-  mockingResponses?: Maybe<Scalars['Boolean']>;
-  preflightScriptEnabled?: Maybe<Scalars['Boolean']>;
-  responseHints?: Maybe<ResponseHints>;
-  tableMode?: Maybe<Scalars['Boolean']>;
-  themeName?: Maybe<ThemeName>;
+  appNavCollapsed: Maybe<Scalars['Boolean']>;
+  autoManageVariables: Maybe<Scalars['Boolean']>;
+  mockingResponses: Maybe<Scalars['Boolean']>;
+  preflightScriptEnabled: Maybe<Scalars['Boolean']>;
+  responseHints: Maybe<ResponseHints>;
+  tableMode: Maybe<Scalars['Boolean']>;
+  themeName: Maybe<ThemeName>;
 };
 
 export enum DeletionTargetType {
@@ -7410,26 +7410,26 @@ export type CompositionStatusSubscription = ChannelSubscription & {
   enabled: Scalars['Boolean'];
   id: Scalars['ID'];
   lastUpdatedAt: Scalars['Timestamp'];
-  variant?: Maybe<Scalars['String']>;
+  variant: Maybe<Scalars['String']>;
 };
 
 export type InternalIdentity = Identity & {
   __typename?: 'InternalIdentity';
   accounts: Array<Account>;
   asActor: Actor;
-  email?: Maybe<Scalars['String']>;
+  email: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   name: Scalars['String'];
 };
 
 /** query documents to validate against */
 export type QueryDocumentInput = {
-  document?: Maybe<Scalars['String']>;
+  document: Maybe<Scalars['String']>;
 };
 
 export type RegistryApiKey = {
   __typename?: 'RegistryApiKey';
-  keyName?: Maybe<Scalars['String']>;
+  keyName: Maybe<Scalars['String']>;
   token: Scalars['String'];
 };
 
@@ -7499,7 +7499,7 @@ export type SchemaTagsAndFieldStatsQueryVariables = Exact<{
 }>;
 
 
-export type SchemaTagsAndFieldStatsQuery = { __typename?: 'Query', service?: Maybe<{ __typename?: 'Service', schemaTags?: Maybe<Array<{ __typename?: 'SchemaTag', tag: string }>>, stats: { __typename?: 'ServiceStatsWindow', fieldStats: Array<{ __typename?: 'ServiceFieldStatsRecord', groupBy: { __typename?: 'ServiceFieldStatsDimensions', field?: Maybe<string> }, metrics: { __typename?: 'ServiceFieldStatsMetrics', fieldHistogram: { __typename?: 'DurationHistogram', durationMs?: Maybe<number> } } }> } }> };
+export type SchemaTagsAndFieldStatsQuery = { __typename?: 'Query', service: Maybe<{ __typename?: 'Service', schemaTags: Maybe<Array<{ __typename?: 'SchemaTag', tag: string }>>, stats: { __typename?: 'ServiceStatsWindow', fieldStats: Array<{ __typename?: 'ServiceFieldStatsRecord', groupBy: { __typename?: 'ServiceFieldStatsDimensions', field: Maybe<string> }, metrics: { __typename?: 'ServiceFieldStatsMetrics', fieldHistogram: { __typename?: 'DurationHistogram', durationMs: Maybe<number> } } }> } }> };
 
 export type GetSchemaByTagQueryVariables = Exact<{
   tag: Scalars['String'];
@@ -7507,10 +7507,10 @@ export type GetSchemaByTagQueryVariables = Exact<{
 }>;
 
 
-export type GetSchemaByTagQuery = { __typename?: 'Query', service?: Maybe<{ __typename: 'Service', schema?: Maybe<{ __typename?: 'Schema', hash: string, __schema: { __typename?: 'IntrospectionSchema', queryType: { __typename?: 'IntrospectionType', name?: Maybe<string> }, mutationType?: Maybe<{ __typename?: 'IntrospectionType', name?: Maybe<string> }>, subscriptionType?: Maybe<{ __typename?: 'IntrospectionType', name?: Maybe<string> }>, types: Array<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, description?: Maybe<string>, fields?: Maybe<Array<{ __typename?: 'IntrospectionField', name: string, description?: Maybe<string>, isDeprecated: boolean, deprecationReason?: Maybe<string>, args: Array<{ __typename?: 'IntrospectionInputValue', name: string, description?: Maybe<string>, defaultValue?: Maybe<string>, type: { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> } }>, type: { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> } }>>, inputFields?: Maybe<Array<{ __typename?: 'IntrospectionInputValue', name: string, description?: Maybe<string>, defaultValue?: Maybe<string>, type: { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> } }>>, interfaces?: Maybe<Array<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> }>>, enumValues?: Maybe<Array<{ __typename?: 'IntrospectionEnumValue', name: string, description?: Maybe<string>, isDeprecated: boolean, deprecationReason?: Maybe<string> }>>, possibleTypes?: Maybe<Array<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> }>> }>, directives: Array<{ __typename?: 'IntrospectionDirective', name: string, description?: Maybe<string>, locations: Array<IntrospectionDirectiveLocation>, args: Array<{ __typename?: 'IntrospectionInputValue', name: string, description?: Maybe<string>, defaultValue?: Maybe<string>, type: { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> } }> }> } }> }> };
+export type GetSchemaByTagQuery = { __typename?: 'Query', service: Maybe<{ __typename: 'Service', schema: Maybe<{ __typename?: 'Schema', hash: string, __schema: { __typename?: 'IntrospectionSchema', queryType: { __typename?: 'IntrospectionType', name: Maybe<string> }, mutationType: Maybe<{ __typename?: 'IntrospectionType', name: Maybe<string> }>, subscriptionType: Maybe<{ __typename?: 'IntrospectionType', name: Maybe<string> }>, types: Array<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, description: Maybe<string>, fields: Maybe<Array<{ __typename?: 'IntrospectionField', name: string, description: Maybe<string>, isDeprecated: boolean, deprecationReason: Maybe<string>, args: Array<{ __typename?: 'IntrospectionInputValue', name: string, description: Maybe<string>, defaultValue: Maybe<string>, type: { __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string> }> }> }> }> }> }> }> } }>, type: { __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string> }> }> }> }> }> }> }> } }>>, inputFields: Maybe<Array<{ __typename?: 'IntrospectionInputValue', name: string, description: Maybe<string>, defaultValue: Maybe<string>, type: { __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string> }> }> }> }> }> }> }> } }>>, interfaces: Maybe<Array<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string> }> }> }> }> }> }> }> }>>, enumValues: Maybe<Array<{ __typename?: 'IntrospectionEnumValue', name: string, description: Maybe<string>, isDeprecated: boolean, deprecationReason: Maybe<string> }>>, possibleTypes: Maybe<Array<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string> }> }> }> }> }> }> }> }>> }>, directives: Array<{ __typename?: 'IntrospectionDirective', name: string, description: Maybe<string>, locations: Array<IntrospectionDirectiveLocation>, args: Array<{ __typename?: 'IntrospectionInputValue', name: string, description: Maybe<string>, defaultValue: Maybe<string>, type: { __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string> }> }> }> }> }> }> }> } }> }> } }> }> };
 
-export type IntrospectionFullTypeFragment = { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, description?: Maybe<string>, fields?: Maybe<Array<{ __typename?: 'IntrospectionField', name: string, description?: Maybe<string>, isDeprecated: boolean, deprecationReason?: Maybe<string>, args: Array<{ __typename?: 'IntrospectionInputValue', name: string, description?: Maybe<string>, defaultValue?: Maybe<string>, type: { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> } }>, type: { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> } }>>, inputFields?: Maybe<Array<{ __typename?: 'IntrospectionInputValue', name: string, description?: Maybe<string>, defaultValue?: Maybe<string>, type: { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> } }>>, interfaces?: Maybe<Array<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> }>>, enumValues?: Maybe<Array<{ __typename?: 'IntrospectionEnumValue', name: string, description?: Maybe<string>, isDeprecated: boolean, deprecationReason?: Maybe<string> }>>, possibleTypes?: Maybe<Array<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> }>> };
+export type IntrospectionFullTypeFragment = { __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, description: Maybe<string>, fields: Maybe<Array<{ __typename?: 'IntrospectionField', name: string, description: Maybe<string>, isDeprecated: boolean, deprecationReason: Maybe<string>, args: Array<{ __typename?: 'IntrospectionInputValue', name: string, description: Maybe<string>, defaultValue: Maybe<string>, type: { __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string> }> }> }> }> }> }> }> } }>, type: { __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string> }> }> }> }> }> }> }> } }>>, inputFields: Maybe<Array<{ __typename?: 'IntrospectionInputValue', name: string, description: Maybe<string>, defaultValue: Maybe<string>, type: { __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string> }> }> }> }> }> }> }> } }>>, interfaces: Maybe<Array<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string> }> }> }> }> }> }> }> }>>, enumValues: Maybe<Array<{ __typename?: 'IntrospectionEnumValue', name: string, description: Maybe<string>, isDeprecated: boolean, deprecationReason: Maybe<string> }>>, possibleTypes: Maybe<Array<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string> }> }> }> }> }> }> }> }>> };
 
-export type IntrospectionInputValueFragment = { __typename?: 'IntrospectionInputValue', name: string, description?: Maybe<string>, defaultValue?: Maybe<string>, type: { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> } };
+export type IntrospectionInputValueFragment = { __typename?: 'IntrospectionInputValue', name: string, description: Maybe<string>, defaultValue: Maybe<string>, type: { __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string> }> }> }> }> }> }> }> } };
 
-export type IntrospectionTypeRefFragment = { __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string>, ofType?: Maybe<{ __typename?: 'IntrospectionType', kind?: Maybe<IntrospectionTypeKind>, name?: Maybe<string> }> }> }> }> }> }> }> };
+export type IntrospectionTypeRefFragment = { __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string>, ofType: Maybe<{ __typename?: 'IntrospectionType', kind: Maybe<IntrospectionTypeKind>, name: Maybe<string> }> }> }> }> }> }> }> };

--- a/src/language-server/providers/schema/engine.ts
+++ b/src/language-server/providers/schema/engine.ts
@@ -11,7 +11,7 @@ import {
   SchemaResolveConfig,
 } from "./base";
 
-import { GetSchemaByTag } from "../../graphqlTypes";
+import { GetSchemaByTagQuery } from "../../graphqlTypes";
 import { Debug } from "../../utilities";
 
 export class EngineSchemaProvider implements GraphQLSchemaProvider {
@@ -47,7 +47,7 @@ export class EngineSchemaProvider implements GraphQLSchemaProvider {
       );
     }
 
-    const { data, errors } = await this.client.execute<GetSchemaByTag>({
+    const { data, errors } = await this.client.execute<GetSchemaByTagQuery>({
       query: SCHEMA_QUERY,
       variables: {
         id: this.config.graph,


### PR DESCRIPTION
graphqlTypes.ts was generated by `apollo codegen` when the VSCode
extension was part of the apollo-tooling repo. When extracted to its own
repo, there was no mechanism checked in  to this repo to regenerate it.

This PR adds a script to regenerate it, and makes that script use
graphql-code-generator rather than `apollo codegen`.



┆Issue is synchronized with this [Jira Task](https://apollographql.atlassian.net/browse/NEBULA-442) by [Unito](https://www.unito.io)
