### PR TITLE
fix importAttributes is not avaliable in old node versions

### DIFF
--- a/.changeset/smooth-dodos-build.md
+++ b/.changeset/smooth-dodos-build.md
@@ -2,4 +2,4 @@
 "vscode-apollo": patch
 ---
 
-Fix config files are unable to load in old VSCode versions
+Fixes config files being unable to load in old VSCode versions

--- a/.changeset/smooth-dodos-build.md
+++ b/.changeset/smooth-dodos-build.md
@@ -1,0 +1,5 @@
+---
+"vscode-apollo": patch
+---
+
+Fix config files are unable to load in old VSCode versions

--- a/src/language-server/config/cache-busting-resolver.js
+++ b/src/language-server/config/cache-busting-resolver.js
@@ -5,7 +5,7 @@ const { pathToFileURL } = require("node:url");
 
 /**
  * importAssertions was renamed to importAttributes after following versions of Node.js.
- * Once we hit a minimum of 1.92, we can remove the legacy check and
+ * Once we hit a minimum of v1.92 of VSCode, we can remove the legacy check and
  * use `importAttributes` directly.
  *
  * - v21.0.0

--- a/src/language-server/config/cache-busting-resolver.js
+++ b/src/language-server/config/cache-busting-resolver.js
@@ -1,7 +1,6 @@
 // @ts-check
 const { pathToFileURL } = require("node:url");
 
-/** @import { ResolveContext, ResolutionResult, LoadResult, ImportContext } from "./cache-busting-resolver.types" */
 /** @import { ResolveContext, ResolutionResult, LoadResult, ImportContext,ImportAttributes } from "./cache-busting-resolver.types" */
 /**
  * importAssertions was renamed to importAttributes in newer versions of Node.js.

--- a/src/language-server/config/cache-busting-resolver.js
+++ b/src/language-server/config/cache-busting-resolver.js
@@ -1,7 +1,7 @@
 // @ts-check
 const { pathToFileURL } = require("node:url");
 
-/** @import { ResolveContext, ResolutionResult, LoadResult, ImportContext,ImportAttributes } from "./cache-busting-resolver.types" */
+/** @import { ResolveContext, ResolutionResult, LoadResult, ImportContext, ImportAttributes } from "./cache-busting-resolver.types" */
 /**
  * importAssertions was renamed to importAttributes in newer versions of Node.js.
  *

--- a/src/language-server/config/cache-busting-resolver.js
+++ b/src/language-server/config/cache-busting-resolver.js
@@ -106,7 +106,7 @@ async function load(url, context, nextLoad) {
   const contents =
     "contents" in importAttributes
       ? importAttributes.contents
-      : Object.keys(importAttributes)[1];
+      : Object.keys(importAttributes).find((key) => key != "as");
   return {
     format,
     shortCircuit: true,

--- a/src/language-server/config/cache-busting-resolver.js
+++ b/src/language-server/config/cache-busting-resolver.js
@@ -9,7 +9,6 @@ const { pathToFileURL } = require("node:url");
  * @param {ResolveContext|ImportContext} context
  * @returns {boolean}
  */
-
 function isImportAttributesAvailable(context) {
   return "importAttributes" in context;
 }

--- a/src/language-server/config/cache-busting-resolver.js
+++ b/src/language-server/config/cache-busting-resolver.js
@@ -110,7 +110,7 @@ async function load(url, context, nextLoad) {
   return {
     format,
     shortCircuit: true,
-    source: contents,
+    source: /** @type {string} */ (contents),
   };
 }
 

