### PR TITLE
Move 'Run in Studio' icon to the right of the operation signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+### vNext
+
+- Move 'Run in Studio' icon to end of line [#42](https://github.com/apollographql/vscode-graphql/pull/42)
+- Fix syntax highlighting for directives on types [#36](https://github.com/apollographql/vscode-graphql/pull/36)
+
 ### 1.19.7
 
 - Specify files with conflicting documents for the 'There are multiple definitions' message. [#29](https://github.com/apollographql/vscode-graphql/pull/29)

--- a/images/IconRun.svg
+++ b/images/IconRun.svg
@@ -3,6 +3,6 @@
     Exported from Streamline App (https://app.streamlineicons.com)
   </title>
   <g transform="matrix(2.54 0 0 2.54 10 9.97)" id="LVKu-U2gXNoh456TxJx47"  >
-    <path style="stroke: rgb(255,255,255); stroke-width: 1; stroke-dasharray: none; stroke-linecap: round; stroke-dashoffset: 0; stroke-linejoin: round; stroke-miterlimit: 4; fill: rgb(255,255,255); fill-rule: evenodd; opacity: 1;" vector-effect="non-scaling-stroke"  transform=" translate(-10.25, -9.71)" d="M 7 6.502 L 7 12.926 C 7 13.293 7.317 13.534 7.592 13.379 L 13.259 10.166 C 13.408058725855952 10.063593398311438 13.49712261259461 9.89434694032026 13.49712261259461 9.7135 C 13.49712261259461 9.532653059679742 13.408058725855952 9.363406601688563 13.259 9.261000000000001 L 7.592 6.047 C 7.317 5.893 7 6.135 7 6.502 Z" stroke-linecap="round" />
+    <path style="stroke: rgb(255,255,255); stroke-width: 1; stroke-dasharray: none; stroke-linecap: round; stroke-dashoffset: 0; stroke-linejoin: round; stroke-miterlimit: 4; fill: #2075D6; fill-rule: evenodd; opacity: 1;" vector-effect="non-scaling-stroke"  transform=" translate(-10.25, -9.71)" d="M 7 6.502 L 7 12.926 C 7 13.293 7.317 13.534 7.592 13.379 L 13.259 10.166 C 13.408058725855952 10.063593398311438 13.49712261259461 9.89434694032026 13.49712261259461 9.7135 C 13.49712261259461 9.532653059679742 13.408058725855952 9.363406601688563 13.259 9.261000000000001 L 7.592 6.047 C 7.317 5.893 7 6.135 7 6.502 Z" stroke-linecap="round" />
   </g>
 </svg>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import {
   Disposable,
   OutputChannel,
   MarkdownString,
+  Range,
 } from "vscode";
 import StatusBar from "./statusBar";
 import { getLanguageServerClient } from "./languageServerClient";
@@ -256,8 +257,13 @@ export function activate(context: ExtensionContext) {
               hoverMessage.isTrusted = true;
             }
 
+            const endOfLinePosition = editor.document.lineAt(
+              decoration.range.start.line
+            ).range.end;
             return {
-              range: editor.document.lineAt(decoration.range.start.line).range,
+              // Hover range of just the end of the line (and the icon) so the hover shows above the icon,
+              // not over at the start of the line
+              range: new Range(endOfLinePosition, endOfLinePosition),
               renderOptions: {
                 after: {
                   contentIconPath: runIconOnDiskPath,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -256,19 +256,15 @@ export function activate(context: ExtensionContext) {
               hoverMessage.isTrusted = true;
             }
 
-            const indentation = decoration.range.start.character;
             return {
               range: editor.document.lineAt(decoration.range.start.line).range,
               renderOptions: {
-                before: {
+                after: {
                   contentIconPath: runIconOnDiskPath,
-                  textDecoration: `none; padding-top: 0px; padding-left: 6px; border-radius: .20rem; ${
-                    // If the text is already indented, don't push it over
-                    indentation <= 2 ? "" : "margin-right: -18px;"
-                  }`,
+                  textDecoration:
+                    "none; border-radius: .20rem; margin-left: 8px; text-align: center;",
                   backgroundColor: "#2075D6",
-                  // This plus the padding-left should add up to 18 to match the height
-                  width: "12px",
+                  width: "18px",
                   height: "18px",
                 },
               },


### PR DESCRIPTION
Moves the icon to the right of the operation signature, this will stop it from pushing around text and keep it more out of the way.

<img width="474" alt="Screen Shot 2021-11-09 at 11 20 00 PM" src="https://user-images.githubusercontent.com/6856868/141067743-00deebbb-89a5-43ec-af77-fa05ab5446de.png">
