### PR TITLE
🔧 Fix rover tests

### DIFF
--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -25,7 +25,17 @@ jobs:
       - run: npm install
       - run: echo 'APOLLO_KEY="service:bob-123:489fhseo4"' > ./sampleWorkspace/spotifyGraph/.env
         shell: bash
+
+      # Print rover version per OS
       - name: Install & Configure Rover (Linux)
+        run: ./node_modules/.bin/rover --version
+        if: runner.os == 'Linux'
+      - name: Install Rover (Windows)
+        run: ./node_modules/.bin/rover.cmd --version
+        if: runner.os == 'Windows'
+
+      # auth rover per OS
+      - name: Configure Rover (Linux)
         run: |
           expect <<EOF
           spawn ./node_modules/.bin/rover config auth --profile VSCode-E2E
@@ -34,9 +44,6 @@ jobs:
           expect eof
           EOF
         if: runner.os == 'Linux'
-      - name: Install Rover (Windows)
-        run: ./node_modules/.bin/rover.cmd --version
-        if: runner.os == 'Windows'
       - name: Configure Rover (Windows)
         run: |
           [void] [System.Reflection.Assembly]::LoadWithPartialName("System.Windows.Forms")
@@ -48,6 +55,15 @@ jobs:
           [System.Windows.Forms.SendKeys]::SendWait("{ENTER}")
         if: runner.os == 'Windows'
         shell: powershell
+
+      # Print profiles per OS
+      - name: Print Rover profiles (Linux)
+        run: ./node_modules/.bin/rover config list
+        if: runner.os == 'Linux'
+      - name: Print Rover profiles (Windows)
+        run: ./node_modules/.bin/rover.cmd config list
+        if: runner.os == 'Windows'
+
       - name: Adjust configuration (Windows)
         run: |
           sed -i -e 's/\(bin:.*\)/\1.exe/' sampleWorkspace/rover/apollo.config.yaml
@@ -56,7 +72,10 @@ jobs:
           echo "module.exports = require('./jest.e2e.config')" > jest.config.ts
         shell: bash
         if: runner.os == 'Windows'
+
       - run: npm run build:production
