### PR TITLE
"graphql-object-field": highlighting "string" -> "variable"

### DIFF
--- a/.changeset/chatty-toes-hammer.md
+++ b/.changeset/chatty-toes-hammer.md
@@ -1,0 +1,5 @@
+---
+"vscode-apollo": patch
+---
+
+Change syntax highlighting of graphql object fields from "string" to "variable".

--- a/syntaxes/graphql.json
+++ b/syntaxes/graphql.json
@@ -601,8 +601,8 @@
     "graphql-object-field": {
       "match": "\\s*(([_A-Za-z][_0-9A-Za-z]*))\\s*(:)",
       "captures": {
-        "1": { "name": "constant.object.key.graphql" },
-        "2": { "name": "string.unquoted.graphql" },
+        "1": { "name": "string.unquoted.graphql" },
+        "2": { "name": "variable.object.key.graphql" },
         "3": { "name": "punctuation.graphql" }
       }
     },


### PR DESCRIPTION
Prioritizes "constant.object.key.graphql" over "string.unquoted.graphql", changes "constant" to "variable".

This makes nested objects in graphql arguments look more in-line.

Snippet for testing:

```graphql
type Query {
  users: [User] @auth(
    role: User,
    permissions: {
      write: true
#     ^^^^^ funny how GitHub also highlights this as a string here
    }
  )
}

enum Role {
  User
  Admin
}

type User {
  id: ID!
  name: String!
}

input Permissions {
  read: Boolean
  write: Boolean
}

directive @auth(role: Role, permissions: Permissions) on FIELD_DEFINITION
```

Without these changes:

![image](https://github.com/user-attachments/assets/642f11d9-fbd5-4ff3-ac1b-2e569edeafb6)

With these changes:

![image](https://github.com/user-attachments/assets/8df96d8d-802c-408d-818c-d4336ca1224c)


Note that after these changes `write` is highlighted the same as `role` or `permissions`.