### PR TITLE
Add config option for disabling 'Run in Studio' button

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,12 @@
           "default": true,
           "markdownDescription": "Switches to the \"Output\" tab whenever an error occurs in the language server.",
           "scope": "window"
+        },
+        "apollographql.display.showRunInStudioButton": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show a \"Run in Studio\" button to the right of Operation Signatures.",
+          "scope": "window"
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -283,10 +283,16 @@ export function activate(context: ExtensionContext) {
           textDecorationType,
           textDecorations
         );
-        window.activeTextEditor!.setDecorations(
-          runGlyphDecorationType,
-          runGlyphDecorations
-        );
+        if (
+          workspace
+            .getConfiguration("apollographql")
+            .get("display.showRunInStudioButton")
+        ) {
+          window.activeTextEditor!.setDecorations(
+            runGlyphDecorationType,
+            runGlyphDecorations
+          );
+        }
       }
     };
 


### PR DESCRIPTION
Adds a 'Show Run in Studio Button' VSCode configuration option
<img width="581" alt="Screen Shot 2021-11-12 at 12 12 40 AM" src="https://user-images.githubusercontent.com/6856868/141433271-4f506395-c83c-4ea8-8c3b-5e0a1a5ddbdf.png">

Follow up from https://github.com/apollographql/vscode-graphql/issues/37