### PR TITLE
Avoid detection if .js config file is ESM or CommonJs, just try both.

### DIFF
--- a/.changeset/silent-badgers-travel.md
+++ b/.changeset/silent-badgers-travel.md
@@ -1,0 +1,5 @@
+---
+"vscode-apollo": patch
+---
+
+Avoid detection if .js config file is ESM or CommonJs, just try both.

--- a/sampleWorkspace/configFileTypes/cjsConfig/apollo.config.cjs
+++ b/sampleWorkspace/configFileTypes/cjsConfig/apollo.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  client: {
+    service: {
+      name: "cjsConfig",
+      localSchemaFile: "./starwarsSchema.graphql",
+    },
+  },
+};

--- a/sampleWorkspace/configFileTypes/cjsConfig/package.json
+++ b/sampleWorkspace/configFileTypes/cjsConfig/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test",
+  "type": "module"
+}

--- a/sampleWorkspace/configFileTypes/cjsConfig/src/test.js
+++ b/sampleWorkspace/configFileTypes/cjsConfig/src/test.js
@@ -1,0 +1,8 @@
+import gql from "graphql-tag";
+gql`
+  query Test {
+    droid(id: "2000") {
+      name
+    }
+  }
+`;

--- a/sampleWorkspace/configFileTypes/cjsConfig/starwarsSchema.graphql
+++ b/sampleWorkspace/configFileTypes/cjsConfig/starwarsSchema.graphql
@@ -1,0 +1,1 @@
+../fixtures/starwarsSchema.graphql

--- a/sampleWorkspace/configFileTypes/jsConfigWithCJS/apollo.config.js
+++ b/sampleWorkspace/configFileTypes/jsConfigWithCJS/apollo.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  client: {
+    service: {
+      name: "jsConfigWithCJS",
+      localSchemaFile: "./starwarsSchema.graphql",
+    },
+  },
+};

--- a/sampleWorkspace/configFileTypes/jsConfigWithCJS/package.json
+++ b/sampleWorkspace/configFileTypes/jsConfigWithCJS/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test",
+  "type": "module"
+}

--- a/sampleWorkspace/configFileTypes/jsConfigWithCJS/src/test.js
+++ b/sampleWorkspace/configFileTypes/jsConfigWithCJS/src/test.js
@@ -1,0 +1,8 @@
+import gql from "graphql-tag";
+gql`
+  query Test {
+    droid(id: "2000") {
+      name
+    }
+  }
+`;

--- a/sampleWorkspace/configFileTypes/jsConfigWithCJS/starwarsSchema.graphql
+++ b/sampleWorkspace/configFileTypes/jsConfigWithCJS/starwarsSchema.graphql
@@ -1,0 +1,1 @@
+../fixtures/starwarsSchema.graphql

--- a/sampleWorkspace/configFileTypes/jsConfigWithESM/apollo.config.js
+++ b/sampleWorkspace/configFileTypes/jsConfigWithESM/apollo.config.js
@@ -1,0 +1,8 @@
+export default {
+  client: {
+    service: {
+      name: "jsConfigWithESM",
+      localSchemaFile: "./starwarsSchema.graphql",
+    },
+  },
+};

--- a/sampleWorkspace/configFileTypes/jsConfigWithESM/package.json
+++ b/sampleWorkspace/configFileTypes/jsConfigWithESM/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test",
+  "type": "commonjs"
+}

--- a/sampleWorkspace/configFileTypes/jsConfigWithESM/src/test.js
+++ b/sampleWorkspace/configFileTypes/jsConfigWithESM/src/test.js
@@ -1,0 +1,8 @@
+import gql from "graphql-tag";
+gql`
+  query Test {
+    droid(id: "2000") {
+      name
+    }
+  }
+`;

--- a/sampleWorkspace/configFileTypes/jsConfigWithESM/starwarsSchema.graphql
+++ b/sampleWorkspace/configFileTypes/jsConfigWithESM/starwarsSchema.graphql
@@ -1,0 +1,1 @@
+../fixtures/starwarsSchema.graphql

--- a/sampleWorkspace/configFileTypes/mjsConfig/apollo.config.mjs
+++ b/sampleWorkspace/configFileTypes/mjsConfig/apollo.config.mjs
@@ -1,0 +1,8 @@
+export default {
+  client: {
+    service: {
+      name: "mjsConfig",
+      localSchemaFile: "./starwarsSchema.graphql",
+    },
+  },
+};

--- a/sampleWorkspace/configFileTypes/mjsConfig/package.json
+++ b/sampleWorkspace/configFileTypes/mjsConfig/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test",
+  "type": "commonjs"
+}

