### PR TITLE
remove `codemirror` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@types/node-fetch": "2.6.11",
         "apollo-datasource": "^0.8.0",
         "await-to-js": "^3.0.0",
-        "codemirror": "^5.63.3",
         "cosmiconfig": "^9.0.0",
         "dotenv": "^16.0.0",
         "glob": "^7.1.3",
@@ -5649,11 +5648,6 @@
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
       }
-    },
-    "node_modules/codemirror": {
-      "version": "5.63.3",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.63.3.tgz",
-      "integrity": "sha512-1C+LELr+5grgJYqwZKqxrcbPsHFHapVaVAloBsFBASbpLnQqLw1U8yXJ3gT5D+rhxIiSpo+kTqN+hQ+9ialIXw=="
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@types/node-fetch": "2.6.11",
     "apollo-datasource": "^0.8.0",
     "await-to-js": "^3.0.0",
-    "codemirror": "^5.63.3",
     "cosmiconfig": "^9.0.0",
     "dotenv": "^16.0.0",
     "glob": "^7.1.3",

--- a/src/language-server/typings/codemirror.d.ts
+++ b/src/language-server/typings/codemirror.d.ts
@@ -1,4 +1,0 @@
-// `codemirror` types have some issues, and this isn't really being used anyways
-declare module "codemirror" {
-  type Token = any;
-}


### PR DESCRIPTION
closes #127

I have no solid idea why this is there, it's not referenced in code anywhere.

Seems like it was added in #34 in this commit: [`5ad99fb` (#34)](https://github.com/apollographql/vscode-graphql/pull/34/commits/5ad99fb69bce55f33c73676e69abb42bfde095e1)

>  Install codemirror
>
> Seems like the updated `graphql-language-service-interface` has this as an implicit peer dependency
>
> Add `codemirror` types

It seems that has been inlined upsteam, at least I cannot find any references to the `codemirror` package in `graphql-language-service`, which recently replaced `graphql-language-service-interface`