### PR TITLE
fix: Specify file names for conflicting operation definition message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### Next
+
+- Specify files with conflicting documents for the 'There are multiple definitions' message. [#29](https://github.com/apollographql/vscode-graphql/pull/29)
+
 ### 1.19.6
 
 - Fix 'Run in explorer' link. [#25](https://github.com/apollographql/vscode-graphql/pull/25)


### PR DESCRIPTION
Improve 'Conflicting definitions' message to specify files that are causing the issue.

Fixes: Part of https://github.com/apollographql/vscode-graphql/issues/18