### PR TITLE
fix regex for ruby heredoc

### DIFF
--- a/.changeset/nice-hats-peel.md
+++ b/.changeset/nice-hats-peel.md
@@ -1,0 +1,5 @@
+---
+"vscode-apollo": patch
+---
+
+Fix regex for ruby heredoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     name: Changesets Release
     # Prevents action from creating a PR on forks
-    if: github.repository == 'apollographql/vscode-apollo'
+    if: github.repository == 'apollographql/vscode-graphql'
     runs-on: ubuntu-latest
     # Permissions necessary for Changesets to push a new branch and open PRs
     # (for automated Version Packages PRs), and request the JWT for provenance.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-apollo",
   "displayName": "Apollo GraphQL",
   "description": "Rich editor support for GraphQL client and server development that seamlessly integrates with the Apollo platform",
-  "version": "1.19.11",
+  "version": "1.19.12",
   "referenceID": "87197759-7617-40d0-b32e-46d378e907c7",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-apollo",
   "displayName": "Apollo GraphQL",
   "description": "Rich editor support for GraphQL client and server development that seamlessly integrates with the Apollo platform",
-  "version": "1.19.12",
+  "version": "1.19.11",
   "referenceID": "87197759-7617-40d0-b32e-46d378e907c7",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",

--- a/syntaxes/graphql.rb.json
+++ b/syntaxes/graphql.rb.json
@@ -4,7 +4,7 @@
   "patterns": [
     {
       "contentName": "meta.embedded.block.graphql",
-      "begin": "(?=(?><<[-~](['\"]?)((?:[_\\w]+_|)GRAPHQL)\\b\\1))",
+      "begin": "(?><<[-~](['\"`]?)((?:[_\\w]+_|)GRAPHQL)\\b\\1)",
       "beginCaptures": {
         "0": {
           "name": "punctuation.definition.string.begin.ruby"


### PR DESCRIPTION
Fixes https://github.com/apollographql/vscode-graphql/issues/74 

I ran into this issue where the syntax highlighting got all borked when ApolloGraphQL was installed but noticed that other extensions were working fine. For example: https://github.com/kumarharsh/graphql-for-vscode/blob/master/syntaxes/graphql.rb.json. This PR uses the same regex which seems to resolve the issue. 

First time contributing here, so let me know if theres anything else needed to merge this.



┆Issue is synchronized with this [Jira Task](https://apollographql.atlassian.net/browse/NEBULA-1416) by [Unito](https://www.unito.io)
