### PR TITLE
Fix detection of new Apollo configuration file

### DIFF
--- a/.changeset/many-trainers-think.md
+++ b/.changeset/many-trainers-think.md
@@ -1,0 +1,5 @@
+---
+"vscode-apollo": patch
+---
+
+Fix an issue where adding a new Apollo configuration file would not be detected

--- a/schemas/apollo.config.schema.json
+++ b/schemas/apollo.config.schema.json
@@ -12,9 +12,7 @@
               "$ref": "#/definitions/clientConfig"
             }
           },
-          "required": [
-            "client"
-          ],
+          "required": ["client"],
           "additionalProperties": false
         },
         {
@@ -24,9 +22,7 @@
               "$ref": "#/definitions/roverConfig"
             }
           },
-          "required": [
-            "rover"
-          ],
+          "required": ["rover"],
           "additionalProperties": false
         }
       ]
@@ -67,9 +63,7 @@
                   "description": "Skip SSL validation. May be required for self-signed certificates."
                 }
               },
-              "required": [
-                "url"
-              ],
+              "required": ["url"],
               "additionalProperties": false,
               "description": "Configuration for using a local schema from a URL."
             },
@@ -97,9 +91,7 @@
                   "description": "Path to a local schema file to use as GraphQL Schema for this project. Can be a string or an array of strings to merge multiple partial schemas into one."
                 }
               },
-              "required": [
-                "localSchemaFile"
-              ],
+              "required": ["localSchemaFile"],
               "additionalProperties": false,
               "description": "Configuration for using a local schema from a file."
             }
@@ -127,10 +119,7 @@
           "items": {
             "type": "string"
           },
-          "default": [
-            "**/node_modules",
-            "**/__tests__"
-          ],
+          "default": ["**/node_modules", "**/__tests__"],
           "description": "Files to exclude from this project. The Apollo GraphQL extension will not provide IntelliSense-like features in these files."
         },
         "tagName": {
@@ -157,9 +146,7 @@
           "description": "This option is no longer supported, please remove it from your configuration file."
         }
       },
-      "required": [
-        "service"
-      ],
+      "required": ["service"],
       "additionalProperties": false,
       "description": "Configuration for a Client project."
     },
@@ -175,10 +162,7 @@
           "description": "The name of the profile to use."
         },
         "supergraphConfig": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "description": "The path to your `supergraph.yaml` file. \nDefaults to a `supergraph.yaml` in the folder of your `apollo.config.json`, if there is one."
         },
         "extraArgs": {

--- a/schemas/apollo.config.schema.json
+++ b/schemas/apollo.config.schema.json
@@ -12,7 +12,9 @@
               "$ref": "#/definitions/clientConfig"
             }
           },
-          "required": ["client"],
+          "required": [
+            "client"
+          ],
           "additionalProperties": false
         },
         {
@@ -22,7 +24,9 @@
               "$ref": "#/definitions/roverConfig"
             }
           },
-          "required": ["rover"],
+          "required": [
+            "rover"
+          ],
           "additionalProperties": false
         }
       ]
@@ -63,7 +67,9 @@
                   "description": "Skip SSL validation. May be required for self-signed certificates."
                 }
               },
-              "required": ["url"],
+              "required": [
+                "url"
+              ],
               "additionalProperties": false,
               "description": "Configuration for using a local schema from a URL."
             },
@@ -91,7 +97,9 @@
                   "description": "Path to a local schema file to use as GraphQL Schema for this project. Can be a string or an array of strings to merge multiple partial schemas into one."
                 }
               },
-              "required": ["localSchemaFile"],
+              "required": [
+                "localSchemaFile"
+              ],
               "additionalProperties": false,
               "description": "Configuration for using a local schema from a file."
             }
@@ -119,7 +127,10 @@
           "items": {
             "type": "string"
           },
-          "default": ["**/node_modules", "**/__tests__"],
+          "default": [
+            "**/node_modules",
+            "**/__tests__"
+          ],
           "description": "Files to exclude from this project. The Apollo GraphQL extension will not provide IntelliSense-like features in these files."
         },
         "tagName": {
@@ -146,7 +157,9 @@
           "description": "This option is no longer supported, please remove it from your configuration file."
         }
       },
-      "required": ["service"],
+      "required": [
+        "service"
+      ],
       "additionalProperties": false,
       "description": "Configuration for a Client project."
     },
@@ -162,7 +175,10 @@
           "description": "The name of the profile to use."
         },
         "supergraphConfig": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "The path to your `supergraph.yaml` file. \nDefaults to a `supergraph.yaml` in the folder of your `apollo.config.json`, if there is one."
         },
         "extraArgs": {

--- a/src/language-server/workspace.ts
+++ b/src/language-server/workspace.ts
@@ -228,12 +228,12 @@ export class GraphQLWorkspace {
         folder: { uri: folderUri } as WorkspaceFolder,
       });
 
+      this.reloadService();
       const existingProjects = this.projectsByFolderUri.get(folderUri) || [];
       this.projectsByFolderUri.set(folderUri, [
         ...existingProjects,
         newProject,
       ]);
-      this.reloadService();
     }
   }
 

--- a/src/languageServerClient.ts
+++ b/src/languageServerClient.ts
@@ -52,9 +52,8 @@ export function getLanguageServerClient(
     documentSelector: supportedLanguageIds,
     synchronize: {
       fileEvents: [
-        workspace.createFileSystemWatcher(
-          "**/{.env?(.local),apollo.config.{json,yml,yaml}}",
-        ),
+        workspace.createFileSystemWatcher("**/{.env?(.local)}"),
+        workspace.createFileSystemWatcher("**/apollo.config.{json,yml,yaml}"),
         workspace.createFileSystemWatcher(
           "**/*{" + supportedExtensions.join(",") + "}",
         ),


### PR DESCRIPTION
Adding a new configuration file, such as `apollo.config.yaml` or `apollo.config.js`, was not being detected by the VS Code extension. This made it very confusing to try to set up the extension, because adding the config file would not cause the extension to start working. This was due to an incorrect glob pattern, which has been fixed.

Also fixes a race condition when detecting the new config file - it was creating the project, then calling `reloadService`, which immediately destroyed and created the project again, resulting in an error when trying to initialize the already disposed project.