### PR TITLE
Add support for GraphQL in Notebooks

### DIFF
--- a/.changeset/wise-gorillas-greet.md
+++ b/.changeset/wise-gorillas-greet.md
@@ -1,0 +1,5 @@
+---
+"vscode-apollo": minor
+---
+
+Add support for GraphQL in Notebook cells

--- a/src/language-server/project/internal.ts
+++ b/src/language-server/project/internal.ts
@@ -48,6 +48,7 @@ const fileAssociations: { [extension: string]: string } = {
   ".re": "reason",
   ".ex": "elixir",
   ".exs": "elixir",
+  ".ipynb": "python",
 };
 
 export interface GraphQLInternalProjectConfig extends GraphQLProjectConfig {

--- a/src/language-server/server.ts
+++ b/src/language-server/server.ts
@@ -157,13 +157,14 @@ connection.onInitialized(async () => {
 });
 
 const documents = new TextDocuments(TextDocument);
+const schemes = ["file", "vscode-notebook-cell"];
 
 // Make the text document manager listen on the connection
 // for open, change and close text document events
 documents.listen(connection);
 
-function isFile(uri: string) {
-  return URI.parse(uri).scheme === "file";
+function isEnabledDocument(uri: string) {
+  return schemes.includes(URI.parse(uri).scheme);
 }
 
 documents.onDidChangeContent((params) => {
@@ -173,8 +174,7 @@ documents.onDidChangeContent((params) => {
   );
   if (!project) return;
 
-  // Only watch changes to files
-  if (!isFile(params.document.uri)) {
+  if (!isEnabledDocument(params.document.uri)) {
     return;
   }
 
@@ -213,8 +213,7 @@ connection.onDidChangeWatchedFiles((params) => {
       continue;
     }
 
-    // Only watch changes to files
-    if (!isFile(uri)) {
+    if (!isEnabledDocument(uri)) {
       continue;
     }
 

--- a/src/tools/utilities/languageInformation.ts
+++ b/src/tools/utilities/languageInformation.ts
@@ -30,7 +30,7 @@ export const minimumKnownExtensions: Record<
   typescriptreact: [".tsx"],
   vue: [".vue"],
   svelte: [".svelte"],
-  python: [".py"],
+  python: [".py", ".ipynb"],
   ruby: [".rb"],
   dart: [".dart"],
   reason: [".re"],


### PR DESCRIPTION
Small changes to extend the existing Python support in the extension to also work within Jupyter notebook code cells. This works across cells - a fragment defined in one cell can be used in another cell, and code navigation, validation, etc. works across cells.
<img width="548" alt="gql-notebook" src="https://github.com/user-attachments/assets/576bd869-0f09-4799-8109-7822de61e4ab">
