### PR TITLE
fix: replace deprecated util.isString for Node 24 compatibility

### DIFF
--- a/.changeset/quick-jokes-grow.md
+++ b/.changeset/quick-jokes-grow.md
@@ -1,0 +1,5 @@
+---
+"vscode-apollo": patch
+---
+
+Replace deprecated `util.isString` with `typeof x === "string"` so the extension works on Node 24, where the runtime-deprecated `util.isString` has been removed.

--- a/src/language-server/providers/schema/endpoint.ts
+++ b/src/language-server/providers/schema/endpoint.ts
@@ -16,7 +16,6 @@ import { Agent as HTTPSAgent } from "https";
 import { RemoteServiceConfig } from "../../config";
 import { GraphQLSchemaProvider, SchemaChangeUnsubscribeHandler } from "./base";
 import { Debug } from "../../utilities";
-import { isString } from "util";
 import { fetch as undiciFetch, Agent } from "undici";
 
 const skipSSLValidationFetchOptions = {
@@ -51,7 +50,7 @@ export class EndpointSchemaProvider implements GraphQLSchemaProvider {
       }),
     ).catch((e) => {
       // html response from introspection
-      if (isString(e.message) && e.message.includes("token <")) {
+      if (typeof e.message === "string" && e.message.includes("token <")) {
         throw new Error(
           "Apollo tried to introspect a running GraphQL service at " +
             url +
@@ -65,7 +64,7 @@ export class EndpointSchemaProvider implements GraphQLSchemaProvider {
       }
 
       // 404 with a non-default url
-      if (isString(e.message) && e.message.includes("ECONNREFUSED")) {
+      if (typeof e.message === "string" && e.message.includes("ECONNREFUSED")) {
         throw new Error(
           "Failed to connect to a running GraphQL endpoint at " +
             url +


### PR DESCRIPTION
Fixes #312

util.isString is runtime-deprecated (DEP0056), End-of-Life in Node 23, and removed in Node 24, breaking the extension. Replace with typeof checks per Node docs.