### PR TITLE
Fix windows language server integration

### DIFF
--- a/src/language-server/__e2e__/configFileTypes.e2e.ts
+++ b/src/language-server/__e2e__/configFileTypes.e2e.ts
@@ -21,14 +21,14 @@ test.each([
 ] as const)("%s with `type: '%s'`", async (project, moduleType) => {
   await writeFile(
     resolveRelativeToSampleWorkspace(`configFileTypes/${project}/package.json`),
-    JSON.stringify(
+    `${JSON.stringify(
       {
         name: "test",
         type: moduleType,
       },
       undefined,
       2,
-    ),
+    )}\n`,
     "utf-8",
   );
   await reloadService();

--- a/src/language-server/__e2e__/rover.e2e.ts
+++ b/src/language-server/__e2e__/rover.e2e.ts
@@ -1,4 +1,3 @@
-import { test as origTest } from "@jest/globals";
 import { TextEditor } from "vscode";
 import {
   closeAllEditors,
@@ -10,12 +9,6 @@ import {
   getFullSemanticTokens,
   getDefinitions,
 } from "./utils";
-
-let test = origTest.skip;
-if (process.platform === "win32") {
-  console.info("Skipping rover E2E tests in Windows");
-  test = origTest.skip;
-}
 
 let editor: TextEditor;
 let getPosition: GetPositionFn;

--- a/src/language-server/__e2e__/rover.e2e.ts
+++ b/src/language-server/__e2e__/rover.e2e.ts
@@ -40,11 +40,11 @@ test("completion", async () => {
     "label": "@authenticated",
   },
   {
-    "detail": undefined,
+    "detail": "",
     "label": "@deprecated",
   },
   {
-    "detail": undefined,
+    "detail": "",
     "label": "@external",
   },
   {
@@ -52,7 +52,7 @@ test("completion", async () => {
     "label": "@inaccessible",
   },
   {
-    "detail": undefined,
+    "detail": "",
     "label": "@override(…)",
   },
   {
@@ -64,7 +64,7 @@ test("completion", async () => {
     "label": "@provides(…)",
   },
   {
-    "detail": undefined,
+    "detail": "",
     "label": "@requires(…)",
   },
   {
@@ -72,7 +72,7 @@ test("completion", async () => {
     "label": "@requiresScopes(…)",
   },
   {
-    "detail": undefined,
+    "detail": "",
     "label": "@shareable",
   },
   {
@@ -80,23 +80,23 @@ test("completion", async () => {
     "label": "@tag(…)",
   },
   {
-    "detail": undefined,
+    "detail": "",
     "label": "@federation__authenticated",
   },
   {
-    "detail": undefined,
+    "detail": "",
     "label": "@federation__inaccessible",
   },
   {
-    "detail": undefined,
+    "detail": "",
     "label": "@federation__policy(…)",
   },
   {
-    "detail": undefined,
+    "detail": "",
     "label": "@federation__provides(…)",
   },
   {
-    "detail": undefined,
+    "detail": "",
     "label": "@federation__requiresScopes(…)",
   },
   {

--- a/src/language-server/config/config.ts
+++ b/src/language-server/config/config.ts
@@ -322,8 +322,10 @@ export abstract class ApolloConfig {
   get configDirURI() {
     // if the filepath has a _file_ in it, then we get its dir
     return this.configURI &&
-      this.configURI.fsPath.match(/\.(ts|js|cjs|mjs|yaml|yml|json)$/i)
-      ? URI.parse(dirname(this.configURI.fsPath))
+      this.configURI.path.match(/\.(ts|js|cjs|mjs|yaml|yml|json)$/i)
+      ? URI.from(this.configURI).with({
+          path: dirname(this.configURI.path),
+        })
       : this.configURI;
   }
 


### PR DESCRIPTION
Requires: https://github.com/apollographql/vscode-graphql/pull/286
On windows, the rootUri and the file uris end up in different formats, different encoding but also different scheme with and without the drive letter.

We need the file URIs to start with the rootUri to know it belongs to the project, so what this does is does dirname on the raw `path` and modifies in in the same format so they should always match. 

We are also enabling the windows tests here.
You can see the tests failing on the [enable tests on windows](https://github.com/apollographql/vscode-graphql/pull/285/commits/3d05c775b593844628931def28432369c1f82c59) commit, and then they are fixed in [Use path instead of fsPath](https://github.com/apollographql/vscode-graphql/pull/285/commits/b5a9512f814e2f95519a590c941ca121ad1524ae)