--- a/sampleWorkspace/configFileTypes/mjsConfig/src/test.js
+++ b/sampleWorkspace/configFileTypes/mjsConfig/src/test.js
@@ -1,0 +1,8 @@
+import gql from "graphql-tag";
+gql`
+  query Test {
+    droid(id: "2000") {
+      name
+    }
+  }
+`;

--- a/sampleWorkspace/configFileTypes/mjsConfig/starwarsSchema.graphql
+++ b/sampleWorkspace/configFileTypes/mjsConfig/starwarsSchema.graphql
@@ -1,0 +1,1 @@
+../fixtures/starwarsSchema.graphql

--- a/sampleWorkspace/configFileTypes/tsConfigWithCJS/apollo.config.ts
+++ b/sampleWorkspace/configFileTypes/tsConfigWithCJS/apollo.config.ts
@@ -1,0 +1,8 @@
+module.exports = {
+  client: {
+    service: {
+      name: "tsConfigWithCJS",
+      localSchemaFile: "./starwarsSchema.graphql",
+    },
+  },
+};

--- a/sampleWorkspace/configFileTypes/tsConfigWithCJS/package.json
+++ b/sampleWorkspace/configFileTypes/tsConfigWithCJS/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test",
+  "type": "module"
+}

--- a/sampleWorkspace/configFileTypes/tsConfigWithCJS/src/test.js
+++ b/sampleWorkspace/configFileTypes/tsConfigWithCJS/src/test.js
@@ -1,0 +1,8 @@
+import gql from "graphql-tag";
+gql`
+  query Test {
+    droid(id: "2000") {
+      name
+    }
+  }
+`;

--- a/sampleWorkspace/configFileTypes/tsConfigWithCJS/starwarsSchema.graphql
+++ b/sampleWorkspace/configFileTypes/tsConfigWithCJS/starwarsSchema.graphql
@@ -1,0 +1,1 @@
+../fixtures/starwarsSchema.graphql

--- a/sampleWorkspace/configFileTypes/tsConfigWithESM/apollo.config.ts
+++ b/sampleWorkspace/configFileTypes/tsConfigWithESM/apollo.config.ts
@@ -1,0 +1,8 @@
+export default {
+  client: {
+    service: {
+      name: "tsConfigWithESM",
+      localSchemaFile: "./starwarsSchema.graphql",
+    },
+  },
+};

--- a/sampleWorkspace/configFileTypes/tsConfigWithESM/package.json
+++ b/sampleWorkspace/configFileTypes/tsConfigWithESM/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test",
+  "type": "commonjs"
+}

--- a/sampleWorkspace/configFileTypes/tsConfigWithESM/src/test.js
+++ b/sampleWorkspace/configFileTypes/tsConfigWithESM/src/test.js
@@ -1,0 +1,8 @@
+import gql from "graphql-tag";
+gql`
+  query Test {
+    droid(id: "2000") {
+      name
+    }
+  }
+`;

--- a/sampleWorkspace/configFileTypes/tsConfigWithESM/starwarsSchema.graphql
+++ b/sampleWorkspace/configFileTypes/tsConfigWithESM/starwarsSchema.graphql
@@ -1,0 +1,1 @@
+../fixtures/starwarsSchema.graphql

--- a/sampleWorkspace/sampleWorkspace.code-workspace
+++ b/sampleWorkspace/sampleWorkspace.code-workspace
@@ -19,6 +19,9 @@
       "path": "rover"
     },
     {
+      "path": "configFileTypes"
+    },
+    {
       "path": "../src/language-server/__tests__/fixtures/documents"
     }
   ],

--- a/src/language-server/__e2e__/configFileTypes.e2e.ts
+++ b/src/language-server/__e2e__/configFileTypes.e2e.ts
@@ -1,0 +1,33 @@
+import { writeFile } from "fs/promises";
+import {
+  reloadService,
+  waitForLSP,
+  resolveRelativeToSampleWorkspace,
+} from "./utils";
+
+test.each([
+  ["jsConfigWithCJS", "commonjs"],
+  ["jsConfigWithCJS", "module"],
+  ["jsConfigWithESM", "module"],
+  ["jsConfigWithESM", "commonjs"],
+  ["tsConfigWithCJS", "commonjs"],
+  ["tsConfigWithCJS", "module"],
+  ["tsConfigWithESM", "module"],
+  ["tsConfigWithESM", "commonjs"],
+] as const)("%s with `type: '%s'`", async (project, moduleType) => {
+  await writeFile(
+    resolveRelativeToSampleWorkspace(`configFileTypes/${project}/package.json`),
+    JSON.stringify(
+      {
+        name: "test",
+        type: moduleType,
+      },
+      undefined,
+      2,
+    ),
+    "utf-8",
+  );
+  await reloadService();
+  const stats = await waitForLSP(`configFileTypes/${project}/src/test.js`);
+  expect(stats.serviceId).toBe(project);
+});

