### PR TITLE
fix: fix the configuration file .cjs suffix does not support the bug

### DIFF
--- a/.changeset/many-garlics-remain.md
+++ b/.changeset/many-garlics-remain.md
@@ -1,0 +1,5 @@
+---
+"vscode-apollo": patch
+---
+
+Support configuration files with .cjs file extension

--- a/src/language-server/config/config.ts
+++ b/src/language-server/config/config.ts
@@ -146,7 +146,7 @@ export class ApolloConfig {
 
   get configDirURI() {
     // if the filepath has a _file_ in it, then we get its dir
-    return this.configURI && this.configURI.fsPath.match(/\.(ts|js|json)$/i)
+    return this.configURI && this.configURI.fsPath.match(/\.(ts|js|cjs|json)$/i)
       ? URI.parse(dirname(this.configURI.fsPath))
       : this.configURI;
   }


### PR DESCRIPTION
修复cjs后缀的配置文件,无法正常使用的问题.
I'm sorry, I'm not good at English. The following is a machine translation.
Repair the CJS suffix configuration file, cannot use normally.