--- a/src/language-server/config/cache-busting-resolver.js
+++ b/src/language-server/config/cache-busting-resolver.js
@@ -18,7 +18,7 @@ function isImportAttributesAvailable(context) {
  * @param {ResolveContext|ImportContext} context
  * @returns {"importAttributes"|"importAssertions"}
  */
-function importAttributesKeyName(context) {
+function resolveImportAttributesKeyName(context) {
   if (isImportAttributesAvailable(context)) {
     return "importAttributes";
   }
@@ -63,7 +63,7 @@ async function resolve(specifier, context, nextResolve) {
   return {
     url: bustFileName(specifier),
     format,
-    [importAttributesKeyName(context)]: importAttributes,
+    [resolveImportAttributesKeyName(context)]: importAttributes,
     shortCircuit: true,
   };
 }

--- a/src/language-server/config/cache-busting-resolver.js
+++ b/src/language-server/config/cache-busting-resolver.js
@@ -29,10 +29,10 @@ function resolveImportAttributesKeyName(context) {
  * @returns {ImportAttributes}
  */
 function resolveImportAttributes(context) {
-  if (!isImportAttributesAvailable(context)) {
-    return context.importAssertions;
+  if (isImportAttributesAvailable(context)) {
+    return context.importAttributes;
   }
-  return context.importAttributes;
+  return context.importAssertions;
 }
 
 /**

--- a/src/language-server/config/cache-busting-resolver.js
+++ b/src/language-server/config/cache-busting-resolver.js
@@ -6,7 +6,7 @@ const { pathToFileURL } = require("node:url");
  * importAssertions was renamed to importAttributes in newer versions of Node.js.
  *
  * @param {ResolveContext|ImportContext} context
- * @returns {boolean}
+ * @returns {context is {importAttributes: ImportAttributes}}
  */
 function isImportAttributesAvailable(context) {
   return "importAttributes" in context;

--- a/src/language-server/config/cache-busting-resolver.js
+++ b/src/language-server/config/cache-busting-resolver.js
@@ -2,7 +2,7 @@
 const { pathToFileURL } = require("node:url");
 
 /** @import { ResolveContext, ResolutionResult, LoadResult, ImportContext } from "./cache-busting-resolver.types" */
-
+/** @import { ResolveContext, ResolutionResult, LoadResult, ImportContext,ImportAttributes } from "./cache-busting-resolver.types" */
 /**
  * importAssertions was renamed to importAttributes in newer versions of Node.js.
  *

--- a/src/language-server/config/cache-busting-resolver.js
+++ b/src/language-server/config/cache-busting-resolver.js
@@ -15,8 +15,6 @@ function isImportAttributesAvailable(context) {
 }
 
 /**
- * importAssertions was renamed to importAttributes in newer versions of Node.js.
- *
  * @param {ResolveContext|ImportContext} context
  * @returns {"importAttributes"|"importAssertions"}
  */
@@ -28,8 +26,6 @@ function importAttributesKeyName(context) {
 }
 
 /**
- * importAssertions was renamed to importAttributes in newer versions of Node.js.
- *
  * @param {ResolveContext|ImportContext} context
  * @returns {ImportAttributes}
  */

--- a/src/language-server/config/cache-busting-resolver.types.ts
+++ b/src/language-server/config/cache-busting-resolver.types.ts
@@ -2,12 +2,19 @@ import { pathToFileURL } from "node:url";
 
 export type ImportAttributes =
   | {
-      as: `cachebust:${"module" | "commonjs"}`;
+      as: `cachebust:${Format}`;
       contents: string;
     }
   | { as?: undefined };
 
-type Format =
+export type ImportAssertions =
+  | {
+      as: `cachebust:${Format}`;
+      [key: string]: string;
+    }
+  | { as?: undefined };
+
+export type Format =
   | "builtin"
   | "commonjs"
   | "json"
@@ -16,17 +23,26 @@ type Format =
   | null
   | undefined;
 
-export interface ResolveContext {
+export interface LegacyResolveContext {
   conditions: string[];
-  importAttributes?: ImportAttributes;
-  importAssertions: ImportAttributes;
+  importAssertions: ImportAssertions;
   parentURL?: string;
 }
 
+export interface ResolveContext {
+  conditions: string[];
+  importAttributes: ImportAttributes;
+  parentURL?: string;
+}
+
+export interface LegacyImportContext {
+  conditions: string[];
+  importAssertions: ImportAssertions;
+  format: Format;
+}
 export interface ImportContext {
   conditions: string[];
-  importAttributes?: ImportAttributes;
-  importAssertions: ImportAttributes;
+  importAttributes: ImportAttributes;
   format: Format;
 }
 

--- a/src/language-server/config/cache-busting-resolver.types.ts
+++ b/src/language-server/config/cache-busting-resolver.types.ts
@@ -4,6 +4,7 @@ export type ImportAttributes =
   | {
       as: `cachebust:${Format}`;
       contents: string;
+      format: Format;
     }
   | { as?: undefined };
 

--- a/src/language-server/config/cache-busting-resolver.types.ts
+++ b/src/language-server/config/cache-busting-resolver.types.ts
@@ -2,9 +2,8 @@ import { pathToFileURL } from "node:url";
 
 export type ImportAttributes =
   | {
-      as: "cachebust";
+      as: `cachebust:${"module" | "commonjs"}`;
       contents: string;
-      format: Format;
     }
   | { as?: undefined };
 

--- a/src/language-server/config/cache-busting-resolver.types.ts
+++ b/src/language-server/config/cache-busting-resolver.types.ts
@@ -19,13 +19,15 @@ type Format =
 
 export interface ResolveContext {
   conditions: string[];
-  importAttributes: ImportAttributes;
+  importAttributes?: ImportAttributes;
+  importAssertions: ImportAttributes;
   parentURL?: string;
 }
 
 export interface ImportContext {
   conditions: string[];
-  importAttributes: ImportAttributes;
+  importAttributes?: ImportAttributes;
+  importAssertions: ImportAttributes;
   format: Format;
 }
 

--- a/src/language-server/config/loadConfig.ts
+++ b/src/language-server/config/loadConfig.ts
@@ -73,16 +73,10 @@ export async function loadConfig({
 
   // search can fail if a file can't be parsed (ex: a nonsense js file) so we wrap in a try/catch
   let loadedConfig: ConfigResult<RawApolloConfigFormat>;
-  try {
-    loadedConfig = (await explorer.search(
-      configPath,
-    )) as ConfigResult<RawApolloConfigFormat>;
-  } catch (error) {
-    throw new Error(`A config file failed to load with options: ${JSON.stringify(
-      arguments[0],
-    )}.
-    The error was: ${error}`);
-  }
+  loadedConfig = (await explorer.search(
+    configPath,
+  )) as ConfigResult<RawApolloConfigFormat>;
+
 
   if (!loadedConfig || loadedConfig.isEmpty) {
     Debug.error(

--- a/src/language-server/config/loadConfig.ts
+++ b/src/language-server/config/loadConfig.ts
@@ -73,10 +73,16 @@ export async function loadConfig({
 
   // search can fail if a file can't be parsed (ex: a nonsense js file) so we wrap in a try/catch
   let loadedConfig: ConfigResult<RawApolloConfigFormat>;
-  loadedConfig = (await explorer.search(
-    configPath,
-  )) as ConfigResult<RawApolloConfigFormat>;
-
+  try {
+    loadedConfig = (await explorer.search(
+      configPath,
+    )) as ConfigResult<RawApolloConfigFormat>;
+  } catch (error) {
+    throw new Error(`A config file failed to load with options: ${JSON.stringify(
+      arguments[0],
+    )}.
+    The error was: ${error}`);
+  }
 
   if (!loadedConfig || loadedConfig.isEmpty) {
     Debug.error(

--- a/src/language-server/config/loadTsConfig.ts
+++ b/src/language-server/config/loadTsConfig.ts
@@ -117,10 +117,6 @@ async function loadCachebustedJs(
           as: `cachebust:${type}`,
           contents,
         } satisfies ImportAttributes,
-        assert: {
-          as: `cachebust:${type}`,
-          contents,
-        } satisfies ImportAttributes,
       }
     )
   ).default;

--- a/src/language-server/config/loadTsConfig.ts
+++ b/src/language-server/config/loadTsConfig.ts
@@ -113,9 +113,12 @@ async function loadCachebustedJs(
       // @ts-ignore
       {
         with: {
-          as: "cachebust",
+          as: `cachebust:${type}`,
           contents,
-          format: type,
+        } satisfies ImportAttributes,
+        assert: {
+          as: `cachebust:${type}`,
+          contents,
         } satisfies ImportAttributes,
       }
     )

--- a/src/language-server/config/loadTsConfig.ts
+++ b/src/language-server/config/loadTsConfig.ts
@@ -8,11 +8,11 @@ import { ImportAttributes } from "./cache-busting-resolver.types";
 // Copyright (c) 2015 David Clark licensed MIT. Full license can be found here:
 // https://github.com/cosmiconfig/cosmiconfig/blob/a5a842547c13392ebb89a485b9e56d9f37e3cbd3/LICENSE
 
-if (process.env.JEST_WORKER_ID === undefined) {
+try {
   register(
     pathToFileURL(require.resolve("./config/cache-busting-resolver.js")),
   );
-} else {
+} catch {
   register(pathToFileURL(require.resolve("./cache-busting-resolver.js")));
 }
 

--- a/src/language-server/config/loadTsConfig.ts
+++ b/src/language-server/config/loadTsConfig.ts
@@ -3,7 +3,10 @@ import { dirname, extname } from "node:path";
 import typescript from "typescript";
 import { pathToFileURL } from "node:url";
 import { register } from "node:module";
-import { ImportAttributes } from "./cache-busting-resolver.types";
+import {
+  ImportAssertions,
+  ImportAttributes,
+} from "./cache-busting-resolver.types";
 // implementation based on https://github.com/cosmiconfig/cosmiconfig/blob/a5a842547c13392ebb89a485b9e56d9f37e3cbd3/src/loaders.ts
 // Copyright (c) 2015 David Clark licensed MIT. Full license can be found here:
 // https://github.com/cosmiconfig/cosmiconfig/blob/a5a842547c13392ebb89a485b9e56d9f37e3cbd3/LICENSE
@@ -116,7 +119,13 @@ async function loadCachebustedJs(
         with: {
           as: `cachebust:${type}`,
           contents,
+          format: type,
         } satisfies ImportAttributes,
+        assert: {
+          as: `cachebust:${type}`,
+          contents,
+          format: type,
+        } satisfies ImportAssertions,
       }
     )
   ).default;


### PR DESCRIPTION
fix #225 

Tested with VSCode 1.91.1 (Node.js 20.9.0) and VSCode 1.94.0 (Node.js 20.16.0).