### PR TITLE
Change default recommended configuration file format to `json`.

### DIFF
--- a/.changeset/fuzzy-fireants-exercise.md
+++ b/.changeset/fuzzy-fireants-exercise.md
@@ -1,5 +1,5 @@
 ---
-"vscode-apollo": patch
+"vscode-apollo": minor
 ---
 
 Change default recommended configuration file format to `json`.

--- a/.changeset/fuzzy-fireants-exercise.md
+++ b/.changeset/fuzzy-fireants-exercise.md
@@ -1,0 +1,5 @@
+---
+"vscode-apollo": patch
+---
+
+Change default recommended configuration file format to `json`.

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ To link a project to a published schema, edit the `apollo.config.json` file to l
 ```json
 {
   "client": {
-    "service": "graphos-graph-id",
-  },
-};
+    "service": "graphos-graph-id"
+  }
+}
 ```
 
 The `service` name is the name of the graph you've created in [GraphOS Studio](https://studio.apollographql.com).
@@ -89,10 +89,10 @@ Sometimes it may make sense to link the editor to a locally running version of a
   "client": {
     "service": {
       "name": "my-graphql-app",
-      "url": "http://localhost:4000/graphql",
-    },
-  },
-};
+      "url": "http://localhost:4000/graphql"
+    }
+  }
+}
 ```
 
 Linking to the local schema won't provide all features, such as switching graph variants and performance metrics.
@@ -113,10 +113,10 @@ To link to a local schema file, add the following to the `apollo.config.json` fi
   "client": {
     "service": {
       // can be a string pointing to a single file or an array of strings
-      "localSchemaFile": "./path/to/schema.graphql",
-    },
-  },
-};
+      "localSchemaFile": "./path/to/schema.graphql"
+    }
+  }
+}
 ```
 
 </details>
@@ -134,9 +134,9 @@ Client side schema definitions can be spread throughout the client app project a
     // array of glob patterns
     "includes": ["./src/**/*.js"],
     // array of glob patterns
