### PR TITLE
Fix schema extension directive highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### vNext
+
+- Fix highlighting on schema extension directives [#66](https://github.com/apollographql/vscode-graphql/pull/66)
+
 ### 1.19.9
 
 - Add validation/completion for #graphql annotated strings in js [#47](https://github.com/apollographql/vscode-graphql/pull/47)

--- a/syntaxes/graphql.json
+++ b/syntaxes/graphql.json
@@ -124,10 +124,11 @@
       ]
     },
     "graphql-schema": {
-      "begin": "\\s*\\b(schema)\\b",
-      "end": "(?<=})",
+      "begin": "\\s*\\b(extend)?\\b\\s*\\b(schema)\\b",
+      "end": "\\s*(?!\\s|#|{|@|$)",
       "beginCaptures": {
-        "1": { "name": "keyword.schema.graphql" }
+        "1": { "name": "keyword.extend.graphql" },
+        "2": { "name": "keyword.schema.graphql" }
       },
       "patterns": [
         {
@@ -165,6 +166,7 @@
             { "include": "#graphql-skip-newlines" }
           ]
         },
+        { "include": "#graphql-directive" },
         { "include": "#graphql-comment" },
         { "include": "#graphql-skip-newlines" }
       ]


### PR DESCRIPTION
This fixes syntax highlighting of the schema node. There are two main changes here


* Allow the 'extend' keyword before 'schema'
* Add directives as a pattern for the schema node. Also change the 'end' check to look for the start of anything that doesn't match one of its child patterns (no directives, comments, or opening selection sets) instead of looking specifically for a closing '}'

It's worth noting that this grammar is still quite wrong, patterns are unordered so you can do things like have directives after the selection set, directives are also allowed top level so even if something fails to parse, the directive will still highlight (or a dangling directive attached to nothing). This slightly fixes the happy path here, but does nothing to surface any failure cases.

Grammar documentation: https://macromates.com/manual/en/language_grammars

Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/6856868/163029112-f5e0ffce-7f07-4d1e-9ade-ecd921b41638.png)  |  ![](https://user-images.githubusercontent.com/6856868/163028347-b1801b55-30e3-4c08-b2e0-0ef41e9ddd63.png)
![](https://user-images.githubusercontent.com/6856868/163029115-20945cca-4f3d-41dd-a88a-dd3c5930dce2.png) | ![](https://user-images.githubusercontent.com/6856868/163028356-397aa776-7086-42ae-aa43-112640b1b06f.png)
![](https://user-images.githubusercontent.com/6856868/163029119-fbe3f447-7c10-4660-9a4d-c8b4c35d6b86.png) | ![](https://user-images.githubusercontent.com/6856868/163028360-05b5d065-0b54-4ca6-ac02-ddf23442f816.png)
![](https://user-images.githubusercontent.com/6856868/163029121-029aed58-c5bf-441f-8cec-fedd79f444c7.png) | ![](https://user-images.githubusercontent.com/6856868/163028363-c3afe32c-a641-4233-a307-10d95766614b.png)



┆Issue is synchronized with this [Jira Task](https://apollographql.atlassian.net/browse/NEBULA-1175) by [Unito](https://www.unito.io)
