### PR TITLE
Update extraction regex to recognize #graphql annotated strings in js

### DIFF
--- a/src/language-server/document.ts
+++ b/src/language-server/document.ts
@@ -90,7 +90,10 @@ function extractGraphQLDocumentsFromJSTemplateLiterals(
 
   const documents: GraphQLDocument[] = [];
 
-  const regExp = new RegExp(`${tagName}\\s*\`([\\s\\S]+?)\``, "gm");
+  const regExp = new RegExp(
+    `(?:${tagName}\\s*\`|\`#graphql)([\\s\\S]+?)\``,
+    "gm"
+  );
 
   let result;
   while ((result = regExp.exec(text)) !== null) {


### PR DESCRIPTION
Follow up to https://github.com/apollographql/vscode-graphql/issues/15. This updates the extraction regex to accept either the template tag, or the `#graphql` annotation inside. This matches the highlighting recognizer in https://github.com/apollographql/vscode-graphql/blob/main/syntaxes/graphql.js.json

<img width="371" alt="Screen Shot 2021-11-12 at 12 51 59 AM" src="https://user-images.githubusercontent.com/6856868/141438740-085af4ae-4a37-435f-8904-fc33db915d98.png">
