### PR TITLE
Fix a situation where config files using `require` would not be imported as CommonJS.

### DIFF
--- a/.changeset/unlucky-apricots-report.md
+++ b/.changeset/unlucky-apricots-report.md
@@ -1,0 +1,5 @@
+---
+"vscode-apollo": patch
+---
+
+Fix a situation where config files using `require` would not be imported as CommonJS.

--- a/src/language-server/config/loadTsConfig.ts
+++ b/src/language-server/config/loadTsConfig.ts
@@ -93,7 +93,8 @@ export const loadJs: Loader = async function loadJs(filepath, contents) {
     if (
       error instanceof Error &&
       // [ERROR] ReferenceError: module is not defined in ES module scope
-      error.message.includes("module is not defined")
+      // [ERROR] ReferenceError: require is not defined in ES module scope
+      error.message.includes("is not defined in ES module scope")
     ) {
       return loadCachebustedJs(filepath, contents, "commonjs");
     } else {


### PR DESCRIPTION
Reported in #187 