### PR TITLE
feature: implement elixir support based only on sigils

### DIFF
--- a/src/language-server/__tests__/document.test.ts
+++ b/src/language-server/__tests__/document.test.ts
@@ -157,4 +157,68 @@ describe("extractGraphQLDocuments", () => {
       expect(documents?.[0].ast?.definitions.length).toBe(1);
     });
   });
+
+  describe("extracting documents from Elixir extension nodes", () => {
+    const mockTextDocument = (text: string): TextDocument => ({
+      getText: jest.fn().mockReturnValue(text),
+      offsetAt(): number {
+        return 0;
+      },
+      positionAt(): Position {
+        return {
+          character: 0,
+          line: 0,
+        };
+      },
+      languageId: "elixir",
+      lineCount: 0,
+      uri: "",
+      version: 1,
+    });
+
+    it("works with function style node", () => {
+      const textDocument = mockTextDocument(`
+      gql("""
+        query SomeQuery {
+          id
+        }
+      """)
+    `);
+      const documents = extractGraphQLDocuments(textDocument);
+
+      expect(documents?.length).toEqual(1);
+      expect(documents?.[0].syntaxErrors.length).toBe(0);
+      expect(documents?.[0].ast?.definitions.length).toBe(1);
+    });
+
+    it("works with function style node with sigil", () => {
+      const textDocument = mockTextDocument(`
+      gql(r"""
+        query SomeQuery {
+          id
+        }
+      """)
+    `);
+      const documents = extractGraphQLDocuments(textDocument);
+
+      expect(documents?.length).toEqual(1);
+      expect(documents?.[0].syntaxErrors.length).toBe(0);
+      expect(documents?.[0].ast?.definitions.length).toBe(1);
+    });
+
+    it("works with custom sigil", () => {
+      const textDocument = mockTextDocument(`
+      ~gql"""
+        query SomeQuery {
+          id
+        }
+      """
+    `);
+      const documents = extractGraphQLDocuments(textDocument);
+
+      expect(documents?.length).toEqual(1);
+      expect(documents?.[0].syntaxErrors.length).toBe(0);
+      expect(documents?.[0].ast?.definitions.length).toBe(1);
+    });
+  });
 });

--- a/src/language-server/document.ts
+++ b/src/language-server/document.ts
@@ -242,13 +242,13 @@ function extractGraphQLDocumentsFromElixirStrings(
   const documents: GraphQLDocument[] = [];
 
   const regExp = new RegExp(
-    `\\b(${tagName}\\(\\s*r?("""))([\\s\\S]+?)\\2\\s*\\)`,
+    `(~${tagName}"""|\\b${tagName}\\(\\s*r?""")([\\s\\S]+?)"""(\\s*\\))?`,
     "gm"
   );
 
   let result;
   while ((result = regExp.exec(text)) !== null) {
-    const contents = replacePlaceholdersWithWhiteSpace(result[3]);
+    const contents = replacePlaceholdersWithWhiteSpace(result[2]);
     const position = document.positionAt(result.index + result[1].length);
     const locationOffset: SourceLocation = {
       line: position.line + 1,

--- a/syntaxes/graphql.ex.json
+++ b/syntaxes/graphql.ex.json
@@ -35,6 +35,17 @@
           ]
         }
       ]
+    },
+    {
+      "name": "taggedTemplates",
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "\\~(gql|graphql|GQL|GRAPHQL)(\"\"\")",
+      "end": "((\\2))",
+      "patterns": [
+        {
+          "include": "source.graphql"
+        }
+      ]
     }
   ],
   "scopeName": "inline.graphql.elixir"


### PR DESCRIPTION
Hey, first of all, thank you for the tooling. Apollo has been an excellent tool in the GraphQL ecosystem 🙇🏾 . In this PR, I'm adding an alternative syntax for using `vscode-graphql` with Elixir, some context why: 

#### Context
The original implementation requires the GraphQL block to be wrapped in a `gql` function. That forces users to define an empty `gql` function if the devs want to use `vscode-graphql` features even with no utility. I took a look at the original PR (apollographql/apollo-tooling#1304), and it was intentional. It seems like the original author had this pattern already defined in his codebase.

#### Solution
One option is to use [sigils](https://elixir-lang.org/getting-started/sigils.html#strings-char-lists-and-word-lists-sigils) for improving it. Sigils also allow heredocs, and heredocs is how `vscode-graphql` supports ruby (apollographql/apollo-tooling#1304).

By default, elixir allows users to use `~s"""...` for strings without interpolation and `~S"""...` for cases where string interpolation or escaping is needed. Elixir is a very extensible language, allowing users to [write their own sigils](https://elixir-lang.org/getting-started/sigils.html#custom-sigils). This implementation makes `vscode-graphql` shine when users have defined sigils in a heredoc style for graphql operations.

Once users may be using the original format, I kept that working together with the new syntax support. I also added basic tests to ensure things are still working for the version based on function and the version based on sigils.

### Screenshots
![vscode-elixir-with-sigils](https://user-images.githubusercontent.com/9089847/142500572-68be0f88-68fc-4a06-b378-cdfe48d00e7b.gif)



┆Issue is synchronized with this [Jira Task](https://apollographql.atlassian.net/browse/NEBULA-647) by [Unito](https://www.unito.io)
