### PR TITLE
Fix directive highlighting on enums and arguments

### DIFF
--- a/syntaxes/graphql.json
+++ b/syntaxes/graphql.json
@@ -263,7 +263,8 @@
         { "include": "#graphql-input-types" },
         { "include": "#graphql-variable-assignment" },
         { "include": "#literal-quasi-embedded" },
-        { "include": "#graphql-skip-newlines" }
+        { "include": "#graphql-skip-newlines" },
+        { "include": "#graphql-directive" }
       ]
     },
     "graphql-input-types": {

--- a/syntaxes/graphql.json
+++ b/syntaxes/graphql.json
@@ -297,7 +297,7 @@
       "match": "\\s*\\b(scalar)\\b\\s*([_A-Za-z][_0-9A-Za-z]*)",
       "captures": {
         "1": { "name": "keyword.scalar.graphql" },
-        "2": { "name": "entity.scalar.graphql" }
+        "2": { "name": "support.type.enum.graphql" }
       }
     },
     "graphql-scalar-type": {

--- a/syntaxes/graphql.json
+++ b/syntaxes/graphql.json
@@ -535,7 +535,7 @@
           },
           "patterns": [
             { "include": "#graphql-object-type" },
-
+            { "include": "#graphql-directive" },
             { "include": "#graphql-comment" },
             { "include": "#graphql-enum-value" },
             { "include": "#literal-quasi-embedded" }

--- a/syntaxes/graphql.json
+++ b/syntaxes/graphql.json
@@ -540,7 +540,8 @@
             { "include": "#graphql-enum-value" },
             { "include": "#literal-quasi-embedded" }
           ]
-        }
+        },
+        { "include": "#graphql-directive" }
       ]
     },
     "graphql-enum-value": {


### PR DESCRIPTION
Highlights directives properly on enum definitions, enum values, and arguments. Also fixes the highlight for scalar type names. This basically just includes the directive pattern under each of the rules where directives should be allowed

Before:
![](https://user-images.githubusercontent.com/6856868/166638240-fb5bd38f-06bd-4e48-939a-9afe8df955b7.png)

After:

![](https://user-images.githubusercontent.com/6856868/166638225-d1dcaa88-15ac-4d02-946a-a2c133e9a822.png)



┆Issue is synchronized with this [Jira Task](https://apollographql.atlassian.net/browse/NEBULA-1255) by [Unito](https://www.unito.io)