+
+      # Run test per OS
       - name: "Run Extension E2E tests (Linux)"
         run: xvfb-run -a npm run test:extension
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "zod-validation-error": "3.4.0"
       },
       "devDependencies": {
-        "@apollo/rover": "0.27.0-preview.0",
+        "@apollo/rover": "0.27.0",
         "@changesets/changelog-github": "0.5.0",
         "@changesets/cli": "2.27.10",
         "@graphql-codegen/cli": "5.0.2",
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/@apollo/rover": {
-      "version": "0.27.0-preview.0",
-      "resolved": "https://registry.npmjs.org/@apollo/rover/-/rover-0.27.0-preview.0.tgz",
-      "integrity": "sha512-5y3eoxm9LRokXCIdlAvxqiCEqCjJX4NIv2oMKpZsSIMdbs+J/Btj+Flwx1POe9WCTl5lb6xROgJS5jXi6VNU2A==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@apollo/rover/-/rover-0.27.0.tgz",
+      "integrity": "sha512-iwYGxUXpjPV0pH4JigyjmXRQ3WuUyVHISSesFaGu5dZl0zxA/jgSzTZDkr9PDBNN/2wBnRDZk5abb0TToYkARg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "zod-validation-error": "3.4.0"
   },
   "devDependencies": {
-    "@apollo/rover": "0.27.0-preview.0",
+    "@apollo/rover": "0.27.0",
     "@changesets/changelog-github": "0.5.0",
     "@changesets/cli": "2.27.10",
     "@graphql-codegen/cli": "5.0.2",

--- a/sampleWorkspace/rover/apollo.config.yaml
+++ b/sampleWorkspace/rover/apollo.config.yaml
@@ -1,3 +1,3 @@
 rover:
   profile: VSCode-E2E
-  bin: ../../node_modules/@apollo/rover/binary/rover-0.27.0-alpha.0
+  bin: ../../node_modules/@apollo/rover/binary/rover-0.27.0-preview.0

--- a/sampleWorkspace/rover/apollo.config.yaml
+++ b/sampleWorkspace/rover/apollo.config.yaml
@@ -1,3 +1,3 @@
 rover:
   profile: VSCode-E2E
-  bin: ../../node_modules/@apollo/rover/binary/rover-0.27.0-preview.0
+  bin: ../../node_modules/@apollo/rover/binary/rover-0.27.0

--- a/sampleWorkspace/rover/supergraph.yaml
+++ b/sampleWorkspace/rover/supergraph.yaml
@@ -1,0 +1,4 @@
+subgraphs:
+  subgraph:
+    schema:
+      file: src/test.graphql

--- a/src/language-server/__e2e__/rover.e2e.ts
+++ b/src/language-server/__e2e__/rover.e2e.ts
@@ -1,9 +1,4 @@
 import { test as origTest } from "@jest/globals";
-import { load } from "js-yaml";
-import { readFileSync } from "node:fs";
-import { execFileSync } from "node:child_process";
-import { join } from "node:path";
-import { ParsedApolloConfigFormat } from "../config";
 import { TextEditor } from "vscode";
 import {
   closeAllEditors,

--- a/src/language-server/__e2e__/rover.e2e.ts
+++ b/src/language-server/__e2e__/rover.e2e.ts
@@ -73,11 +73,47 @@ test("completion", async () => {
 [
   {
     "detail": undefined,
+    "label": "@authenticated",
+  },
+  {
+    "detail": undefined,
     "label": "@deprecated",
   },
   {
     "detail": undefined,
     "label": "@external",
+  },
+  {
+    "detail": undefined,
+    "label": "@inaccessible",
+  },
+  {
+    "detail": undefined,
+    "label": "@override(…)",
+  },
+  {
+    "detail": undefined,
+    "label": "@policy(…)",
+  },
+  {
+    "detail": undefined,
+    "label": "@provides(…)",
+  },
+  {
+    "detail": undefined,
+    "label": "@requires(…)",
+  },
+  {
+    "detail": undefined,
+    "label": "@requiresScopes(…)",
+  },
+  {
+    "detail": undefined,
+    "label": "@shareable",
+  },
+  {
+    "detail": undefined,
+    "label": "@tag(…)",
   },
   {
     "detail": undefined,
@@ -102,18 +138,6 @@ test("completion", async () => {
   {
     "detail": undefined,
     "label": "@federation__tag(…)",
-  },
-  {
-    "detail": undefined,
-    "label": "@override(…)",
-  },
-  {
-    "detail": undefined,
-    "label": "@requires(…)",
-  },
-  {
-    "detail": undefined,
-    "label": "@shareable",
   },
 ]
 `);

--- a/src/language-server/__e2e__/rover.e2e.ts
+++ b/src/language-server/__e2e__/rover.e2e.ts
@@ -16,31 +16,7 @@ import {
   getDefinitions,
 } from "./utils";
 
-// we want to skip these tests unless the user running them has a rover config profile named "VSCode-E2E"
 let test = origTest.skip;
-try {
-  const roverProjectDir = join(__dirname, "../../../sampleWorkspace/rover");
-  const config = load(
-    readFileSync(join(roverProjectDir, "apollo.config.yaml"), "utf-8"),
-  ) as ParsedApolloConfigFormat;
-  const roverBin = join(roverProjectDir, config.rover!.bin);
-  const result = execFileSync(roverBin, [
-    "config",
-    "list",
-    "--format=json",
-  ]).toString("utf8");
-  const parsed = JSON.parse(result);
-  if (parsed.data.profiles.includes("VSCode-E2E")) {
-    test = origTest;
-  }
-} catch (e) {}
-if (test === origTest.skip) {
-  console.info(
-    "Skipping rover E2E tests: no profile with the name 'VSCode-E2E'\n" +
-      "You can create one by running `rover config auth --profile VSCode-E2E`",
-  );
-}
-
 if (process.platform === "win32") {
   console.info("Skipping rover E2E tests in Windows");
   test = origTest.skip;


### PR DESCRIPTION
Currently, the rover.e2e.ts tests aren't running on any platform, this fixes it so they run on everything but windows (windows needs another fix, so I will enable those tests in that PR)
- Fix the binary path to be the preview that replaced the alpha
- Stop checking for profile in rover.e2e.ts at all, it's not a dependency
- Fix the supergraph.yaml, an empty file is preventing the extension from launching
- Update snapshot for the current rover/lsp version