### PR TITLE
Simplify Rover debugging

### DIFF
--- a/src/language-server/project/rover/project.ts
+++ b/src/language-server/project/rover/project.ts
@@ -179,6 +179,9 @@ export class RoverProject extends GraphQLProject {
     if (this.config.rover.supergraphConfig) {
       args.push("--supergraph-config", this.config.rover.supergraphConfig);
     }
+    if (Debug.traceLevel >= TraceLevel.verbose) {
+      args.push("--log", "debug");
+    }
     args.push(...this.config.rover.extraArgs);
 
     Debug.traceVerbose(

--- a/src/language-server/project/rover/project.ts
+++ b/src/language-server/project/rover/project.ts
@@ -185,7 +185,7 @@ export class RoverProject extends GraphQLProject {
       `starting ${this.config.rover.bin} '${args.join("' '")}'`,
     );
     const child = cp.spawn(this.config.rover.bin, args, {
-      env: {NO_COLOR: "1"},
+      env: { NO_COLOR: "1" },
       stdio: [
         "pipe",
         "pipe",

--- a/src/language-server/project/rover/project.ts
+++ b/src/language-server/project/rover/project.ts
@@ -185,8 +185,7 @@ export class RoverProject extends GraphQLProject {
       `starting ${this.config.rover.bin} '${args.join("' '")}'`,
     );
     const child = cp.spawn(this.config.rover.bin, args, {
-      env:
-        Debug.traceLevel >= TraceLevel.verbose ? { RUST_BACKTRACE: "1" } : {},
+      env: {NO_COLOR: "1"},
       stdio: [
         "pipe",
         "pipe",


### PR DESCRIPTION
Gets rid of the colors & special ANSI stuff from output _all_ the time, and sets the log level to debug when in verbose mode.