### PR TITLE
fix: Fix syntax highlighting for implements with directive

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,6 +8,7 @@ src
 .gitignore
 .nvmrc
 .prettierrc
+.gitattributes
 codegen.yml
 graphql.configuration.json
 jest.config.ts

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
         "injectTo": [
           "source.js",
           "source.ts",
-          "source.js.jsx",
+          "source.jsx",
           "source.tsx",
           "source.vue",
           "source.svelte"

--- a/syntaxes/graphql.json
+++ b/syntaxes/graphql.json
@@ -119,7 +119,7 @@
         { "include": "#graphql-type-object" },
         { "include": "#graphql-colon" },
         { "include": "#graphql-input-types" },
-        { "include": "#graphql-directive"},
+        { "include": "#graphql-directive" },
         { "include": "#literal-quasi-embedded" }
       ]
     },

--- a/syntaxes/graphql.json
+++ b/syntaxes/graphql.json
@@ -65,7 +65,7 @@
       "patterns": [
         {
           "begin": "\\s*\\b(implements)\\b\\s*",
-          "end": "\\s*(?={)",
+          "end": "\\s*(?=[{@])",
           "beginCaptures": {
             "1": { "name": "keyword.implements.graphql.RRR" }
           },


### PR DESCRIPTION
```graphql
type Product implements ProductItf @key(fields: "id") {
  …
}
```
would previously not follow the pattern `"begin": "\\s*\\b(implements)\\b\\s*", "end": "\\s*(?={)",` because the `implements ProductItf` was followed by an ‘@’, not a ‘{’ (which is perfectly valid). This meant this was not getting recognized as an interface.

You might be asking, why do we have our own full grammar defined here when it probably isn't up to date with the spec, there must be a better way 💭 Agree, but let's fix this issue for now 😛

A few other random small cleanups here as well. The first commit is the functional change.