### PR TITLE
Add referrer to 'Run in Studio' link

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+package-lock.json -diff

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-apollo",
-  "version": "1.19.4",
+  "version": "1.19.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-apollo",
-      "version": "1.19.4",
+      "version": "1.19.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -34,6 +34,7 @@
         "minimatch": "^3.0.4",
         "moment": "^2.29.1",
         "node-fetch": "^2.2.0",
+        "query-string": "^7.0.1",
         "resolve-from": "^5.0.0",
         "sha.js": "^2.4.11",
         "vscode-languageclient": "^5.2.1",
@@ -4993,6 +4994,14 @@
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -6069,6 +6078,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/find-up": {
@@ -10744,6 +10761,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/query-string": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
+      "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
+      "dependencies": {
+        "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -11239,6 +11273,14 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/sponge-case": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
@@ -11269,6 +11311,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/string-env-interpolation": {
@@ -16495,6 +16545,11 @@
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
     "decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -17302,6 +17357,11 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "find-up": {
       "version": "4.1.0",
@@ -20928,6 +20988,17 @@
         "side-channel": "^1.0.4"
       }
     },
+    "query-string": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
+      "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -21307,6 +21378,11 @@
         "source-map": "^0.6.0"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "sponge-case": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
@@ -21337,6 +21413,11 @@
       "requires": {
         "escape-string-regexp": "^2.0.0"
       }
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-env-interpolation": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "minimatch": "^3.0.4",
     "moment": "^2.29.1",
     "node-fetch": "^2.2.0",
+    "query-string": "^7.0.1",
     "resolve-from": "^5.0.0",
     "sha.js": "^2.4.11",
     "vscode-languageclient": "^5.2.1",

--- a/src/language-server/project/client.ts
+++ b/src/language-server/project/client.ts
@@ -418,11 +418,19 @@ export class GraphQLClientProject extends GraphQLProject {
                   const runInExplorerPath = graphId
                     ? stringifyUrl({
                         url: `/graph/${graphId}/explorer`,
-                        query: { variant, explorerURLState },
+                        query: {
+                          variant,
+                          explorerURLState,
+                          referrer: "vscode",
+                        },
                       })
                     : stringifyUrl({
                         url: "/sandbox/explorer",
-                        query: { endpoint, explorerURLState },
+                        query: {
+                          endpoint,
+                          explorerURLState,
+                          referrer: "vscode",
+                        },
                       });
                   const runInExplorerLink = join(
                     frontendUrlRoot,

--- a/src/language-server/project/client.ts
+++ b/src/language-server/project/client.ts
@@ -25,6 +25,7 @@ import {
 import { ValidationRule } from "graphql/validation/ValidationContext";
 import { NotificationHandler, DiagnosticSeverity } from "vscode-languageserver";
 import LZString from "lz-string";
+import { stringifyUrl } from "query-string";
 
 import { rangeForASTNode } from "../utilities/source";
 import { formatMS } from "../format";
@@ -403,16 +404,26 @@ export class GraphQLClientProject extends GraphQLProject {
                   const frontendUrlRoot =
                     this.frontendUrlRoot ?? "https://studio.apollographql.com";
 
-                  const endpoint = this.config.service?.endpoint;
                   const variant = this.config.variant;
                   const graphId = this.config.graph;
-                  this.config.client.service;
+
+                  const { client, service } = this.config;
+                  const remoteServiceConfig =
+                    typeof client.service === "object" &&
+                    "url" in client.service
+                      ? client.service
+                      : service?.endpoint;
+                  const endpoint = remoteServiceConfig?.url;
 
                   const runInExplorerPath = graphId
-                    ? `/graph/${graphId}/explorer?variant=${variant}&explorerURLState=${explorerURLState}`
-                    : `/sandbox/explorer?explorerURLState=${explorerURLState}${
-                        endpoint ? `&endpoint=${endpoint}` : ""
-                      }`;
+                    ? stringifyUrl({
+                        url: `/graph/${graphId}/explorer`,
+                        query: { variant, explorerURLState },
+                      })
+                    : stringifyUrl({
+                        url: "/sandbox/explorer",
+                        query: { endpoint, explorerURLState },
+                      });
                   const runInExplorerLink = join(
                     frontendUrlRoot,
                     runInExplorerPath


### PR DESCRIPTION
This does a tiny bit of cleanup and adds `referrer=vscode` to the generated 'Run in Studio' links for tracking.

More details in commit descriptions.