### PR TITLE
Add block strings to GraphQL grammar

### DIFF
--- a/.changeset/kind-dodos-repair.md
+++ b/.changeset/kind-dodos-repair.md
@@ -1,0 +1,5 @@
+---
+"vscode-apollo": patch
+---
+
+Improve syntax highlighting for GraphQL block strings

--- a/syntaxes/graphql.json
+++ b/syntaxes/graphql.json
@@ -485,6 +485,19 @@
         "1": { "name": "constant.language.null.graphql" }
       }
     },
+    "graphql-block-string-value": {
+      "contentName": "string.quoted.triple.block.graphql",
+      "begin": "\\s*+((\"\"\"))",
+      "end": "\\s*+((\"\"\"))",
+      "beginCaptures": {
+        "1": { "name": "string.quoted.triple.block.graphql" },
+        "2": { "name": "punctuation.definition.string.begin.graphql" }
+      },
+      "endCaptures": {
+        "1": { "name": "string.quoted.triple.block.graphql" },
+        "2": { "name": "punctuation.definition.string.end.graphql" }
+      }
+    },
     "graphql-string-value": {
       "contentName": "string.quoted.double.graphql",
       "begin": "\\s*+((\"))",
@@ -553,6 +566,7 @@
       "patterns": [
         { "include": "#graphql-variable-name" },
         { "include": "#graphql-float-value" },
+        { "include": "#graphql-block-string-value" },
         { "include": "#graphql-string-value" },
         { "include": "#graphql-boolean-value" },
         { "include": "#graphql-null-value" },


### PR DESCRIPTION
The GraphQL TextMate grammar did not have separate handling for [block strings](https://spec.graphql.org/October2021/#sec-String-Value.Block-Strings), which are different from normal string values in that they may contain unescaped characters like quotes. Block strings were matching the `string.quoted.double.graphql` scope, which did not handle these unescaped characters, leading to incorrect results:

<img width="216" alt="Screenshot 2025-02-21 at 12 35 43 PM" src="https://github.com/user-attachments/assets/18b205cb-b9db-4105-bb36-efdcddb5813b" />

A new `string.quoted.triple.block.graphql` scope is defined, which matches everything up to the closing `"""`:

<img width="223" alt="Screenshot 2025-02-21 at 12 36 42 PM" src="https://github.com/user-attachments/assets/509ea47f-b6d7-4ac3-9bd3-43e733f0e9ef" />

This becomes more important with Apollo Connectors, where the `selection` attribute is often a block string containing mapping selection syntax that may contain special characters.
