### PR TITLE
Fix for #64: return before error on missing fields

### DIFF
--- a/.changeset/five-spiders-protect.md
+++ b/.changeset/five-spiders-protect.md
@@ -1,0 +1,5 @@
+---
+"vscode-apollo": patch
+---
+
+Return early instead of erroring on missing fields

--- a/src/language-server/errors/validation.ts
+++ b/src/language-server/errors/validation.ts
@@ -175,7 +175,7 @@ export function NoMissingClientDirectives(context: ValidationContext) {
     const fieldDef = context.getFieldDef();
 
     // if we don't have a type to check then we can early return
-    if (!parentType) return;
+    if (!parentType || fieldDef) return;
 
     // here we collect all of the fields on a type that are marked "local"
     const clientFields =

--- a/src/language-server/errors/validation.ts
+++ b/src/language-server/errors/validation.ts
@@ -175,7 +175,7 @@ export function NoMissingClientDirectives(context: ValidationContext) {
     const fieldDef = context.getFieldDef();
 
     // if we don't have a type to check then we can early return
-    if (!parentType || fieldDef) return;
+    if (!parentType || !fieldDef) return;
 
     // here we collect all of the fields on a type that are marked "local"
     const clientFields =


### PR DESCRIPTION
I am getting the error described in https://github.com/apollographql/vscode-graphql/issues/64.

As far as I can tell, it is happening in when a GraphQL document includes a field that doesn't exist on the server schema. In this scenario the validation should add an error like this:

![CleanShot 2022-05-24 at 13 07 29](https://user-images.githubusercontent.com/1632086/169940818-8214d981-6175-42a1-846d-a047aa824f52.png)

But when it gets run though the `NoMissingClientDirectives` rule, `context.getFieldDef()` returns `undefined`, causing the extension to error on line 103 of `validation.js`. 

Adding an early return if the `fieldDef` doesn't exist prevents the error.



┆Issue is synchronized with this [Jira Task](https://apollographql.atlassian.net/browse/NEBULA-1294) by [Unito](https://www.unito.io)
