### PR TITLE
adjust Rover debug logging to use tracing level

### DIFF
--- a/src/language-server/project/rover/DocumentSynchronization.ts
+++ b/src/language-server/project/rover/DocumentSynchronization.ts
@@ -23,7 +23,7 @@ import {
   rangeInContainingDocument,
 } from "../../utilities/source";
 import { URI } from "vscode-uri";
-import { DEBUG } from "./project";
+import { Debug } from "../../utilities";
 
 export interface FilePart {
   fractionalIndex: string;
@@ -285,7 +285,7 @@ export class DocumentSynchronization {
   }
 
   handlePartDiagnostics(params: PublishDiagnosticsParams) {
-    DEBUG && console.log("Received diagnostics", params);
+    Debug.traceVerbose("Received diagnostics", params);
     const uriDetails = splitUri(params.uri);
     const found = this.knownFiles.get(uriDetails.uri);
     if (!found || found.source === "lsp") {

--- a/src/language-server/server.ts
+++ b/src/language-server/server.ts
@@ -7,6 +7,7 @@ import {
   TextDocumentSyncKind,
   SymbolInformation,
   FileEvent,
+  SetTraceNotification,
 } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { type QuickPickItem } from "vscode";
@@ -25,6 +26,7 @@ import { GraphQLProject } from "./project/base";
 import type { LanguageIdExtensionMap } from "../tools/utilities/languageInformation";
 import { setLanguageIdExtensionMap } from "./utilities/languageIdForExtension";
 import { envFileNames, supportedConfigFileNames } from "./config";
+import { TraceLevel } from "./utilities/debug";
 
 export type InitializationOptions = {
   languageIdExtensionMap: LanguageIdExtensionMap;
@@ -92,11 +94,16 @@ workspace.onConfigFilesFound(async (params) => {
   );
 });
 
+connection.onNotification(SetTraceNotification.type, ({ value }) => {
+  Debug.traceLevel = value;
+});
+
 connection.onInitialize(
-  async ({ capabilities, workspaceFolders, initializationOptions }) => {
+  async ({ capabilities, workspaceFolders, initializationOptions, trace }) => {
     const { languageIdExtensionMap } =
       initializationOptions as InitializationOptions;
     setLanguageIdExtensionMap(languageIdExtensionMap);
+    Debug.traceLevel = trace;
 
     hasWorkspaceFolderCapability = !!(
       capabilities.workspace && capabilities.workspace.workspaceFolders

--- a/src/language-server/server.ts
+++ b/src/language-server/server.ts
@@ -26,7 +26,6 @@ import { GraphQLProject } from "./project/base";
 import type { LanguageIdExtensionMap } from "../tools/utilities/languageInformation";
 import { setLanguageIdExtensionMap } from "./utilities/languageIdForExtension";
 import { envFileNames, supportedConfigFileNames } from "./config";
-import { TraceLevel } from "./utilities/debug";
 
 export type InitializationOptions = {
   languageIdExtensionMap: LanguageIdExtensionMap;


### PR DESCRIPTION
Some clean up in preparation on a release. 
We don't need a `DEBUG` constant, there is already a "tracing" level built into VSCode, and it's enabled for the extension via the setting in 
https://github.com/apollographql/vscode-graphql/blob/5449afbe7e4835630efbdfd9555d85a8c9888a87/package.json#L118-L128