-    "excludes": ["**/__tests__/**"],
-  },
-};
+    "excludes": ["**/__tests__/**"]
+  }
+}
 ```
 
 <h3 id="get-the-extension">Get the extension</h3>
@@ -218,11 +218,11 @@ _Optional_ - custom tagged template literal.
 
 When using GraphQL with JavaScript or TypeScript projects, it is common to use the `gql` tagged template literal to write out operations. Apollo tools look through your files for the `gql` tag to extract your queries, so if you use a different template literal, you can configure it like so:
 
-```js
-module.exports = {
-  client: {
-    tagName: "graphql", // highlight-line
-    service: ...
+```json
+{
+  "client": {
+    "tagName": "graphql",
+    "service": //...
   }
-};
+}
 ```

--- a/README.md
+++ b/README.md
@@ -35,22 +35,17 @@ For the contents of this configuration file, select one of these options:
 
 <details>
 <summary>
-<h3>Setting the Extension up for use with Apollo GraphOS</h3>
+<h3>Configure extension for schemas published to Apollo GraphOS</h3>
 </summary>
 
-To get all the benefits of the VS Code experience, it's best to link the schema that is being developed against before installing the extension. The best way to do that is by [publishing a schema](https://www.apollographql.com/docs/graphos/delivery/publishing-schemas/) to the Apollo schema registry. After that's done:
+To get all the benefits of the VS Code experience, it's best to link the schema that is being developed against before installing the extension. The best way to do that is by [publishing a schema](https://www.apollographql.com/docs/graphos/delivery/publishing-schemas/) to the Apollo schema registry.
 
-1. Create an `apollo.config.json` file at the root of the project.
-2. Obtain a [Personal API key](https://www.apollographql.com/docs/graphos/api-keys) from GraphOS Studio.
-
-<h3 id="apollo-config">Setting up an Apollo config</h3>
-
-To link a project to a published schema, edit the `apollo.config.json` file to look like this:
+After that's done, edit the `apollo.config.json` file to look like this:
 
 ```json
 {
   "client": {
-    "service": "graphos-graph-id"
+    "service": "graphos-graph-name"
   }
 }
 ```
@@ -58,8 +53,6 @@ To link a project to a published schema, edit the `apollo.config.json` file to l
 The `service` name is the name of the graph you've created in [GraphOS Studio](https://studio.apollographql.com).
 
 See [additional configuration options](#additional-apollo-config-options).
-
-<h3 id="api-key">Setting up the <code>.env</code> file</h3>
 
 To authenticate with GraphOS Studio to pull down your schema, create a `.env` file in the same directory as the `apollo.config.json` file. This should be an untracked file (that is, don't commit it to Git).
 
@@ -79,7 +72,7 @@ After this is done, VS Code can be reloaded and the Apollo integration will conn
 
 <details>
 <summary>
-<h3 id="local-schemas">Setting the Extension up for use with a local schema</h3>
+<h3 id="local-schemas">Configure extension to use introspection from a locally running service</h3>
 </summary>
 
 Sometimes it may make sense to link the editor to a locally running version of a schema to try out new designs that are in active development. To do this, the `apollo.config.json` file can be linked to a local service definition:
@@ -101,7 +94,7 @@ Linking to the local schema won't provide all features, such as switching graph 
 
 <details>
 <summary>
-<h3 id="local-schema-files">Setting the Extension up for use with local schema files</h3>
+<h3 id="local-schema-files">Configure extension for local schema files</h3>
 </summary>
 
 You might not always have a running server to link to, so the extension also supports linking to a local schema file.

--- a/README.md
+++ b/README.md
@@ -26,25 +26,31 @@ The Apollo GraphQL extension for VS Code brings an all-in-one tooling experience
 
 <h2 id="getting-started">Getting started</h2>
 
+For the VS Code plugin to know how to find the schema, it needs to be linked to either a published schema or a local one.
+
+First, create an `apollo.config.json` file at the root of the project.
+Alternatively, you can create a `yaml`, `cjs`, `mjs`, or `ts` file with the same configuration.
+
+For the contents of this configuration file, select one of these options:
+
 <details>
 <summary>
-<h3>Setting the Extension up for use with GraphOS</h3>
+<h3>Setting the Extension up for use with Apollo GraphOS</h3>
 </summary>
 
 To get all the benefits of the VS Code experience, it's best to link the schema that is being developed against before installing the extension. The best way to do that is by [publishing a schema](https://www.apollographql.com/docs/graphos/delivery/publishing-schemas/) to the Apollo schema registry. After that's done:
 
 1. Create an `apollo.config.json` file at the root of the project.
-   Alternatively, you can create a `yaml`, `cjs`, `mjs`, or `ts` file with the same configuration.
 2. Obtain a [Personal API key](https://www.apollographql.com/docs/graphos/api-keys) from GraphOS Studio.
 
 <h3 id="apollo-config">Setting up an Apollo config</h3>
 
-For the VS Code plugin to know how to find the schema, it needs to be linked to either a published schema or a local one. To link a project to a published schema, edit the `apollo.config.json` file to look like this:
+To link a project to a published schema, edit the `apollo.config.json` file to look like this:
 
 ```json
 {
   "client": {
-    "service": "my-graphql-app",
+    "service": "graphos-graph-id",
   },
 };
 ```
@@ -124,7 +130,7 @@ Client side schema definitions can be spread throughout the client app project a
 ```json
 {
   "client": {
-    "service": "my-graphql-app",
+    // "service": <your service configuration>,
     // array of glob patterns
     "includes": ["./src/**/*.js"],
     // array of glob patterns

--- a/README.md
+++ b/README.md
@@ -26,20 +26,25 @@ The Apollo GraphQL extension for VS Code brings an all-in-one tooling experience
 
 <h2 id="getting-started">Getting started</h2>
 
+<details>
+<summary>
+<h3>Setting the Extension up for use with GraphOS</h3>
+</summary>
+
 To get all the benefits of the VS Code experience, it's best to link the schema that is being developed against before installing the extension. The best way to do that is by [publishing a schema](https://www.apollographql.com/docs/graphos/delivery/publishing-schemas/) to the Apollo schema registry. After that's done:
 
-1. Create an `apollo.config.js` file at the root of the project.
-   Alternatively, you can create a `cjs`, `mjs`, or `ts` file with the same configuration.
+1. Create an `apollo.config.json` file at the root of the project.
+   Alternatively, you can create a `yaml`, `cjs`, `mjs`, or `ts` file with the same configuration.
 2. Obtain a [Personal API key](https://www.apollographql.com/docs/graphos/api-keys) from GraphOS Studio.
 
 <h3 id="apollo-config">Setting up an Apollo config</h3>
 
-For the VS Code plugin to know how to find the schema, it needs to be linked to either a published schema or a local one. To link a project to a published schema, edit the `apollo.config.js` file to look like this:
+For the VS Code plugin to know how to find the schema, it needs to be linked to either a published schema or a local one. To link a project to a published schema, edit the `apollo.config.json` file to look like this:
 
-```js
-module.exports = {
-  client: {
-    service: "my-graphql-app",
+```json
+{
+  "client": {
+    "service": "my-graphql-app",
   },
 };
 ```
@@ -50,7 +55,7 @@ See [additional configuration options](#additional-apollo-config-options).
 
 <h3 id="api-key">Setting up the <code>.env</code> file</h3>
 
-To authenticate with GraphOS Studio to pull down your schema, create a `.env` file in the same directory as the `apollo.config.js` file. This should be an untracked file (that is, don't commit it to Git).
+To authenticate with GraphOS Studio to pull down your schema, create a `.env` file in the same directory as the `apollo.config.json` file. This should be an untracked file (that is, don't commit it to Git).
 
 Then go to your [User Settings page](https://studio.apollographql.com/user-settings/api-keys?referrer=docs-content) in GraphOS Studio to create a new Personal API key.
 
@@ -64,16 +69,21 @@ APOLLO_KEY=<enter copied key here>
 
 After this is done, VS Code can be reloaded and the Apollo integration will connect to GraphOS Studio to provide autocomplete, validation, and more.
 
-<h3 id="local-schemas">Local schemas</h3>
+</details>
 
-Sometimes it may make sense to link the editor to a locally running version of a schema to try out new designs that are in active development. To do this, the `apollo.config.js` file can be linked to a local service definition:
+<details>
+<summary>
+<h3 id="local-schemas">Setting the Extension up for use with a local schema</h3>
+</summary>
 
-```js
-module.exports = {
-  client: {
-    service: {
-      name: "my-graphql-app",
-      url: "http://localhost:4000/graphql",
+Sometimes it may make sense to link the editor to a locally running version of a schema to try out new designs that are in active development. To do this, the `apollo.config.json` file can be linked to a local service definition:
+
+```json
+{
+  "client": {
+    "service": {
+      "name": "my-graphql-app",
+      "url": "http://localhost:4000/graphql",
     },
   },
 };
@@ -81,37 +91,44 @@ module.exports = {
 
 Linking to the local schema won't provide all features, such as switching graph variants and performance metrics.
 
-<h3 id="local-schema-files">Local schema files</h3>
+</details>
+
+<details>
+<summary>
+<h3 id="local-schema-files">Setting the Extension up for use with local schema files</h3>
+</summary>
 
 You might not always have a running server to link to, so the extension also supports linking to a local schema file.
 This is useful for working on a schema in isolation or for testing out new features.
-To link to a local schema file, add the following to the `apollo.config.js` file:
+To link to a local schema file, add the following to the `apollo.config.json` file:
 
-```js
-module.exports = {
-  client: {
-    service: {
+```json
+{
+  "client": {
+    "service": {
       // can be a string pointing to a single file or an array of strings
-      localSchemaFile: "./path/to/schema.graphql",
+      "localSchemaFile": "./path/to/schema.graphql",
     },
   },
 };
 ```
 
-<h3 id="client-only-schemas">Client-only schemas</h3>
+</details>
+
+<h3 id="client-only-schemas">Adding Client-only schemas</h3>
 
 One of the best features of the VS Code extension is the automatic merging of remote schemas and local ones when using integrated state management with Apollo Client. This happens automatically whenever schema definitions are found within a client project. By default, the VS Code extension will look for all JavaScript, TypeScript and GraphQL files under `./src` to find both the operations and schema definitions for building a complete schema for the application.
 
-Client side schema definitions can be spread throughout the client app project and will be merged together to create one single schema. The default behavior can be controlled by adding specifications to the `apollo.config.js`:
+Client side schema definitions can be spread throughout the client app project and will be merged together to create one single schema. The default behavior can be controlled by adding specifications to the `apollo.config.json`:
 
-```js
-module.exports = {
-  client: {
-    service: "my-graphql-app",
+```json
+{
+  "client": {
+    "service": "my-graphql-app",
     // array of glob patterns
-    includes: ["./src/**/*.js"],
+    "includes": ["./src/**/*.js"],
     // array of glob patterns
-    excludes: ["**/__tests__/**"],
+    "excludes": ["**/__tests__/**"],
   },
 };
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "graphql": "16.9.0",
         "graphql-language-service": "5.2.2",
         "graphql-tag": "2.12.6",
+        "jsonc-parser": "^3.3.1",
         "lodash.debounce": "4.0.8",
         "lodash.merge": "4.6.2",
         "lodash.throttle": "4.1.1",
@@ -10386,6 +10387,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "graphql": "16.9.0",
     "graphql-language-service": "5.2.2",
     "graphql-tag": "2.12.6",
+    "jsonc-parser": "^3.3.1",
     "lodash.debounce": "4.0.8",
     "lodash.merge": "4.6.2",
     "lodash.throttle": "4.1.1",
@@ -150,6 +151,12 @@
           "GraphQL"
         ],
         "configuration": "./graphql.configuration.json"
+      },
+      {
+        "id": "jsonc",
+        "filenames": [
+          "apollo.config.json"
+        ]
       }
     ],
     "grammars": [

--- a/sampleWorkspace/localSchemaArray/apollo.config.json
+++ b/sampleWorkspace/localSchemaArray/apollo.config.json
@@ -1,6 +1,7 @@
 {
   "client": {
     "service": {
+      // test
       "name": "localMultiSchema",
       "localSchemaFile": ["./starwarsSchema.graphql", "./planets.graphql"]
     }

--- a/src/build.js
+++ b/src/build.js
@@ -27,6 +27,7 @@ async function main() {
       /* add to the end of plugins array */
       esbuildProblemMatcherPlugin,
       buildJsonSchemaPlugin,
+      resolvePlugin,
     ],
   });
   if (watch) {
@@ -86,6 +87,19 @@ const buildJsonSchemaPlugin = {
         JSON.stringify(jsonSchema, null, 2),
       );
     });
+  },
+};
+
+const resolvePlugin = {
+  name: "resolve",
+  setup(build) {
+    console.log("setup");
+    build.onResolve(
+      { filter: /^jsonc-parser$/ },
+      async ({ path, ...options }) => {
+        return build.resolve("jsonc-parser/lib/esm/main.js", options);
+      },
+    );
   },
 };
 

--- a/src/build.js
+++ b/src/build.js
@@ -93,7 +93,6 @@ const buildJsonSchemaPlugin = {
 const resolvePlugin = {
   name: "resolve",
   setup(build) {
-    console.log("setup");
     build.onResolve(
       { filter: /^jsonc-parser$/ },
       async ({ path, ...options }) => {

--- a/src/language-server/config/__tests__/loadConfig.ts
+++ b/src/language-server/config/__tests__/loadConfig.ts
@@ -214,7 +214,7 @@ client:
 
     it("loads config from a json file", async () => {
       writeFilesToDir(dir, {
-        "apollo.config.json": `{"client": {"service": "hello"} }`,
+        "apollo.config.json": `{"client": /* testing jsonc */ {"service": "hello"} }`,
       });
       const config = await loadConfig({ configPath: dirPath });
       expect(config?.client?.service).toEqual("hello");

--- a/src/language-server/config/loadConfig.ts
+++ b/src/language-server/config/loadConfig.ts
@@ -10,7 +10,7 @@ import { getServiceFromKey } from "./utils";
 import { URI } from "vscode-uri";
 import { Debug } from "../utilities";
 import { loadTs } from "./loadTsConfig";
-import { ParseError, parse as parseJsonC } from "jsonc-parser/lib/esm/main.js";
+import { ParseError, parse as parseJsonC } from "jsonc-parser";
 
 // config settings
 const MODULE_NAME = "apollo";


### PR DESCRIPTION
This changes the default recommended configuration file format to `.json`.

I would prefer to make this `yaml` instead, but the configuration's JSON schema is natively supported  by VSCode for `.json` files and needs an additional extension to be installed by the user to support `.yaml` files, so I believe going this way will result in less onboarding friction.