### PR TITLE
fix: Ignore edits/creations for non file documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Next
 
 - Specify files with conflicting documents for the 'There are multiple definitions' message. [#29](https://github.com/apollographql/vscode-graphql/pull/29)
+- Dont watch non file documents. Diff view will no longer crash extension. [#28](https://github.com/apollographql/vscode-graphql/pull/28)
 
 ### 1.19.6
 


### PR DESCRIPTION
This ignores document edits/creations that are coming from non file sources (eg merge view documents).

Previously if you opened the diff viewer (and possibly other ephemeral documents) the extension would see multiple definitions with the same name and crash.

Adapted from: https://github.com/apollographql/apollo-tooling/pull/1894
Fixes: https://github.com/apollographql/apollo-tooling/issues/1789, https://github.com/apollographql/apollo-tooling/issues/1875, part of https://github.com/apollographql/vscode-graphql/issues/18