### PR TITLE
Add inline syntax highlighting support for Lua

### DIFF
--- a/.changeset/neat-frogs-trade.md
+++ b/.changeset/neat-frogs-trade.md
@@ -1,0 +1,5 @@
+---
+"vscode-apollo": minor
+---
+
+Add inline syntax highlighting support for Lua

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -14,3 +14,4 @@ graphql.configuration.json
 jest.config.ts
 package-lock.json
 tsconfig.build.json
+tsconfig.json

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -14,4 +14,3 @@ graphql.configuration.json
 jest.config.ts
 package-lock.json
 tsconfig.build.json
-tsconfig.json

--- a/package.json
+++ b/package.json
@@ -177,6 +177,16 @@
       },
       {
         "injectTo": [
+          "source.lua"
+        ],
+        "scopeName": "inline.graphql.lua",
+        "path": "./syntaxes/graphql.lua.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.graphql": "graphql"
+        }
+      },
+      {
+        "injectTo": [
           "source.ruby"
         ],
         "scopeName": "inline.graphql.ruby",

--- a/syntaxes/graphql.lua.json
+++ b/syntaxes/graphql.lua.json
@@ -1,0 +1,26 @@
+{
+  "fileTypes": ["lua", "luau"],
+  "injectionSelector": "L:source -string -comment",
+  "patterns": [
+    {
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "(gql)\\(?\\s*(\\[\\[)",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function.lua"
+        },
+        "2": {
+          "name": "string.quoted.double.lua"
+        }
+      },
+      "end": "(\\]\\])",
+      "endCaptures": {
+        "1": {
+          "name": "string.quoted.double.lua"
+        }
+      },
+      "patterns": [{ "include": "source.graphql" }]
+    }
+  ],
+  "scopeName": "inline.graphql.lua"
+}

--- a/syntaxes/graphql.lua.json
+++ b/syntaxes/graphql.lua.json
@@ -4,6 +4,31 @@
   "patterns": [
     {
       "contentName": "meta.embedded.block.graphql",
+      "begin": "(--\\[\\[)\\s*(gql)\\s*(\\]\\])\\s*(\\[\\[)",
+      "beginCaptures": {
+        "1": {
+          "name": "comment.block.lua"
+        },
+        "2": {
+          "name": "entity.name.function.lua"
+        },
+        "3": {
+          "name": "comment.block.lua"
+        },
+        "4": {
+          "name": "string.quoted.double.lua"
+        }
+      },
+      "end": "(\\]\\])",
+      "endCaptures": {
+        "1": {
+          "name": "string.quoted.double.lua"
+        }
+      },
+      "patterns": [{ "include": "source.graphql" }]
+    },
+    {
+      "contentName": "meta.embedded.block.graphql",
       "begin": "(gql)\\(?\\s*(\\[\\[)",
       "beginCaptures": {
         "1": {


### PR DESCRIPTION
This extension supports inline syntax highlighting for several languages already (great work!), and our workflow uses Lua so I've added Lua to that list of supported languages.

I've added support for two common syntaxes: passing a string to `gql` and defining a string for later use while tagging it with a gql comment.

![image](https://github.com/apollographql/vscode-graphql/assets/67015571/089c869f-7e81-46ef-af26-501f36408f84)
