### PR TITLE
Switch timing hints to use fieldLatencies query

### DIFF
--- a/src/language-server/engine/operations/schemaTagsAndFieldStats.ts
+++ b/src/language-server/engine/operations/schemaTagsAndFieldStats.ts
@@ -7,7 +7,7 @@ export const SCHEMA_TAGS_AND_FIELD_STATS = gql`
         tag
       }
       stats(from: "-86400", to: "-0") {
-        fieldStats {
+        fieldLatencies {
           groupBy {
             field
           }

--- a/src/language-server/graphqlTypes.ts
+++ b/src/language-server/graphqlTypes.ts
@@ -7499,7 +7499,7 @@ export type SchemaTagsAndFieldStatsQueryVariables = Exact<{
 }>;
 
 
-export type SchemaTagsAndFieldStatsQuery = { __typename?: 'Query', service: Maybe<{ __typename?: 'Service', schemaTags: Maybe<Array<{ __typename?: 'SchemaTag', tag: string }>>, stats: { __typename?: 'ServiceStatsWindow', fieldStats: Array<{ __typename?: 'ServiceFieldStatsRecord', groupBy: { __typename?: 'ServiceFieldStatsDimensions', field: Maybe<string> }, metrics: { __typename?: 'ServiceFieldStatsMetrics', fieldHistogram: { __typename?: 'DurationHistogram', durationMs: Maybe<number> } } }> } }> };
+export type SchemaTagsAndFieldStatsQuery = { __typename?: 'Query', service: Maybe<{ __typename?: 'Service', schemaTags: Maybe<Array<{ __typename?: 'SchemaTag', tag: string }>>, stats: { __typename?: 'ServiceStatsWindow', fieldLatencies: Array<{ __typename?: 'ServiceFieldLatenciesRecord', groupBy: { __typename?: 'ServiceFieldLatenciesDimensions', field: Maybe<string> }, metrics: { __typename?: 'ServiceFieldLatenciesMetrics', fieldHistogram: { __typename?: 'DurationHistogram', durationMs: Maybe<number> } } }> } }> };
 
 export type GetSchemaByTagQueryVariables = Exact<{
   tag: Scalars['String'];


### PR DESCRIPTION
This query is backed by a more efficient data store than fieldStats. (We plan
to keep old versions of the plugin working by eventually aliasing fieldStats
to fieldLatencies, but fieldLatencies is the more appropriate field to use going
forward.)



┆Issue is synchronized with this [Jira Task](https://apollographql.atlassian.net/browse/NEBULA-446) by [Unito](https://www.unito.io)
