### PR TITLE
Fix "Toggle Line Comment"

### DIFF
--- a/.changeset/fresh-spoons-lie.md
+++ b/.changeset/fresh-spoons-lie.md
@@ -1,0 +1,5 @@
+---
+"vscode-apollo": patch
+---
+
+Fix "Toggle Line Comment"

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -10,7 +10,6 @@ src
 .prettierrc
 .gitattributes
 codegen.yml
-graphql.configuration.json
 jest.*.ts
 jest.*.js
 package-lock.json


### PR DESCRIPTION
For some reason, this file was added to `.vscodeignore` back in #26 and since then, "Toggle Line Comment" was broken, except in our local development builds.