--- a/src/language-server/__e2e__/configFileTypes.e2e.ts
+++ b/src/language-server/__e2e__/configFileTypes.e2e.ts
@@ -6,6 +6,10 @@ import {
 } from "./utils";
 
 test.each([
+  ["cjsConfig", "commonjs"],
+  ["cjsConfig", "module"],
+  ["mjsConfig", "module"],
+  ["mjsConfig", "commonjs"],
   ["jsConfigWithCJS", "commonjs"],
   ["jsConfigWithCJS", "module"],
   ["jsConfigWithESM", "module"],

--- a/src/language-server/__e2e__/utils.ts
+++ b/src/language-server/__e2e__/utils.ts
@@ -7,6 +7,7 @@ import { VSCodeGraphQLExtension } from "src/extension";
 function resolve(file: string) {
   return join(__dirname, "..", "..", "..", "sampleWorkspace", file);
 }
+export { resolve as resolveRelativeToSampleWorkspace };
 
 export async function closeAllEditors() {
   while (vscode.window.visibleTextEditors.length > 0) {
@@ -46,7 +47,7 @@ export function waitForLSP(file: string) {
       uri.toString(),
     );
     expect(stats.loaded).toBe(true);
-    return stats;
+    return stats as ProjectStats & { loaded: true };
   });
 }
 

--- a/src/language-server/config/cache-busting-resolver.js
+++ b/src/language-server/config/cache-busting-resolver.js
@@ -24,20 +24,12 @@ async function resolve(specifier, context, nextResolve) {
   if (context.importAttributes.as !== "cachebust") {
     return nextResolve(specifier, context);
   }
-  if (context.importAttributes.format) {
-    // no need to resolve at all, we have all necessary information
-    return {
-      url: bustFileName(specifier),
-      format: context.importAttributes.format,
-      importAttributes: context.importAttributes,
-      shortCircuit: true,
-    };
-  }
-  const result = await nextResolve(specifier, context);
+  // no need to resolve at all, we have all necessary information
   return {
-    ...result,
-    url: bustFileName(result.url),
+    url: bustFileName(specifier),
+    format: context.importAttributes.format,
     importAttributes: context.importAttributes,
+    shortCircuit: true,
   };
 }
 

--- a/src/language-server/config/cache-busting-resolver.types.ts
+++ b/src/language-server/config/cache-busting-resolver.types.ts
@@ -4,7 +4,7 @@ export type ImportAttributes =
   | {
       as: "cachebust";
       contents: string;
-      format?: Format;
+      format: Format;
     }
   | { as?: undefined };
 

--- a/src/language-server/config/loadTsConfig.ts
+++ b/src/language-server/config/loadTsConfig.ts
@@ -92,15 +92,39 @@ function resolveTsConfig(directory: string): any {
 }
 
 export const loadJs: Loader = async function loadJs(filepath, contents) {
-  return (
-    await import(
-      filepath, // @ts-ignore
-      {
-        with: {
-          as: "cachebust",
-          contents,
-        } satisfies ImportAttributes,
-      }
-    )
-  ).default;
+  try {
+    return (
+      await import(
+        filepath, // @ts-ignore
+        {
+          with: {
+            as: "cachebust",
+            contents,
+            format: "module",
+          } satisfies ImportAttributes,
+        }
+      )
+    ).default;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      // [ERROR] ReferenceError: module is not defined in ES module scope
+      error.message.includes("module is not defined")
+    ) {
+      return (
+        await import(
+          filepath, // @ts-ignore
+          {
+            with: {
+              as: "cachebust",
+              contents,
+              format: "commonjs",
+            } satisfies ImportAttributes,
+          }
+        )
+      ).default;
+    } else {
+      throw error;
+    }
+  }
 };


### PR DESCRIPTION
This came up here: https://github.com/apollographql/vscode-graphql/issues/187#issuecomment-2358950870

Because we relied on the original `resolve` call to determine if a file was a module or commonjs, that call would apply the normal ESM detection logic - if your `package.json` had `type: 'module'`, this means that your config file could not be CommonJS anymore.

This approach now just tries to load it as ESM and if that fails tries again with CJS - we do the same for TypeScript already.